### PR TITLE
Fixes #39 - Adds MySQL TIMESTAMP and PgSQL DATETIME formats.

### DIFF
--- a/src/Mapper/Object/DateTimeObjectBuilder.php
+++ b/src/Mapper/Object/DateTimeObjectBuilder.php
@@ -21,6 +21,9 @@ use function is_string;
 
 final class DateTimeObjectBuilder implements ObjectBuilder
 {
+    public const DATE_MYSQL = 'Y-m-d H:i:s';
+    public const DATE_PGSQL = 'Y-m-d H:i:s.u';
+
     /** @var class-string<DateTime|DateTimeImmutable> */
     private string $className;
 
@@ -75,7 +78,7 @@ final class DateTimeObjectBuilder implements ObjectBuilder
         $formats = [
             DATE_ATOM, DATE_RFC850, DATE_COOKIE, DATE_RFC822, DATE_RFC1036,
             DATE_RFC1123, DATE_RFC2822, DATE_RFC3339, DATE_RFC3339_EXTENDED,
-            DATE_RFC7231, DATE_RSS, DATE_W3C,
+            DATE_RFC7231, DATE_RSS, DATE_W3C, self::DATE_MYSQL, self::DATE_PGSQL,
         ];
 
         foreach ($formats as $format) {

--- a/src/Mapper/Object/DateTimeObjectBuilder.php
+++ b/src/Mapper/Object/DateTimeObjectBuilder.php
@@ -76,9 +76,9 @@ final class DateTimeObjectBuilder implements ObjectBuilder
     private function tryAllFormats(string $value): ?DateTimeInterface
     {
         $formats = [
-            DATE_ATOM, DATE_RFC850, DATE_COOKIE, DATE_RFC822, DATE_RFC1036,
-            DATE_RFC1123, DATE_RFC2822, DATE_RFC3339, DATE_RFC3339_EXTENDED,
-            DATE_RFC7231, DATE_RSS, DATE_W3C, self::DATE_MYSQL, self::DATE_PGSQL,
+            self::DATE_MYSQL, self::DATE_PGSQL, DATE_ATOM, DATE_RFC850, DATE_COOKIE,
+            DATE_RFC822, DATE_RFC1036, DATE_RFC1123, DATE_RFC2822, DATE_RFC3339,
+            DATE_RFC3339_EXTENDED, DATE_RFC7231, DATE_RSS, DATE_W3C,
         ];
 
         foreach ($formats as $format) {

--- a/tests/Integration/Mapping/Type/DateTimeMappingTest.php
+++ b/tests/Integration/Mapping/Type/DateTimeMappingTest.php
@@ -29,8 +29,8 @@ final class DateTimeMappingTest extends IntegrationTest
             'datetime' => '2012-12-21 13:37:42',
             'format' => 'Y-m-d H:i:s',
         ];
-        $mysqlTimestamp = '2012-12-21 13:37:42';
-        $pgsqlDateTime = '2012-12-21 13:37:42.123456';
+        $mysqlDate = '2012-12-21 13:37:42';
+        $pgsqlDate = '2012-12-21 13:37:42.123456';
 
         try {
             $result = $this->mapperBuilder->mapper()->map(AllDateTimeValues::class, [
@@ -40,8 +40,8 @@ final class DateTimeMappingTest extends IntegrationTest
                 'dateTimeFromTimestampWithFormat' => $dateTimeFromTimestampWithFormat,
                 'dateTimeFromAtomFormat' => $dateTimeFromAtomFormat,
                 'dateTimeFromArray' => $dateTimeFromArray,
-                'mysqlTimestamp' => $mysqlTimestamp,
-                'pgsqlDateTime' => $pgsqlDateTime,
+                'mysqlDate' => $mysqlDate,
+                'pgsqlDate' => $pgsqlDate,
 
             ]);
         } catch (MappingError $error) {
@@ -55,8 +55,8 @@ final class DateTimeMappingTest extends IntegrationTest
         self::assertEquals(new DateTimeImmutable("@{$dateTimeFromTimestampWithFormat['datetime']}"), $result->dateTimeFromTimestampWithFormat);
         self::assertEquals(DateTimeImmutable::createFromFormat(DATE_ATOM, $dateTimeFromAtomFormat), $result->dateTimeFromAtomFormat);
         self::assertEquals(DateTimeImmutable::createFromFormat($dateTimeFromArray['format'], $dateTimeFromArray['datetime']), $result->dateTimeFromArray);
-        self::assertEquals(DateTimeImmutable::createFromFormat(DateTimeObjectBuilder::DATE_MYSQL, $mysqlTimestamp), $result->mysqlTimestamp);
-        self::assertEquals(DateTimeImmutable::createFromFormat(DateTimeObjectBuilder::DATE_PGSQL, $pgsqlDateTime), $result->pgsqlDateTime);
+        self::assertEquals(DateTimeImmutable::createFromFormat(DateTimeObjectBuilder::DATE_MYSQL, $mysqlDate), $result->mysqlDate);
+        self::assertEquals(DateTimeImmutable::createFromFormat(DateTimeObjectBuilder::DATE_PGSQL, $pgsqlDate), $result->pgsqlDate);
     }
 
     public function test_invalid_datetime_throws_exception(): void
@@ -137,7 +137,7 @@ final class AllDateTimeValues
 
     public DateTimeInterface $dateTimeFromArray;
 
-    public DateTimeInterface $mysqlTimestamp;
+    public DateTimeInterface $mysqlDate;
 
-    public DateTimeInterface $pgsqlDateTime;
+    public DateTimeInterface $pgsqlDate;
 }

--- a/tests/Integration/Mapping/Type/DateTimeMappingTest.php
+++ b/tests/Integration/Mapping/Type/DateTimeMappingTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Type;
 
 use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\Mapper\Object\DateTimeObjectBuilder;
 use CuyZ\Valinor\Mapper\Object\Exception\CannotParseToDateTime;
 use CuyZ\Valinor\Tests\Integration\IntegrationTest;
 use CuyZ\Valinor\Type\Resolver\Exception\UnionTypeDoesNotAllowNull;
@@ -28,6 +29,8 @@ final class DateTimeMappingTest extends IntegrationTest
             'datetime' => '2012-12-21 13:37:42',
             'format' => 'Y-m-d H:i:s',
         ];
+        $mysqlTimestamp = '2012-12-21 13:37:42';
+        $pgsqlDateTime = '2012-12-21 13:37:42.123456';
 
         try {
             $result = $this->mapperBuilder->mapper()->map(AllDateTimeValues::class, [
@@ -37,6 +40,9 @@ final class DateTimeMappingTest extends IntegrationTest
                 'dateTimeFromTimestampWithFormat' => $dateTimeFromTimestampWithFormat,
                 'dateTimeFromAtomFormat' => $dateTimeFromAtomFormat,
                 'dateTimeFromArray' => $dateTimeFromArray,
+                'mysqlTimestamp' => $mysqlTimestamp,
+                'pgsqlDateTime' => $pgsqlDateTime,
+
             ]);
         } catch (MappingError $error) {
             $this->mappingFail($error);
@@ -49,6 +55,8 @@ final class DateTimeMappingTest extends IntegrationTest
         self::assertEquals(new DateTimeImmutable("@{$dateTimeFromTimestampWithFormat['datetime']}"), $result->dateTimeFromTimestampWithFormat);
         self::assertEquals(DateTimeImmutable::createFromFormat(DATE_ATOM, $dateTimeFromAtomFormat), $result->dateTimeFromAtomFormat);
         self::assertEquals(DateTimeImmutable::createFromFormat($dateTimeFromArray['format'], $dateTimeFromArray['datetime']), $result->dateTimeFromArray);
+        self::assertEquals(DateTimeImmutable::createFromFormat(DateTimeObjectBuilder::DATE_MYSQL, $mysqlTimestamp), $result->mysqlTimestamp);
+        self::assertEquals(DateTimeImmutable::createFromFormat(DateTimeObjectBuilder::DATE_PGSQL, $pgsqlDateTime), $result->pgsqlDateTime);
     }
 
     public function test_invalid_datetime_throws_exception(): void
@@ -128,4 +136,8 @@ final class AllDateTimeValues
     public DateTimeInterface $dateTimeFromAtomFormat;
 
     public DateTimeInterface $dateTimeFromArray;
+
+    public DateTimeInterface $mysqlTimestamp;
+
+    public DateTimeInterface $pgsqlDateTime;
 }


### PR DESCRIPTION
I'm not sure I put these in the right place, but if there's a better place, let me know. 

I see this package being incredibly useful for automatically mapping data from databases into entities/value objects, so I hope that you'll consider this patch.