### PR TITLE
Changed AttributesCompiler to use serializer/unserializer when compiling arguments

### DIFF
--- a/src/Definition/Repository/Cache/Compiler/AttributesCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/AttributesCompiler.php
@@ -91,7 +91,8 @@ final class AttributesCompiler
 
         /** @infection-ignore-all */
         if (count($arguments) > 0) {
-            $arguments = var_export($arguments, true);
+            $arguments = serialize($arguments);
+            $arguments = 'unserialize(' . var_export($arguments, true) . ')';
 
             return "new $name(...$arguments)";
         }

--- a/tests/Fixture/Attribute/NestedAttribute.php
+++ b/tests/Fixture/Attribute/NestedAttribute.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Fixture\Attribute;
+
+use Attribute;
+
+#[Attribute]
+final class NestedAttribute
+{
+    public function __construct(
+        /** @var list<object> */
+        public array $nestedAttributes,
+    ) {
+    }
+}

--- a/tests/Fixture/Object/ObjectWithNestedAttributes.php
+++ b/tests/Fixture/Object/ObjectWithNestedAttributes.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Fixture\Object;
+
+use CuyZ\Valinor\Tests\Fixture\Attribute\AttributeWithArguments;
+use CuyZ\Valinor\Tests\Fixture\Attribute\BasicAttribute;
+use CuyZ\Valinor\Tests\Fixture\Attribute\NestedAttribute;
+
+#[BasicAttribute]
+#[AttributeWithArguments('foo', 'bar')]
+#[NestedAttribute([
+    new BasicAttribute(),
+    new AttributeWithArguments('foo', 'bar'),
+])]
+// @PHP8.0 move to anonymous class
+final class ObjectWithNestedAttributes
+{
+    #[BasicAttribute]
+    #[AttributeWithArguments('foo', 'bar')]
+    #[NestedAttribute([
+        new BasicAttribute(),
+        new AttributeWithArguments('foo', 'bar'),
+    ])]
+    public bool $property;
+
+    #[BasicAttribute]
+    #[AttributeWithArguments('foo', 'bar')]
+    #[NestedAttribute([
+        new BasicAttribute(),
+        new AttributeWithArguments('foo', 'bar'),
+    ])]
+    public function method(#[BasicAttribute] string $parameter): void
+    {
+    }
+}


### PR DESCRIPTION
In PHP 8.1 `new` in initializers were introduced which allows now to use nested attributes. The current implementation of [`AttributesCompiler`](https://github.com/CuyZ/Valinor/blob/master/src/Definition/Repository/Cache/Compiler/AttributesCompiler.php#L94) uses `var_export` which generates invalid PHP Code for cached PHP files.

Thanks to @Ocramius suggestion I was able to fix this issue using `serialize/unserialize` 