### PR TITLE
fix: filter type symbols with strict string comparison

### DIFF
--- a/src/Type/Parser/LexingParser.php
+++ b/src/Type/Parser/LexingParser.php
@@ -27,7 +27,7 @@ final class LexingParser implements TypeParser
     {
         $symbols = $this->splitTokens($raw);
         $symbols = array_map('trim', $symbols);
-        $symbols = array_filter($symbols);
+        $symbols = array_filter($symbols, static fn ($value) => $value !== '');
 
         $tokens = array_map(
             fn (string $symbol) => $this->lexer->tokenize($symbol),


### PR DESCRIPTION
Previously, `array_filter` would remove the integer value `0` from the
array.

See #1