### PR TITLE
feat: introduce automatic union of objects inferring during mapping

### DIFF
--- a/src/Library/Container.php
+++ b/src/Library/Container.php
@@ -21,7 +21,6 @@ use CuyZ\Valinor\Mapper\Object\Factory\AttributeObjectBuilderFactory;
 use CuyZ\Valinor\Mapper\Object\Factory\BasicObjectBuilderFactory;
 use CuyZ\Valinor\Mapper\Object\Factory\ObjectBuilderFactory;
 use CuyZ\Valinor\Mapper\Tree\Builder\ArrayNodeBuilder;
-use CuyZ\Valinor\Mapper\Tree\Builder\VisitorNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\CasterNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\ClassNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\EnumNodeBuilder;
@@ -31,12 +30,13 @@ use CuyZ\Valinor\Mapper\Tree\Builder\NodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\RootNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\ScalarNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\ShapedArrayNodeBuilder;
-use CuyZ\Valinor\Mapper\Tree\Builder\ValueAlteringNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\ShellVisitorNodeBuilder;
+use CuyZ\Valinor\Mapper\Tree\Builder\ValueAlteringNodeBuilder;
+use CuyZ\Valinor\Mapper\Tree\Builder\VisitorNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Visitor\AggregateShellVisitor;
 use CuyZ\Valinor\Mapper\Tree\Visitor\AttributeShellVisitor;
-use CuyZ\Valinor\Mapper\Tree\Visitor\ObjectBindingShellVisitor;
 use CuyZ\Valinor\Mapper\Tree\Visitor\InterfaceShellVisitor;
+use CuyZ\Valinor\Mapper\Tree\Visitor\ObjectBindingShellVisitor;
 use CuyZ\Valinor\Mapper\Tree\Visitor\ShellVisitor;
 use CuyZ\Valinor\Mapper\Tree\Visitor\UnionShellVisitor;
 use CuyZ\Valinor\Mapper\TreeMapper;
@@ -49,6 +49,7 @@ use CuyZ\Valinor\Type\Parser\Template\BasicTemplateParser;
 use CuyZ\Valinor\Type\Parser\Template\TemplateParser;
 use CuyZ\Valinor\Type\Parser\TypeParser;
 use CuyZ\Valinor\Type\Resolver\Union\UnionNullNarrower;
+use CuyZ\Valinor\Type\Resolver\Union\UnionObjectNarrower;
 use CuyZ\Valinor\Type\Resolver\Union\UnionScalarNarrower;
 use CuyZ\Valinor\Type\ScalarType;
 use CuyZ\Valinor\Type\Types\ArrayType;
