### PR TITLE
fix: README: Mapping error must be linked to a property

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,10 +188,7 @@ the exception.
 ```php
 final class SomeClass
 {
-    public function __construct(private string $someValue)
-    {
-        Assert::startsWith($someValue, 'foo_');
-    }
+    public function __construct(private int $someValue) { }
 }
 
 try {


### PR DESCRIPTION
'someValue' is not a key in `Node::children()` as used later in the example.

![image](https://user-images.githubusercontent.com/41789/148166248-c0c23e24-0854-402e-976d-e3ca31ad8ce8.png)

After change

![image](https://user-images.githubusercontent.com/41789/148166496-f4737b26-cdb2-4e30-9438-a0e02cf470e4.png)