@@ -91,7 +92,13 @@ final class Container
             ShellVisitor::class => function () use ($settings): ShellVisitor {
                 return new AggregateShellVisitor(
                     new UnionShellVisitor(
-                        new UnionNullNarrower(new UnionScalarNarrower())
+                        new UnionNullNarrower(
+                            new UnionObjectNarrower(
+                                new UnionScalarNarrower(),
+                                $this->get(ClassDefinitionRepository::class),
+                                $this->get(ObjectBuilderFactory::class),
+                            )
+                        )
                     ),
                     new InterfaceShellVisitor(
                         $settings->interfaceMapping,

--- a/src/Mapper/Object/Argument.php
+++ b/src/Mapper/Object/Argument.php
@@ -15,19 +15,41 @@ final class Argument
     private Type $type;
 
     /** @var mixed */
-    private $value;
+    private $defaultValue;
 
-    private ?Attributes $attributes;
+    private bool $isRequired = true;
 
-    /**
-     * @param mixed $value
-     */
-    public function __construct(string $name, Type $type, $value, Attributes $attributes = null)
+    private Attributes $attributes;
+
+    private function __construct(string $name, Type $type)
     {
         $this->name = $name;
         $this->type = $type;
-        $this->value = $value;
-        $this->attributes = $attributes;
+    }
+
+    public static function required(string $name, Type $type): self
+    {
+        return new self($name, $type);
+    }
+
+    /**
+     * @param mixed $defaultValue
+     */
+    public static function optional(string $name, Type $type, $defaultValue): self
+    {
+        $instance = new self($name, $type);
+        $instance->defaultValue = $defaultValue;
+        $instance->isRequired = false;
+
+        return $instance;
+    }
+
+    public function withAttributes(Attributes $attributes): self
+    {
+        $clone = clone $this;
+        $clone->attributes = $attributes;
+
+        return $clone;
     }
 
     public function name(): string
@@ -43,9 +65,14 @@ final class Argument
     /**
      * @return mixed
      */
-    public function value()
+    public function defaultValue()
     {
-        return $this->value;
+        return $this->defaultValue;
+    }
+
+    public function isRequired(): bool
+    {
+        return $this->isRequired;
     }
 
     public function attributes(): Attributes

--- a/src/Mapper/Object/ObjectBuilder.php
+++ b/src/Mapper/Object/ObjectBuilder.php
@@ -7,10 +7,9 @@ namespace CuyZ\Valinor\Mapper\Object;
 interface ObjectBuilder
 {
     /**
-     * @param mixed $source
      * @return iterable<Argument>
      */
-    public function describeArguments($source): iterable;
+    public function describeArguments(): iterable;
 
     /**
      * @param array<string, mixed> $arguments

--- a/src/Mapper/Object/ReflectionObjectBuilder.php
+++ b/src/Mapper/Object/ReflectionObjectBuilder.php
@@ -5,14 +5,9 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Object;
 
 use CuyZ\Valinor\Definition\ClassDefinition;
-use CuyZ\Valinor\Mapper\Object\Exception\InvalidSourceForObject;
 use CuyZ\Valinor\Mapper\Object\Exception\MissingPropertyArgument;
 
 use function array_key_exists;
-use function array_keys;
-use function count;
-use function is_array;
-use function iterator_to_array;
 
 final class ReflectionObjectBuilder implements ObjectBuilder
 {
@@ -23,17 +18,14 @@ final class ReflectionObjectBuilder implements ObjectBuilder
         $this->class = $class;
     }
 
-    public function describeArguments($source): iterable
+    public function describeArguments(): iterable
     {
-        $source = $this->transformSource($source);
-
         foreach ($this->class->properties() as $property) {
-            $name = $property->name();
-            $type = $property->type();
-            $attributes = $property->attributes();
-            $value = array_key_exists($name, $source) ? $source[$name] : $property->defaultValue();
+            $argument = $property->hasDefaultValue()
+                ? Argument::optional($property->name(), $property->type(), $property->defaultValue())
+                : Argument::required($property->name(), $property->type());
 
-            yield new Argument($name, $type, $value, $attributes);
+            yield $argument->withAttributes($property->attributes());
         }
     }
 
@@ -56,36 +48,5 @@ final class ReflectionObjectBuilder implements ObjectBuilder
         })->call($object);
 
         return $object;
-    }
-
-    /**
-     * @param mixed $source
-     * @return mixed[]
-     */
-    private function transformSource($source): array
-    {
-        if ($source === null) {
-            return [];
-        }
-
-        if (is_iterable($source) && ! is_array($source)) {
-            $source = iterator_to_array($source);
-        }
-
-        $properties = $this->class->properties();
-
-        if (count($properties) === 1) {
-            $name = array_keys(iterator_to_array($properties))[0];
-
-            if (! is_array($source) || ! array_key_exists($name, $source)) {
-                $source = [$name => $source];
-            }
-        }
-
-        if (! is_array($source)) {
-            throw new InvalidSourceForObject($source);
-        }
-
-        return $source;
     }
 }

--- a/src/Type/Resolver/Exception/CannotResolveObjectTypeFromUnion.php
+++ b/src/Type/Resolver/Exception/CannotResolveObjectTypeFromUnion.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Type\Resolver\Exception;
+
+use CuyZ\Valinor\Mapper\Tree\Message\Message;
+use CuyZ\Valinor\Type\Types\UnionType;
+use RuntimeException;
+
+final class CannotResolveObjectTypeFromUnion extends RuntimeException implements Message
+{
+    public function __construct(UnionType $unionType)
+    {
+        parent::__construct(
+            "Impossible to resolve the object type from the union `$unionType`.",
+            1641406600
+        );
+    }
+}

--- a/src/Type/Resolver/Exception/CannotResolveTypeFromUnion.php
+++ b/src/Type/Resolver/Exception/CannotResolveTypeFromUnion.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Resolver\Exception;
 
+use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use CuyZ\Valinor\Type\Types\UnionType;
 use RuntimeException;
 
 use function get_debug_type;
 
-final class CannotResolveTypeFromUnion extends RuntimeException
+final class CannotResolveTypeFromUnion extends RuntimeException implements Message
 {
     /**
      * @param mixed $value

--- a/src/Type/Resolver/Union/UnionObjectNarrower.php
+++ b/src/Type/Resolver/Union/UnionObjectNarrower.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Type\Resolver\Union;
+
+use CuyZ\Valinor\Definition\Repository\ClassDefinitionRepository;
+use CuyZ\Valinor\Mapper\Object\Argument;
+use CuyZ\Valinor\Mapper\Object\Factory\ObjectBuilderFactory;
+use CuyZ\Valinor\Type\ObjectType;
+use CuyZ\Valinor\Type\Resolver\Exception\CannotResolveObjectTypeFromUnion;
+use CuyZ\Valinor\Type\Type;
+use CuyZ\Valinor\Type\Types\UnionType;
+
+use function array_map;
+use function array_pop;
+use function array_shift;
+use function count;
+use function in_array;
+use function is_array;
+use function ksort;
+
+final class UnionObjectNarrower implements UnionNarrower
+{
+    private UnionNarrower $delegate;
+
+    private ClassDefinitionRepository $classDefinitionRepository;
+
+    private ObjectBuilderFactory $objectBuilderFactory;
+
+    public function __construct(
+        UnionNarrower $delegate,
+        ClassDefinitionRepository $classDefinitionRepository,
+        ObjectBuilderFactory $objectBuilderFactory
+    ) {
+        $this->delegate = $delegate;
+        $this->classDefinitionRepository = $classDefinitionRepository;
+        $this->objectBuilderFactory = $objectBuilderFactory;
+    }
+
+    public function narrow(UnionType $unionType, $source): Type
+    {
+        if (! is_array($source)) {
+            return $this->delegate->narrow($unionType, $source);
+        }
+
+        $isIncremental = true;
+        $types = [];
+        $argumentsList = [];
+
+        foreach ($unionType->types() as $type) {
+            if (! $type instanceof ObjectType) {
+                return $this->delegate->narrow($unionType, $source);
+            }
+
+            $class = $this->classDefinitionRepository->for($type->signature());
+            $objectBuilder = $this->objectBuilderFactory->for($class);
+            $arguments = [...$objectBuilder->describeArguments()];
+
+            foreach ($arguments as $argument) {
+                if (! isset($source[$argument->name()]) && $argument->isRequired()) {
+                    continue 2;
+                }
+            }
+
+            $count = count($arguments);
+
+            if (isset($types[$count])) {
+                $isIncremental = false;
+                /** @infection-ignore-all */
+                break;
+            }
+
+            $types[$count] = $type;
+            $argumentsList[$count] = $arguments;
+        }
+
+        ksort($types);
+        ksort($argumentsList);
+
+        if ($isIncremental && count($types) >= 1 && $this->argumentsAreSharedAcrossList($argumentsList)) {
+            return array_pop($types);
+        }
+
+        throw new CannotResolveObjectTypeFromUnion($unionType);
+    }
+
+    /**
+     * @param array<int, array<Argument>> $argumentsList
+     */
+    private function argumentsAreSharedAcrossList(array $argumentsList): bool
+    {
+        $namesList = [];
+
+        foreach ($argumentsList as $arguments) {
+            $namesList[] = array_map(fn (Argument $argument) => $argument->name(), $arguments);
+        }
+
+        while ($current = array_shift($namesList)) {
+            if (count($namesList) === 0) {
+                /** @infection-ignore-all */
+                break;
+            }
+
+            foreach ($current as $name) {
+                foreach ($namesList as $other) {
+                    if (! in_array($name, $other, true)) {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Type/Types/Exception/ForbiddenMixedType.php
+++ b/src/Type/Types/Exception/ForbiddenMixedType.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Types\Exception;
 
+use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use LogicException;
 
-final class ForbiddenMixedType extends LogicException
+final class ForbiddenMixedType extends LogicException implements InvalidType
 {
     public function __construct()
     {

--- a/tests/Fake/Mapper/Object/FakeObjectBuilder.php
+++ b/tests/Fake/Mapper/Object/FakeObjectBuilder.php
@@ -9,7 +9,7 @@ use stdClass;
 
 final class FakeObjectBuilder implements ObjectBuilder
 {
-    public function describeArguments($source): iterable
+    public function describeArguments(): iterable
     {
         return [];
     }

--- a/tests/Integration/Mapping/Fixture/NativeUnionOfObjects.php
+++ b/tests/Integration/Mapping/Fixture/NativeUnionOfObjects.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Mapping\Fixture;
+
+// @PHP8.0 move inside \CuyZ\Valinor\Tests\Integration\Mapping\Object\UnionOfObjectsMappingTest
+final class NativeUnionOfObjects
+{
+    public SomeFooObject|SomeBarObject $object;
+}
+
+final class SomeFooObject
+{
+    public string $foo;
+}
+
+final class SomeBarObject
+{
+    public string $bar;
+}

--- a/tests/Integration/Mapping/Object/DateTimeMappingTest.php
+++ b/tests/Integration/Mapping/Object/DateTimeMappingTest.php
@@ -103,10 +103,9 @@ final class DateTimeMappingTest extends IntegrationTest
                     ],
                 ]);
         } catch (MappingError $exception) {
-            $error = $exception->node()->children()['dateTime']->children()['datetime']->messages()[0];
+            $error = $exception->node()->children()['dateTime']->children()['value']->messages()[0];
 
-            self::assertSame('1618742357', $error->code());
-            self::assertSame('Cannot assign an empty value to union type `positive-int|non-empty-string`.', (string)$error);
+            self::assertSame('1607027306', $error->code());
         }
     }
 }

--- a/tests/Integration/Mapping/Object/ObjectValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ObjectValuesMappingTest.php
@@ -13,6 +13,7 @@ final class ObjectValuesMappingTest extends IntegrationTest
     public function test_values_are_mapped_properly(): void
     {
         $source = [
+            'string' => 'foo',
             'object' => [
                 'value' => 'foo',
             ],
@@ -28,17 +29,36 @@ final class ObjectValuesMappingTest extends IntegrationTest
             self::assertSame('foo', $result->object->value);
         }
     }
+
+    public function test_invalid_iterable_source_throws_exception(): void
+    {
+        $source = 'foo';
+
+        foreach ([ObjectValues::class, ObjectValuesWithConstructor::class] as $class) {
+            try {
+                $this->mapperBuilder->mapper()->map($class, $source);
+            } catch (MappingError $exception) {
+                $error = $exception->node()->messages()[0];
+
+                self::assertSame('1632903281', $error->code());
+                self::assertSame('Invalid source type `string`, it must be an iterable.', (string)$error);
+            }
+        }
+    }
 }
 
 class ObjectValues
 {
     public SimpleObject $object;
+
+    public string $string;
 }
 
 class ObjectValuesWithConstructor extends ObjectValues
 {
-    public function __construct(SimpleObject $object)
+    public function __construct(SimpleObject $object, string $string)
     {
         $this->object = $object;
+        $this->string = $string;
     }
 }

--- a/tests/Integration/Mapping/Object/UnionOfObjectsMappingTest.php
+++ b/tests/Integration/Mapping/Object/UnionOfObjectsMappingTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
+
+use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\Tests\Integration\IntegrationTest;
+use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\NativeUnionOfObjects;
+
+final class UnionOfObjectsMappingTest extends IntegrationTest
+{
+    /**
+     * @requires PHP >= 8
+     */
+    public function test_object_type_is_narrowed_correctly_for_simple_case(): void
+    {
+        try {
+            $resultFoo = $this->mapperBuilder->mapper()->map(NativeUnionOfObjects::class, [
+                'foo' => 'foo'
+            ]);
+            $resultBar = $this->mapperBuilder->mapper()->map(NativeUnionOfObjects::class, [
+                'bar' => 'bar'
+            ]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertInstanceOf(\CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SomeFooObject::class, $resultFoo->object);
+        self::assertInstanceOf(\CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SomeBarObject::class, $resultBar->object);
+    }
+
+    public function test_object_type_is_narrowed_correctly_for_simple_array_case(): void
+    {
+        try {
+            $result = $this->mapperBuilder->mapper()->map(UnionOfFooAndBar::class, [
+                'foo' => ['foo' => 'foo'],
+                'bar' => ['bar' => 'bar'],
+            ]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertInstanceOf(SomeFooObject::class, $result->objects['foo']);
+        self::assertInstanceOf(SomeBarObject::class, $result->objects['bar']);
+    }
+
+    public function test_objects_sharing_one_property_are_resolved_correctly(): void
+    {
+        try {
+            $result = $this->mapperBuilder->mapper()->map(UnionOfFooAndBarAndFoo::class, [
+                ['foo' => 'foo'],
+                ['foo' => 'foo', 'bar' => 'bar'],
+            ]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertInstanceOf(SomeFooObject::class, $result->objects[0]);
+        self::assertInstanceOf(SomeFooAndBarObject::class, $result->objects[1]);
+    }
+
+    /**
+     *
+     * @dataProvider mapping_error_when_cannot_resolve_union_data_provider
+     *
+     * @param class-string $className
+     * @param mixed[] $source
+     */
+    public function test_mapping_error_when_cannot_resolve_union(string $className, array $source): void
+    {
+        try {
+            $this->mapperBuilder->mapper()->map($className, $source);
+
+            self::fail('No mapping error when one was expected');
+        } catch (MappingError $exception) {
+            $error = $exception->node()->children()['objects']->children()[0]->messages()[0];
+
+            self::assertSame('1641406600', $error->code());
+        }
+    }
+
+    public function mapping_error_when_cannot_resolve_union_data_provider(): iterable
+    {
+        yield [
+            'className' => UnionOfFooAndBar::class,
+            'source' => [['foo' => 'foo', 'bar' => 'bar']],
+        ];
+        yield [
+            'className' => UnionOfFooAndBarAndFiz::class,
+            'source' => [['foo' => 'foo', 'bar' => 'bar', 'fiz' => 'fiz']],
+        ];
+        yield [
+            'className' => UnionOfFooAndAnotherFoo::class,
+            'source' => [['foo' => 'foo']],
+        ];
+    }
+}
+
+final class UnionOfFooAndBar
+{
+    /** @var array<SomeFooObject|SomeBarObject> */
+    public array $objects;
+}
+
+final class UnionOfFooAndAnotherFoo
+{
+    /** @var array<SomeFooObject|SomeOtherFooObject> */
+    public array $objects;
+}
+
+final class UnionOfFooAndBarAndFoo
+{
+    /** @var array<SomeFooAndBarObject|SomeFooObject> */
+    public array $objects;
+}
+
+final class UnionOfFooAndBarAndFiz
+{
+    /** @var array<SomeFooObject|SomeBarAndFizObject> */
+    public array $objects;
+}
+
+final class SomeFooObject
+{
+    public string $foo;
+}
+
+final class SomeOtherFooObject
+{
+    public string $foo;
+}
+
+final class SomeBarObject
+{
+    public string $bar;
+}
+
+final class SomeFooAndBarObject
+{
+    public string $foo;
+
+    public string $bar;
+}
+
+final class SomeBarAndFizObject
+{
+    public string $bar;
+
+    public string $fiz;
+}

--- a/tests/Unit/Cache/Compiled/CompiledPhpFileCacheTest.php
+++ b/tests/Unit/Cache/Compiled/CompiledPhpFileCacheTest.php
@@ -165,7 +165,9 @@ final class CompiledPhpFileCacheTest extends TestCase
 
     public function test_clear_cache_does_not_delete_unrelated_files(): void
     {
-        mkdir($this->cacheDir);
+        if (! is_dir($this->cacheDir)) {
+            mkdir($this->cacheDir);
+        }
 
         touch($filenameA = $this->cacheDir . DIRECTORY_SEPARATOR . 'foo.php');
         touch($filenameB = $this->cacheDir . DIRECTORY_SEPARATOR . 'bar.php');

--- a/tests/Unit/Mapper/Object/MethodObjectBuilderTest.php
+++ b/tests/Unit/Mapper/Object/MethodObjectBuilderTest.php
@@ -4,18 +4,15 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Unit\Mapper\Object;
 
-use CuyZ\Valinor\Mapper\Object\Argument;
 use CuyZ\Valinor\Mapper\Object\Exception\ConstructorMethodIsNotPublic;
 use CuyZ\Valinor\Mapper\Object\Exception\ConstructorMethodIsNotStatic;
 use CuyZ\Valinor\Mapper\Object\Exception\InvalidConstructorMethodClassReturnType;
 use CuyZ\Valinor\Mapper\Object\Exception\InvalidConstructorMethodReturnType;
-use CuyZ\Valinor\Mapper\Object\Exception\InvalidSourceForObject;
 use CuyZ\Valinor\Mapper\Object\Exception\MethodNotFound;
 use CuyZ\Valinor\Mapper\Object\Exception\MissingMethodArgument;
 use CuyZ\Valinor\Mapper\Object\MethodObjectBuilder;
 use CuyZ\Valinor\Mapper\Tree\Message\ThrowableMessage;
 use CuyZ\Valinor\Tests\Fake\Definition\FakeClassDefinition;
-use Generator;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use RuntimeException;
@@ -116,26 +113,6 @@ final class MethodObjectBuilderTest extends TestCase
 
         $class = FakeClassDefinition::fromReflection(new ReflectionClass($object));
         new MethodObjectBuilder($class, 'invalidConstructor');
-    }
-
-    public function test_invalid_source_type_throws_exception(): void
-    {
-        $object = new class () {
-            public function __construct()
-            {
-            }
-        };
-
-        $class = FakeClassDefinition::fromReflection(new ReflectionClass($object));
-        $objectBuilder = new MethodObjectBuilder($class, '__construct');
-
-        $this->expectException(InvalidSourceForObject::class);
-        $this->expectExceptionCode(1632903281);
-        $this->expectExceptionMessage('Invalid source type `string`, it must be an iterable.');
-
-        /** @var Generator<Argument> $arguments */
-        $arguments = $objectBuilder->describeArguments('foo');
-        $arguments->current();
     }
 
     public function test_missing_arguments_throws_exception(): void

--- a/tests/Unit/Mapper/Object/ReflectionObjectBuilderTest.php
+++ b/tests/Unit/Mapper/Object/ReflectionObjectBuilderTest.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Unit\Mapper\Object;
 
-use CuyZ\Valinor\Mapper\Object\Argument;
-use CuyZ\Valinor\Mapper\Object\Exception\InvalidSourceForObject;
 use CuyZ\Valinor\Mapper\Object\Exception\MissingPropertyArgument;
 use CuyZ\Valinor\Mapper\Object\ReflectionObjectBuilder;
 use CuyZ\Valinor\Tests\Fake\Definition\FakeClassDefinition;
-use Generator;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -51,26 +48,6 @@ final class ReflectionObjectBuilderTest extends TestCase
         self::assertSame('valueA', $result->valueA()); // @phpstan-ignore-line
         self::assertSame('valueB', $result->valueB()); // @phpstan-ignore-line
         self::assertSame('valueC', $result->valueC()); // @phpstan-ignore-line
-    }
-
-    public function test_invalid_source_type_throws_exception(): void
-    {
-        $object = new class () {
-            public function __construct()
-            {
-            }
-        };
-
-        $class = FakeClassDefinition::fromReflection(new ReflectionClass($object));
-        $objectBuilder = new ReflectionObjectBuilder($class);
-
-        $this->expectException(InvalidSourceForObject::class);
-        $this->expectExceptionCode(1632903281);
-        $this->expectExceptionMessage('Invalid source type `string`, it must be an iterable.');
-
-        /** @var Generator<Argument> $arguments */
-        $arguments = $objectBuilder->describeArguments('foo');
-        $arguments->current();
     }
 
     public function test_missing_arguments_throws_exception(): void


### PR DESCRIPTION
When the mapper needs to map a source to a union of objects, it will try
to guess which object it will map to, based on the needed arguments of
the objects, and the values contained in the source.

```php
final class UnionOfObjects
{
    public readonly SomeFooObject|SomeBarObject $object;
}

final class SomeFooObject
{
    public readonly string $foo;
}

final class SomeBarObject
{
    public readonly string $bar;
}

// Will map to an instance of `SomeFooObject`
(new \CuyZ\Valinor\MapperBuilder())
    ->mapper()
    ->map(UnionOfObjects::class, ['foo' => 'foo']);

// Will map to an instance of `SomeBarObject`
(new \CuyZ\Valinor\MapperBuilder())
    ->mapper()
    ->map(UnionOfObjects::class, ['bar' => 'bar']);
```