### PR TITLE
misc!: mark classes with `@internal` or `@api` annotation

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,6 +2,9 @@ includes:
     - qa/PHPStan/valinor-phpstan-configuration.php
     - vendor/phpstan/phpstan-strict-rules/rules.neon
 
+rules:
+    - CuyZ\Valinor\QA\PHPStan\Extension\ApiAndInternalAnnotationCheck
+
 parameters:
     level: max
     paths:

--- a/qa/PHPStan/Extension/ApiAndInternalAnnotationCheck.php
+++ b/qa/PHPStan/Extension/ApiAndInternalAnnotationCheck.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\QA\PHPStan\Extension;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+use function str_starts_with;
+
+/**
+ * @implements Rule<InClassNode>
+ */
+final class ApiAndInternalAnnotationCheck implements Rule
+{
+    public function getNodeType(): string
+    {
+        return InClassNode::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $reflection = $scope->getClassReflection();
+
+        if (! $reflection) {
+            return [];
+        }
+
+        if ($reflection->isAnonymous()) {
+            return [];
+        }
+
+        if (str_starts_with($reflection->getName(), 'CuyZ\Valinor\Tests')) {
+            return [];
+        }
+
+        if (str_starts_with($reflection->getName(), 'CuyZ\Valinor\QA')) {
+            return [];
+        }
+
+        if (! preg_match('/@api|internal\s+/', $reflection->getResolvedPhpDoc()?->getPhpDocString() ?? '')) {
+            return [
+                RuleErrorBuilder::message(
+                    'Missing annotation `@api` or `@internal`.'
+                )->build(),
+            ];
+        }
+
+        return [];
+    }
+}

--- a/src/Attribute/Identifier.php
+++ b/src/Attribute/Identifier.php
@@ -27,6 +27,8 @@ use CuyZ\Valinor\Mapper\Tree\Visitor\ShellVisitor;
  * ];
  * ```
  *
+ * @api
+ *
  * @Annotation
  * @Target({"PROPERTY"})
  */

--- a/src/Attribute/StaticMethodConstructor.php
+++ b/src/Attribute/StaticMethodConstructor.php
@@ -12,6 +12,8 @@ use CuyZ\Valinor\Mapper\Object\ObjectBuilder;
 use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
+ * @api
+ *
  * @Annotation
  * @NamedArgumentConstructor
  * @Target({"CLASS"})

--- a/src/Cache/ChainCache.php
+++ b/src/Cache/ChainCache.php
@@ -8,6 +8,8 @@ use Psr\SimpleCache\CacheInterface;
 use Traversable;
 
 /**
+ * @internal
+ *
  * @template EntryType
  * @implements CacheInterface<EntryType>
  */

--- a/src/Cache/Compiled/CacheCompiler.php
+++ b/src/Cache/Compiled/CacheCompiler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Cache\Compiled;
 
+/** @internal */
 interface CacheCompiler
 {
     /**

--- a/src/Cache/Compiled/CacheValidationCompiler.php
+++ b/src/Cache/Compiled/CacheValidationCompiler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Cache\Compiled;
 
+/** @internal */
 interface CacheValidationCompiler extends CacheCompiler
 {
     /**

--- a/src/Cache/Compiled/CompiledPhpFileCache.php
+++ b/src/Cache/Compiled/CompiledPhpFileCache.php
@@ -28,6 +28,8 @@ use function uniqid;
 use function unlink;
 
 /**
+ * @internal
+ *
  * @template EntryType
  * @implements CacheInterface<EntryType>
  */

--- a/src/Cache/Compiled/HasArguments.php
+++ b/src/Cache/Compiled/HasArguments.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Cache\Compiled;
 
+/** @internal */
 interface HasArguments extends CacheCompiler
 {
     /**

--- a/src/Cache/Compiled/PhpCacheFile.php
+++ b/src/Cache/Compiled/PhpCacheFile.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Cache\Compiled;
 
 /**
+ * @internal
+ *
  * @template ValueType
  */
 interface PhpCacheFile

--- a/src/Cache/Exception/CacheDirectoryNotFound.php
+++ b/src/Cache/Exception/CacheDirectoryNotFound.php
@@ -7,6 +7,8 @@ namespace CuyZ\Valinor\Cache\Exception;
 use RuntimeException;
 
 /**
+ * @internal
+ *
  * @codeCoverageIgnore
  * @infection-ignore-all
  */

--- a/src/Cache/Exception/CompiledPhpCacheFileNotWritten.php
+++ b/src/Cache/Exception/CompiledPhpCacheFileNotWritten.php
@@ -7,6 +7,8 @@ namespace CuyZ\Valinor\Cache\Exception;
 use RuntimeException;
 
 /**
+ * @internal
+ *
  * @codeCoverageIgnore
  * @infection-ignore-all
  */

--- a/src/Cache/Exception/CorruptedCompiledPhpCacheFile.php
+++ b/src/Cache/Exception/CorruptedCompiledPhpCacheFile.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Cache\Exception;
 
 use RuntimeException;
 
+/** @internal */
 final class CorruptedCompiledPhpCacheFile extends RuntimeException
 {
     public function __construct(string $filename)

--- a/src/Cache/RuntimeCache.php
+++ b/src/Cache/RuntimeCache.php
@@ -14,6 +14,8 @@ use Psr\SimpleCache\CacheInterface;
  *
  * @link http://www.php-fig.org/psr/psr-16/
  *
+ * @internal
+ *
  * @template EntryType
  * @implements CacheInterface<EntryType>
  */

--- a/src/Cache/VersionedCache.php
+++ b/src/Cache/VersionedCache.php
@@ -9,6 +9,8 @@ use Psr\SimpleCache\CacheInterface;
 use Traversable;
 
 /**
+ * @internal
+ *
  * @template EntryType
  * @implements CacheInterface<EntryType>
  */

--- a/src/Definition/Attributes.php
+++ b/src/Definition/Attributes.php
@@ -8,6 +8,8 @@ use Countable;
 use IteratorAggregate;
 
 /**
+ * @api
+ *
  * @extends IteratorAggregate<object>
  */
 interface Attributes extends IteratorAggregate, Countable

--- a/src/Definition/AttributesContainer.php
+++ b/src/Definition/AttributesContainer.php
@@ -9,6 +9,7 @@ use Traversable;
 use function array_filter;
 use function count;
 
+/** @internal */
 final class AttributesContainer implements Attributes
 {
     /** @var array<object> */

--- a/src/Definition/ClassDefinition.php
+++ b/src/Definition/ClassDefinition.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Definition;
 
+/** @api */
 final class ClassDefinition
 {
     /** @var class-string */

--- a/src/Definition/ClassSignature.php
+++ b/src/Definition/ClassSignature.php
@@ -10,6 +10,7 @@ use Stringable;
 use function implode;
 use function ltrim;
 
+/** @api */
 final class ClassSignature implements Stringable
 {
     /** @var class-string */

--- a/src/Definition/CombinedAttributes.php
+++ b/src/Definition/CombinedAttributes.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Definition;
 
 use Traversable;
 
+/** @internal */
 final class CombinedAttributes implements Attributes
 {
     private DoctrineAnnotations $doctrineAnnotations;

--- a/src/Definition/DoctrineAnnotations.php
+++ b/src/Definition/DoctrineAnnotations.php
@@ -13,6 +13,7 @@ use ReflectionProperty;
 use Reflector;
 use Traversable;
 
+/** @internal */
 final class DoctrineAnnotations implements Attributes
 {
     private AttributesContainer $delegate;

--- a/src/Definition/EmptyAttributes.php
+++ b/src/Definition/EmptyAttributes.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Definition;
 use CuyZ\Valinor\Utility\IsSingleton;
 use Traversable;
 
+/** @internal */
 final class EmptyAttributes implements Attributes
 {
     use IsSingleton;

--- a/src/Definition/Exception/ClassTypeAliasesDuplication.php
+++ b/src/Definition/Exception/ClassTypeAliasesDuplication.php
@@ -8,6 +8,7 @@ use LogicException;
 
 use function implode;
 
+/** @internal */
 final class ClassTypeAliasesDuplication extends LogicException
 {
     /**

--- a/src/Definition/Exception/InvalidParameterDefaultValue.php
+++ b/src/Definition/Exception/InvalidParameterDefaultValue.php
@@ -9,6 +9,7 @@ use CuyZ\Valinor\Utility\Reflection\Reflection;
 use LogicException;
 use ReflectionParameter;
 
+/** @internal */
 final class InvalidParameterDefaultValue extends LogicException
 {
     public function __construct(ReflectionParameter $reflection, Type $type)

--- a/src/Definition/Exception/InvalidPropertyDefaultValue.php
+++ b/src/Definition/Exception/InvalidPropertyDefaultValue.php
@@ -9,6 +9,7 @@ use CuyZ\Valinor\Utility\Reflection\Reflection;
 use LogicException;
 use ReflectionProperty;
 
+/** @internal */
 final class InvalidPropertyDefaultValue extends LogicException
 {
     public function __construct(ReflectionProperty $reflection, Type $type)

--- a/src/Definition/Exception/InvalidReflectionParameter.php
+++ b/src/Definition/Exception/InvalidReflectionParameter.php
@@ -13,6 +13,7 @@ use Reflector;
 use function get_class;
 use function implode;
 
+/** @internal */
 final class InvalidReflectionParameter extends LogicException
 {
     public function __construct(Reflector $reflector)

--- a/src/Definition/Exception/InvalidTypeAliasImportClass.php
+++ b/src/Definition/Exception/InvalidTypeAliasImportClass.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Definition\Exception;
 use CuyZ\Valinor\Definition\ClassSignature;
 use LogicException;
 
+/** @internal */
 final class InvalidTypeAliasImportClass extends LogicException
 {
     /**

--- a/src/Definition/Exception/InvalidTypeAliasImportClassType.php
+++ b/src/Definition/Exception/InvalidTypeAliasImportClassType.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Definition\ClassSignature;
 use CuyZ\Valinor\Type\Type;
 use LogicException;
 
+/** @internal */
 final class InvalidTypeAliasImportClassType extends LogicException
 {
     public function __construct(ClassSignature $signature, Type $type)

--- a/src/Definition/Exception/MethodNotFound.php
+++ b/src/Definition/Exception/MethodNotFound.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Definition\Exception;
 
 use LogicException;
 
+/** @internal */
 final class MethodNotFound extends LogicException
 {
     public function __construct(string $method)

--- a/src/Definition/Exception/ParameterNotFound.php
+++ b/src/Definition/Exception/ParameterNotFound.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Definition\Exception;
 
 use LogicException;
 
+/** @internal */
 final class ParameterNotFound extends LogicException
 {
     public function __construct(string $parameter)

--- a/src/Definition/Exception/PropertyNotFound.php
+++ b/src/Definition/Exception/PropertyNotFound.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Definition\Exception;
 
 use LogicException;
 
+/** @internal */
 final class PropertyNotFound extends LogicException
 {
     public function __construct(string $property)

--- a/src/Definition/Exception/TypesDoNotMatch.php
+++ b/src/Definition/Exception/TypesDoNotMatch.php
@@ -12,6 +12,7 @@ use ReflectionParameter;
 use ReflectionProperty;
 use Reflector;
 
+/** @internal */
 final class TypesDoNotMatch extends LogicException
 {
     /**

--- a/src/Definition/Exception/UnknownTypeAliasImport.php
+++ b/src/Definition/Exception/UnknownTypeAliasImport.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Definition\Exception;
 use CuyZ\Valinor\Definition\ClassSignature;
 use LogicException;
 
+/** @internal */
 final class UnknownTypeAliasImport extends LogicException
 {
     /**

--- a/src/Definition/MethodDefinition.php
+++ b/src/Definition/MethodDefinition.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Definition;
 
 use CuyZ\Valinor\Type\Type;
 
+/** @api */
 final class MethodDefinition
 {
     private string $name;

--- a/src/Definition/Methods.php
+++ b/src/Definition/Methods.php
@@ -10,6 +10,8 @@ use IteratorAggregate;
 use Traversable;
 
 /**
+ * @api
+ *
  * @implements IteratorAggregate<string, MethodDefinition>
  */
 final class Methods implements IteratorAggregate, Countable

--- a/src/Definition/NativeAttributes.php
+++ b/src/Definition/NativeAttributes.php
@@ -16,6 +16,7 @@ use Traversable;
 
 use function array_map;
 
+/** @internal */
 final class NativeAttributes implements Attributes
 {
     private AttributesContainer $delegate;

--- a/src/Definition/ParameterDefinition.php
+++ b/src/Definition/ParameterDefinition.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Definition;
 
 use CuyZ\Valinor\Type\Type;
 
+/** @api */
 final class ParameterDefinition
 {
     private string $name;

--- a/src/Definition/Parameters.php
+++ b/src/Definition/Parameters.php
@@ -10,6 +10,8 @@ use IteratorAggregate;
 use Traversable;
 
 /**
+ * @api
+ *
  * @implements IteratorAggregate<string, ParameterDefinition>
  */
 final class Parameters implements IteratorAggregate, Countable

--- a/src/Definition/Properties.php
+++ b/src/Definition/Properties.php
@@ -10,6 +10,8 @@ use IteratorAggregate;
 use Traversable;
 
 /**
+ * @api
+ *
  * @implements IteratorAggregate<string, PropertyDefinition>
  */
 final class Properties implements IteratorAggregate, Countable

--- a/src/Definition/PropertyDefinition.php
+++ b/src/Definition/PropertyDefinition.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Definition;
 
 use CuyZ\Valinor\Type\Type;
 
+/** @api */
 final class PropertyDefinition
 {
     private string $name;

--- a/src/Definition/Repository/AttributesRepository.php
+++ b/src/Definition/Repository/AttributesRepository.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Definition\Repository;
 use CuyZ\Valinor\Definition\Attributes;
 use Reflector;
 
+/** @internal */
 interface AttributesRepository
 {
     public function for(Reflector $reflector): Attributes;

--- a/src/Definition/Repository/Cache/CacheClassDefinitionRepository.php
+++ b/src/Definition/Repository/Cache/CacheClassDefinitionRepository.php
@@ -9,6 +9,7 @@ use CuyZ\Valinor\Definition\ClassSignature;
 use CuyZ\Valinor\Definition\Repository\ClassDefinitionRepository;
 use Psr\SimpleCache\CacheInterface;
 
+/** @internal */
 final class CacheClassDefinitionRepository implements ClassDefinitionRepository
 {
     private ClassDefinitionRepository $delegate;

--- a/src/Definition/Repository/Cache/Compiler/AttributesCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/AttributesCompiler.php
@@ -20,6 +20,7 @@ use function count;
 use function implode;
 use function var_export;
 
+/** @internal */
 final class AttributesCompiler
 {
     public function compile(Attributes $attributes): string

--- a/src/Definition/Repository/Cache/Compiler/ClassDefinitionCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/ClassDefinitionCompiler.php
@@ -17,6 +17,7 @@ use function filemtime;
 use function implode;
 use function iterator_to_array;
 
+/** @internal */
 final class ClassDefinitionCompiler implements CacheCompiler, CacheValidationCompiler
 {
     private AttributesCompiler $attributesCompiler;

--- a/src/Definition/Repository/Cache/Compiler/ClassSignatureCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/ClassSignatureCompiler.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Definition\Repository\Cache\Compiler;
 
 use CuyZ\Valinor\Definition\ClassSignature;
 
+/** @internal */
 final class ClassSignatureCompiler
 {
     private TypeCompiler $typeCompiler;

--- a/src/Definition/Repository/Cache/Compiler/Exception/IncompatibleAttributes.php
+++ b/src/Definition/Repository/Cache/Compiler/Exception/IncompatibleAttributes.php
@@ -9,6 +9,7 @@ use LogicException;
 
 use function get_class;
 
+/** @internal */
 final class IncompatibleAttributes extends LogicException
 {
     public function __construct(Attributes $attributes)

--- a/src/Definition/Repository/Cache/Compiler/Exception/TypeCannotBeCompiled.php
+++ b/src/Definition/Repository/Cache/Compiler/Exception/TypeCannotBeCompiled.php
@@ -9,6 +9,7 @@ use LogicException;
 
 use function get_class;
 
+/** @internal */
 final class TypeCannotBeCompiled extends LogicException
 {
     public function __construct(Type $type)

--- a/src/Definition/Repository/Cache/Compiler/MethodDefinitionCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/MethodDefinitionCompiler.php
@@ -9,6 +9,7 @@ use CuyZ\Valinor\Definition\ParameterDefinition;
 
 use function var_export;
 
+/** @internal */
 final class MethodDefinitionCompiler
 {
     private TypeCompiler $typeCompiler;

--- a/src/Definition/Repository/Cache/Compiler/ParameterDefinitionCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/ParameterDefinitionCompiler.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Definition\Repository\Cache\Compiler;
 
 use CuyZ\Valinor\Definition\ParameterDefinition;
 
+/** @internal */
 final class ParameterDefinitionCompiler
 {
     private TypeCompiler $typeCompiler;

--- a/src/Definition/Repository/Cache/Compiler/PropertyDefinitionCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/PropertyDefinitionCompiler.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Definition\Repository\Cache\Compiler;
 
 use CuyZ\Valinor\Definition\PropertyDefinition;
 
+/** @internal */
 final class PropertyDefinitionCompiler
 {
     private TypeCompiler $typeCompiler;

--- a/src/Definition/Repository/Cache/Compiler/TypeCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/TypeCompiler.php
@@ -40,6 +40,7 @@ use function get_class;
 use function implode;
 use function var_export;
 
+/** @internal */
 final class TypeCompiler
 {
     public function compile(Type $type): string

--- a/src/Definition/Repository/ClassDefinitionRepository.php
+++ b/src/Definition/Repository/ClassDefinitionRepository.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Definition\Repository;
 use CuyZ\Valinor\Definition\ClassDefinition;
 use CuyZ\Valinor\Definition\ClassSignature;
 
+/** @internal */
 interface ClassDefinitionRepository
 {
     public function for(ClassSignature $signature): ClassDefinition;

--- a/src/Definition/Repository/Reflection/CombinedAttributesRepository.php
+++ b/src/Definition/Repository/Reflection/CombinedAttributesRepository.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Definition\CombinedAttributes;
 use CuyZ\Valinor\Definition\Repository\AttributesRepository;
 use Reflector;
 
+/** @internal */
 final class CombinedAttributesRepository implements AttributesRepository
 {
     private DoctrineAnnotationsRepository $doctrineAnnotationsFactory;

--- a/src/Definition/Repository/Reflection/DoctrineAnnotationsRepository.php
+++ b/src/Definition/Repository/Reflection/DoctrineAnnotationsRepository.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Definition\DoctrineAnnotations;
 use CuyZ\Valinor\Definition\Repository\AttributesRepository;
 use Reflector;
 
+/** @internal */
 final class DoctrineAnnotationsRepository implements AttributesRepository
 {
     public function for(Reflector $reflector): DoctrineAnnotations

--- a/src/Definition/Repository/Reflection/NativeAttributesRepository.php
+++ b/src/Definition/Repository/Reflection/NativeAttributesRepository.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Definition\NativeAttributes;
 use CuyZ\Valinor\Definition\Repository\AttributesRepository;
 use Reflector;
 
+/** @internal */
 final class NativeAttributesRepository implements AttributesRepository
 {
     public function for(Reflector $reflector): NativeAttributes

--- a/src/Definition/Repository/Reflection/ReflectionClassDefinitionRepository.php
+++ b/src/Definition/Repository/Reflection/ReflectionClassDefinitionRepository.php
@@ -32,6 +32,7 @@ use function array_filter;
 use function array_keys;
 use function array_map;
 
+/** @internal */
 final class ReflectionClassDefinitionRepository implements ClassDefinitionRepository
 {
     private AttributesRepository $attributesFactory;

--- a/src/Definition/Repository/Reflection/ReflectionMethodDefinitionBuilder.php
+++ b/src/Definition/Repository/Reflection/ReflectionMethodDefinitionBuilder.php
@@ -13,6 +13,7 @@ use ReflectionParameter;
 
 use function array_map;
 
+/** @internal */
 final class ReflectionMethodDefinitionBuilder
 {
     private ReflectionParameterDefinitionBuilder $parameterBuilder;

--- a/src/Definition/Repository/Reflection/ReflectionParameterDefinitionBuilder.php
+++ b/src/Definition/Repository/Reflection/ReflectionParameterDefinitionBuilder.php
@@ -11,6 +11,7 @@ use CuyZ\Valinor\Type\Types\UnresolvableType;
 use CuyZ\Valinor\Utility\Reflection\Reflection;
 use ReflectionParameter;
 
+/** @internal */
 final class ReflectionParameterDefinitionBuilder
 {
     private AttributesRepository $attributesFactory;

--- a/src/Definition/Repository/Reflection/ReflectionPropertyDefinitionBuilder.php
+++ b/src/Definition/Repository/Reflection/ReflectionPropertyDefinitionBuilder.php
@@ -11,6 +11,7 @@ use CuyZ\Valinor\Type\Types\UnresolvableType;
 use CuyZ\Valinor\Utility\Reflection\Reflection;
 use ReflectionProperty;
 
+/** @internal */
 final class ReflectionPropertyDefinitionBuilder
 {
     private AttributesRepository $attributesRepository;

--- a/src/Definition/Repository/Reflection/ReflectionTypeResolver.php
+++ b/src/Definition/Repository/Reflection/ReflectionTypeResolver.php
@@ -16,6 +16,7 @@ use ReflectionParameter;
 use ReflectionProperty;
 use Reflector;
 
+/** @internal */
 final class ReflectionTypeResolver
 {
     private TypeParser $nativeParser;

--- a/src/Mapper/Exception/InvalidMappingTypeSignature.php
+++ b/src/Mapper/Exception/InvalidMappingTypeSignature.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Mapper\Exception;
 use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use RuntimeException;
 
+/** @internal */
 final class InvalidMappingTypeSignature extends RuntimeException
 {
     public function __construct(string $raw, InvalidType $exception)

--- a/src/Mapper/MappingError.php
+++ b/src/Mapper/MappingError.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Mapper;
 use CuyZ\Valinor\Mapper\Tree\Node;
 use RuntimeException;
 
+/** @api */
 final class MappingError extends RuntimeException
 {
     private Node $node;

--- a/src/Mapper/Object/Argument.php
+++ b/src/Mapper/Object/Argument.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Definition\Attributes;
 use CuyZ\Valinor\Definition\EmptyAttributes;
 use CuyZ\Valinor\Type\Type;
 
+/** @api */
 final class Argument
 {
     private string $name;

--- a/src/Mapper/Object/CanCompile.php
+++ b/src/Mapper/Object/CanCompile.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper\Object;
 
+/** @api */
 interface CanCompile extends ObjectBuilder
 {
     /**

--- a/src/Mapper/Object/DateTimeObjectBuilder.php
+++ b/src/Mapper/Object/DateTimeObjectBuilder.php
@@ -23,6 +23,7 @@ use function is_int;
 use function is_null;
 use function is_string;
 
+/** @internal */
 final class DateTimeObjectBuilder implements ObjectBuilder
 {
     public const DATE_MYSQL = 'Y-m-d H:i:s';

--- a/src/Mapper/Object/Exception/CannotParseToDateTime.php
+++ b/src/Mapper/Object/Exception/CannotParseToDateTime.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use DateTimeInterface;
 use RuntimeException;
 
+/** @api */
 final class CannotParseToDateTime extends RuntimeException implements Message
 {
     /**

--- a/src/Mapper/Object/Exception/ConstructorMethodIsNotPublic.php
+++ b/src/Mapper/Object/Exception/ConstructorMethodIsNotPublic.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Mapper\Object\Exception;
 use CuyZ\Valinor\Definition\MethodDefinition;
 use LogicException;
 
+/** @internal */
 final class ConstructorMethodIsNotPublic extends LogicException
 {
     public function __construct(MethodDefinition $method)

--- a/src/Mapper/Object/Exception/ConstructorMethodIsNotStatic.php
+++ b/src/Mapper/Object/Exception/ConstructorMethodIsNotStatic.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Mapper\Object\Exception;
 use CuyZ\Valinor\Definition\MethodDefinition;
 use RuntimeException;
 
+/** @internal */
 final class ConstructorMethodIsNotStatic extends RuntimeException
 {
     public function __construct(MethodDefinition $method)

--- a/src/Mapper/Object/Exception/InvalidConstructorMethodClassReturnType.php
+++ b/src/Mapper/Object/Exception/InvalidConstructorMethodClassReturnType.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Mapper\Object\Exception;
 use CuyZ\Valinor\Definition\MethodDefinition;
 use RuntimeException;
 
+/** @internal */
 final class InvalidConstructorMethodClassReturnType extends RuntimeException
 {
     /**

--- a/src/Mapper/Object/Exception/InvalidConstructorMethodReturnType.php
+++ b/src/Mapper/Object/Exception/InvalidConstructorMethodReturnType.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Mapper\Object\Exception;
 use CuyZ\Valinor\Definition\MethodDefinition;
 use RuntimeException;
 
+/** @internal */
 final class InvalidConstructorMethodReturnType extends RuntimeException
 {
     /**

--- a/src/Mapper/Object/Exception/InvalidSourceForObject.php
+++ b/src/Mapper/Object/Exception/InvalidSourceForObject.php
@@ -9,6 +9,7 @@ use RuntimeException;
 
 use function get_debug_type;
 
+/** @api */
 final class InvalidSourceForObject extends RuntimeException implements Message
 {
     /**

--- a/src/Mapper/Object/Exception/MethodNotFound.php
+++ b/src/Mapper/Object/Exception/MethodNotFound.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Mapper\Object\Exception;
 use CuyZ\Valinor\Definition\ClassDefinition;
 use RuntimeException;
 
+/** @internal */
 final class MethodNotFound extends RuntimeException
 {
     public function __construct(ClassDefinition $class, string $methodName)

--- a/src/Mapper/Object/Exception/MissingMethodArgument.php
+++ b/src/Mapper/Object/Exception/MissingMethodArgument.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Definition\ParameterDefinition;
 use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use RuntimeException;
 
+/** @api */
 final class MissingMethodArgument extends RuntimeException implements Message
 {
     public function __construct(ParameterDefinition $parameter)

--- a/src/Mapper/Object/Exception/MissingPropertyArgument.php
+++ b/src/Mapper/Object/Exception/MissingPropertyArgument.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Definition\PropertyDefinition;
 use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use RuntimeException;
 
+/** @api */
 final class MissingPropertyArgument extends RuntimeException implements Message
 {
     public function __construct(PropertyDefinition $property)

--- a/src/Mapper/Object/Exception/TooManyObjectBuilderFactoryAttributes.php
+++ b/src/Mapper/Object/Exception/TooManyObjectBuilderFactoryAttributes.php
@@ -10,6 +10,7 @@ use RuntimeException;
 
 use function count;
 
+/** @internal */
 final class TooManyObjectBuilderFactoryAttributes extends RuntimeException
 {
     /**

--- a/src/Mapper/Object/Factory/AttributeObjectBuilderFactory.php
+++ b/src/Mapper/Object/Factory/AttributeObjectBuilderFactory.php
@@ -10,6 +10,7 @@ use CuyZ\Valinor\Mapper\Object\ObjectBuilder;
 
 use function count;
 
+/** @internal */
 final class AttributeObjectBuilderFactory implements ObjectBuilderFactory
 {
     private ObjectBuilderFactory $delegate;

--- a/src/Mapper/Object/Factory/BasicObjectBuilderFactory.php
+++ b/src/Mapper/Object/Factory/BasicObjectBuilderFactory.php
@@ -13,6 +13,7 @@ use DateTimeInterface;
 
 use function is_a;
 
+/** @internal */
 final class BasicObjectBuilderFactory implements ObjectBuilderFactory
 {
     public function for(ClassDefinition $class): ObjectBuilder

--- a/src/Mapper/Object/Factory/ObjectBuilderFactory.php
+++ b/src/Mapper/Object/Factory/ObjectBuilderFactory.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Mapper\Object\Factory;
 use CuyZ\Valinor\Definition\ClassDefinition;
 use CuyZ\Valinor\Mapper\Object\ObjectBuilder;
 
+/** @internal */
 interface ObjectBuilderFactory
 {
     public function for(ClassDefinition $class): ObjectBuilder;

--- a/src/Mapper/Object/MethodObjectBuilder.php
+++ b/src/Mapper/Object/MethodObjectBuilder.php
@@ -19,6 +19,7 @@ use Exception;
 use function array_values;
 use function is_a;
 
+/** @api */
 final class MethodObjectBuilder implements ObjectBuilder
 {
     private ClassDefinition $class;

--- a/src/Mapper/Object/ObjectBuilder.php
+++ b/src/Mapper/Object/ObjectBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper\Object;
 
+/** @api */
 interface ObjectBuilder
 {
     /**

--- a/src/Mapper/Object/ReflectionObjectBuilder.php
+++ b/src/Mapper/Object/ReflectionObjectBuilder.php
@@ -9,6 +9,7 @@ use CuyZ\Valinor\Mapper\Object\Exception\MissingPropertyArgument;
 
 use function array_key_exists;
 
+/** @api */
 final class ReflectionObjectBuilder implements ObjectBuilder
 {
     private ClassDefinition $class;

--- a/src/Mapper/Source/Exception/FileExtensionNotHandled.php
+++ b/src/Mapper/Source/Exception/FileExtensionNotHandled.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Mapper\Source\Exception;
 
 use RuntimeException;
 
+/** @internal */
 final class FileExtensionNotHandled extends RuntimeException implements SourceException
 {
     public function __construct(string $extension)

--- a/src/Mapper/Source/Exception/InvalidJson.php
+++ b/src/Mapper/Source/Exception/InvalidJson.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Mapper\Source\Exception;
 
 use RuntimeException;
 
+/** @internal */
 final class InvalidJson extends RuntimeException implements SourceException
 {
     public function __construct()

--- a/src/Mapper/Source/Exception/InvalidYaml.php
+++ b/src/Mapper/Source/Exception/InvalidYaml.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Mapper\Source\Exception;
 
 use RuntimeException;
 
+/** @internal */
 final class InvalidYaml extends RuntimeException implements SourceException
 {
     public function __construct()

--- a/src/Mapper/Source/Exception/JsonExtensionNotEnabled.php
+++ b/src/Mapper/Source/Exception/JsonExtensionNotEnabled.php
@@ -7,6 +7,8 @@ namespace CuyZ\Valinor\Mapper\Source\Exception;
 use RuntimeException;
 
 /**
+ * @internal
+ *
  * @codeCoverageIgnore
  * @infection-ignore-all
  */

--- a/src/Mapper/Source/Exception/SourceException.php
+++ b/src/Mapper/Source/Exception/SourceException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper\Source\Exception;
 
+/** @internal */
 interface SourceException
 {
 }

--- a/src/Mapper/Source/Exception/SourceNotIterable.php
+++ b/src/Mapper/Source/Exception/SourceNotIterable.php
@@ -8,6 +8,7 @@ use RuntimeException;
 
 use function get_debug_type;
 
+/** @internal */
 final class SourceNotIterable extends RuntimeException implements SourceException
 {
     /**

--- a/src/Mapper/Source/Exception/UnableToReadFile.php
+++ b/src/Mapper/Source/Exception/UnableToReadFile.php
@@ -7,6 +7,8 @@ namespace CuyZ\Valinor\Mapper\Source\Exception;
 use RuntimeException;
 
 /**
+ * @internal
+ *
  * @codeCoverageIgnore
  * @infection-ignore-all
  */

--- a/src/Mapper/Source/Exception/YamlExtensionNotEnabled.php
+++ b/src/Mapper/Source/Exception/YamlExtensionNotEnabled.php
@@ -7,6 +7,8 @@ namespace CuyZ\Valinor\Mapper\Source\Exception;
 use RuntimeException;
 
 /**
+ * @internal
+ *
  * @codeCoverageIgnore
  * @infection-ignore-all
  */

--- a/src/Mapper/Source/FileSource.php
+++ b/src/Mapper/Source/FileSource.php
@@ -14,6 +14,8 @@ use Traversable;
 use function strtolower;
 
 /**
+ * @api
+ *
  * @implements IteratorAggregate<mixed>
  */
 final class FileSource implements IteratorAggregate, IdentifiableSource

--- a/src/Mapper/Source/IdentifiableSource.php
+++ b/src/Mapper/Source/IdentifiableSource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper\Source;
 
+/** @api */
 interface IdentifiableSource
 {
     public function sourceName(): string;

--- a/src/Mapper/Source/JsonSource.php
+++ b/src/Mapper/Source/JsonSource.php
@@ -17,6 +17,8 @@ use function is_iterable;
 use function json_decode;
 
 /**
+ * @api
+ *
  * @implements IteratorAggregate<mixed>
  */
 final class JsonSource implements IteratorAggregate

--- a/src/Mapper/Source/YamlSource.php
+++ b/src/Mapper/Source/YamlSource.php
@@ -17,6 +17,8 @@ use function is_iterable;
 use function yaml_parse;
 
 /**
+ * @api
+ *
  * @implements IteratorAggregate<mixed>
  */
 final class YamlSource implements IteratorAggregate

--- a/src/Mapper/Tree/Builder/ArrayNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ArrayNodeBuilder.php
@@ -18,6 +18,7 @@ use CuyZ\Valinor\Type\Types\NonEmptyArrayType;
 use function assert;
 use function is_iterable;
 
+/** @internal */
 final class ArrayNodeBuilder implements NodeBuilder
 {
     public function build(Shell $shell, RootNodeBuilder $rootBuilder): Node

--- a/src/Mapper/Tree/Builder/CasterNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/CasterNodeBuilder.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Mapper\Tree\Exception\NoCasterForType;
 use CuyZ\Valinor\Mapper\Tree\Node;
 use CuyZ\Valinor\Mapper\Tree\Shell;
 
+/** @internal */
 final class CasterNodeBuilder implements NodeBuilder
 {
     /** @var array<class-string, NodeBuilder> */

--- a/src/Mapper/Tree/Builder/ClassNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ClassNodeBuilder.php
@@ -20,6 +20,7 @@ use function is_array;
 use function is_iterable;
 use function iterator_to_array;
 
+/** @internal */
 final class ClassNodeBuilder implements NodeBuilder
 {
     private ClassDefinitionRepository $classDefinitionRepository;

--- a/src/Mapper/Tree/Builder/EnumNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/EnumNodeBuilder.php
@@ -18,6 +18,7 @@ use function is_bool;
 use function is_numeric;
 use function is_string;
 
+/** @internal */
 final class EnumNodeBuilder implements NodeBuilder
 {
     public function build(Shell $shell, RootNodeBuilder $rootBuilder): Node

--- a/src/Mapper/Tree/Builder/ErrorCatcherNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ErrorCatcherNodeBuilder.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use CuyZ\Valinor\Mapper\Tree\Node;
 use CuyZ\Valinor\Mapper\Tree\Shell;
 
+/** @internal */
 final class ErrorCatcherNodeBuilder implements NodeBuilder
 {
     private NodeBuilder $delegate;

--- a/src/Mapper/Tree/Builder/ListNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ListNodeBuilder.php
@@ -16,6 +16,7 @@ use CuyZ\Valinor\Type\Types\NonEmptyListType;
 use function assert;
 use function is_iterable;
 
+/** @internal */
 final class ListNodeBuilder implements NodeBuilder
 {
     public function build(Shell $shell, RootNodeBuilder $rootBuilder): Node

--- a/src/Mapper/Tree/Builder/NodeBuilder.php
+++ b/src/Mapper/Tree/Builder/NodeBuilder.php
@@ -5,6 +5,7 @@ namespace CuyZ\Valinor\Mapper\Tree\Builder;
 use CuyZ\Valinor\Mapper\Tree\Node;
 use CuyZ\Valinor\Mapper\Tree\Shell;
 
+/** @internal */
 interface NodeBuilder
 {
     public function build(Shell $shell, RootNodeBuilder $rootBuilder): Node;

--- a/src/Mapper/Tree/Builder/RootNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/RootNodeBuilder.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Mapper\Tree\Builder;
 use CuyZ\Valinor\Mapper\Tree\Node;
 use CuyZ\Valinor\Mapper\Tree\Shell;
 
+/** @internal */
 final class RootNodeBuilder
 {
     private NodeBuilder $root;

--- a/src/Mapper/Tree/Builder/ScalarNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ScalarNodeBuilder.php
@@ -11,6 +11,7 @@ use CuyZ\Valinor\Type\ScalarType;
 
 use function assert;
 
+/** @internal */
 final class ScalarNodeBuilder implements NodeBuilder
 {
     public function build(Shell $shell, RootNodeBuilder $rootBuilder): Node

--- a/src/Mapper/Tree/Builder/ShapedArrayNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ShapedArrayNodeBuilder.php
@@ -14,6 +14,7 @@ use function array_key_exists;
 use function assert;
 use function is_array;
 
+/** @internal */
 final class ShapedArrayNodeBuilder implements NodeBuilder
 {
     public function build(Shell $shell, RootNodeBuilder $rootBuilder): Node

--- a/src/Mapper/Tree/Builder/ShellVisitorNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ShellVisitorNodeBuilder.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Mapper\Tree\Node;
 use CuyZ\Valinor\Mapper\Tree\Shell;
 use CuyZ\Valinor\Mapper\Tree\Visitor\ShellVisitor;
 
+/** @internal */
 final class ShellVisitorNodeBuilder implements NodeBuilder
 {
     private NodeBuilder $delegate;

--- a/src/Mapper/Tree/Builder/ValueAlteringNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ValueAlteringNodeBuilder.php
@@ -8,6 +8,8 @@ use CuyZ\Valinor\Mapper\Tree\Node;
 use CuyZ\Valinor\Mapper\Tree\Shell;
 
 /**
+ * @internal
+ *
  * @template T
  */
 final class ValueAlteringNodeBuilder implements NodeBuilder

--- a/src/Mapper/Tree/Builder/VisitorNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/VisitorNodeBuilder.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Mapper\Tree\Builder;
 use CuyZ\Valinor\Mapper\Tree\Node;
 use CuyZ\Valinor\Mapper\Tree\Shell;
 
+/** @internal */
 final class VisitorNodeBuilder implements NodeBuilder
 {
     private NodeBuilder $delegate;

--- a/src/Mapper/Tree/Exception/CannotCastToScalarValue.php
+++ b/src/Mapper/Tree/Exception/CannotCastToScalarValue.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use CuyZ\Valinor\Type\ScalarType;
 use RuntimeException;
 
+/** @api */
 final class CannotCastToScalarValue extends RuntimeException implements Message
 {
     /**

--- a/src/Mapper/Tree/Exception/CannotGetInvalidNodeValue.php
+++ b/src/Mapper/Tree/Exception/CannotGetInvalidNodeValue.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Mapper\Tree\Exception;
 use CuyZ\Valinor\Mapper\Tree\Node;
 use LogicException;
 
+/** @internal */
 final class CannotGetInvalidNodeValue extends LogicException
 {
     public function __construct(Node $node)

--- a/src/Mapper/Tree/Exception/CannotGetParentOfRootShell.php
+++ b/src/Mapper/Tree/Exception/CannotGetParentOfRootShell.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
 use RuntimeException;
 
+/** @internal */
 final class CannotGetParentOfRootShell extends RuntimeException
 {
     public function __construct()

--- a/src/Mapper/Tree/Exception/DuplicatedNodeChild.php
+++ b/src/Mapper/Tree/Exception/DuplicatedNodeChild.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
 use RuntimeException;
 
+/** @internal */
 final class DuplicatedNodeChild extends RuntimeException
 {
     public function __construct(string $name)

--- a/src/Mapper/Tree/Exception/InvalidEnumValue.php
+++ b/src/Mapper/Tree/Exception/InvalidEnumValue.php
@@ -14,6 +14,7 @@ use function implode;
 use function is_bool;
 use function is_scalar;
 
+/** @api */
 final class InvalidEnumValue extends RuntimeException implements Message
 {
     /**

--- a/src/Mapper/Tree/Exception/InvalidNodeValue.php
+++ b/src/Mapper/Tree/Exception/InvalidNodeValue.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use CuyZ\Valinor\Type\Type;
 use RuntimeException;
 
+/** @api */
 final class InvalidNodeValue extends RuntimeException implements Message
 {
     /**

--- a/src/Mapper/Tree/Exception/InvalidTraversableKey.php
+++ b/src/Mapper/Tree/Exception/InvalidTraversableKey.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use CuyZ\Valinor\Type\Types\ArrayKeyType;
 use RuntimeException;
 
+/** @api */
 final class InvalidTraversableKey extends RuntimeException implements Message
 {
     /**

--- a/src/Mapper/Tree/Exception/NewShellTypeDoesNotMatch.php
+++ b/src/Mapper/Tree/Exception/NewShellTypeDoesNotMatch.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Mapper\Tree\Shell;
 use CuyZ\Valinor\Type\Type;
 use RuntimeException;
 
+/** @internal */
 final class NewShellTypeDoesNotMatch extends RuntimeException
 {
     public function __construct(Shell $shell, Type $newType)

--- a/src/Mapper/Tree/Exception/NoCasterForType.php
+++ b/src/Mapper/Tree/Exception/NoCasterForType.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Mapper\Tree\Exception;
 use CuyZ\Valinor\Type\Type;
 use RuntimeException;
 
+/** @internal */
 final class NoCasterForType extends RuntimeException
 {
     public function __construct(Type $type)

--- a/src/Mapper/Tree/Exception/ShapedArrayElementMissing.php
+++ b/src/Mapper/Tree/Exception/ShapedArrayElementMissing.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use CuyZ\Valinor\Type\Types\ShapedArrayElement;
 use RuntimeException;
 
+/** @api */
 final class ShapedArrayElementMissing extends RuntimeException implements Message
 {
     public function __construct(ShapedArrayElement $element)

--- a/src/Mapper/Tree/Exception/SourceMustBeIterable.php
+++ b/src/Mapper/Tree/Exception/SourceMustBeIterable.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use CuyZ\Valinor\Type\Type;
 use RuntimeException;
 
+/** @api */
 final class SourceMustBeIterable extends RuntimeException implements Message
 {
     /**

--- a/src/Mapper/Tree/Exception/UnresolvableShellType.php
+++ b/src/Mapper/Tree/Exception/UnresolvableShellType.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Mapper\Tree\Exception;
 use CuyZ\Valinor\Type\Types\UnresolvableType;
 use RuntimeException;
 
+/** @internal */
 final class UnresolvableShellType extends RuntimeException
 {
     public function __construct(UnresolvableType $type)

--- a/src/Mapper/Tree/Message/Formatter/MessageFormatter.php
+++ b/src/Mapper/Tree/Message/Formatter/MessageFormatter.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Mapper\Tree\Message\Formatter;
 
 use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
 
+/** @api */
 interface MessageFormatter
 {
     public function format(NodeMessage $message): string;

--- a/src/Mapper/Tree/Message/Formatter/MessageMapFormatter.php
+++ b/src/Mapper/Tree/Message/Formatter/MessageMapFormatter.php
@@ -66,6 +66,8 @@ use function is_callable;
  *
  * $content = $formatter->format($message);
  * ```
+ *
+ * @api
  */
 final class MessageMapFormatter implements MessageFormatter
 {

--- a/src/Mapper/Tree/Message/HasCode.php
+++ b/src/Mapper/Tree/Message/HasCode.php
@@ -7,6 +7,8 @@ namespace CuyZ\Valinor\Mapper\Tree\Message;
 /**
  * This interface can be implemented by a message to help to identify it with a
  * unique code.
+ *
+ * @api
  */
 interface HasCode extends Message
 {

--- a/src/Mapper/Tree/Message/Message.php
+++ b/src/Mapper/Tree/Message/Message.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Mapper\Tree\Message;
 
 use Stringable;
 
+/** @api */
 interface Message extends Stringable
 {
 }

--- a/src/Mapper/Tree/Message/MessagesFlattener.php
+++ b/src/Mapper/Tree/Message/MessagesFlattener.php
@@ -30,6 +30,8 @@ use function array_filter;
  * }
  * ```
  *
+ * @api
+ *
  * @implements IteratorAggregate<NodeMessage>
  */
 final class MessagesFlattener implements IteratorAggregate

--- a/src/Mapper/Tree/Message/NodeMessage.php
+++ b/src/Mapper/Tree/Message/NodeMessage.php
@@ -11,6 +11,7 @@ use Throwable;
 
 use function sprintf;
 
+/** @api */
 final class NodeMessage implements Message, HasCode
 {
     private Node $node;

--- a/src/Mapper/Tree/Message/ThrowableMessage.php
+++ b/src/Mapper/Tree/Message/ThrowableMessage.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Mapper\Tree\Message;
 use RuntimeException;
 use Throwable;
 
+/** @api */
 final class ThrowableMessage extends RuntimeException implements Message, HasCode
 {
     public static function new(string $message, string $code): self

--- a/src/Mapper/Tree/Node.php
+++ b/src/Mapper/Tree/Node.php
@@ -13,6 +13,7 @@ use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
 use CuyZ\Valinor\Type\Type;
 use Throwable;
 
+/** @api */
 final class Node
 {
     private Shell $shell;

--- a/src/Mapper/Tree/NodeTraverser.php
+++ b/src/Mapper/Tree/NodeTraverser.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Tree;
 
 /**
+ * @api
+ *
  * @template T
  */
 final class NodeTraverser

--- a/src/Mapper/Tree/Shell.php
+++ b/src/Mapper/Tree/Shell.php
@@ -15,6 +15,7 @@ use CuyZ\Valinor\Type\Types\UnresolvableType;
 use function array_unshift;
 use function implode;
 
+/** @api */
 final class Shell
 {
     private string $name;

--- a/src/Mapper/Tree/Visitor/AggregateShellVisitor.php
+++ b/src/Mapper/Tree/Visitor/AggregateShellVisitor.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Mapper\Tree\Visitor;
 
 use CuyZ\Valinor\Mapper\Tree\Shell;
 
+/** @internal */
 final class AggregateShellVisitor implements ShellVisitor
 {
     /** @var ShellVisitor[] */

--- a/src/Mapper/Tree/Visitor/AttributeShellVisitor.php
+++ b/src/Mapper/Tree/Visitor/AttributeShellVisitor.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Mapper\Tree\Visitor;
 
 use CuyZ\Valinor\Mapper\Tree\Shell;
 
+/** @internal */
 final class AttributeShellVisitor implements ShellVisitor
 {
     public function visit(Shell $shell): Shell

--- a/src/Mapper/Tree/Visitor/InterfaceShellVisitor.php
+++ b/src/Mapper/Tree/Visitor/InterfaceShellVisitor.php
@@ -17,6 +17,7 @@ use DateTimeInterface;
 
 use function is_string;
 
+/** @internal */
 final class InterfaceShellVisitor implements ShellVisitor
 {
     /** @var array<class-string, callable(Shell): class-string> */

--- a/src/Mapper/Tree/Visitor/ObjectBindingShellVisitor.php
+++ b/src/Mapper/Tree/Visitor/ObjectBindingShellVisitor.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Mapper\Tree\Visitor;
 
 use CuyZ\Valinor\Mapper\Tree\Shell;
 
+/** @internal */
 final class ObjectBindingShellVisitor implements ShellVisitor
 {
     /** @var array<string, callable(mixed): object> */

--- a/src/Mapper/Tree/Visitor/ShellVisitor.php
+++ b/src/Mapper/Tree/Visitor/ShellVisitor.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Mapper\Tree\Visitor;
 
 use CuyZ\Valinor\Mapper\Tree\Shell;
 
+/** @internal */
 interface ShellVisitor
 {
     public function visit(Shell $shell): Shell;

--- a/src/Mapper/Tree/Visitor/UnionShellVisitor.php
+++ b/src/Mapper/Tree/Visitor/UnionShellVisitor.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Mapper\Tree\Shell;
 use CuyZ\Valinor\Type\Resolver\Union\UnionNarrower;
 use CuyZ\Valinor\Type\Types\UnionType;
 
+/** @internal */
 final class UnionShellVisitor implements ShellVisitor
 {
     private UnionNarrower $unionNarrower;

--- a/src/Mapper/TreeMapper.php
+++ b/src/Mapper/TreeMapper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper;
 
+/** @api */
 interface TreeMapper
 {
     /**

--- a/src/Mapper/TreeMapperContainer.php
+++ b/src/Mapper/TreeMapperContainer.php
@@ -11,6 +11,7 @@ use CuyZ\Valinor\Mapper\Tree\Shell;
 use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use CuyZ\Valinor\Type\Parser\TypeParser;
 
+/** @internal */
 final class TreeMapperContainer implements TreeMapper
 {
     private TypeParser $typeParser;

--- a/src/MapperBuilder.php
+++ b/src/MapperBuilder.php
@@ -12,6 +12,7 @@ use CuyZ\Valinor\Mapper\TreeMapper;
 use CuyZ\Valinor\Utility\Reflection\Reflection;
 use LogicException;
 
+/** @api */
 final class MapperBuilder
 {
     private Settings $settings;

--- a/src/Type/CombiningType.php
+++ b/src/Type/CombiningType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type;
 
+/** @api */
 interface CombiningType extends Type
 {
     public function isMatchedBy(Type $other): bool;

--- a/src/Type/CompositeTraversableType.php
+++ b/src/Type/CompositeTraversableType.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type;
 
 use CuyZ\Valinor\Type\Types\ArrayKeyType;
 
+/** @api */
 interface CompositeTraversableType extends Type
 {
     public function keyType(): ArrayKeyType;

--- a/src/Type/FixedType.php
+++ b/src/Type/FixedType.php
@@ -2,6 +2,7 @@
 
 namespace CuyZ\Valinor\Type;
 
+/** @api */
 interface FixedType extends Type
 {
     /**

--- a/src/Type/IntegerType.php
+++ b/src/Type/IntegerType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type;
 
+/** @api */
 interface IntegerType extends ScalarType
 {
     public function cast($value): int;

--- a/src/Type/ObjectType.php
+++ b/src/Type/ObjectType.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type;
 
 use CuyZ\Valinor\Definition\ClassSignature;
 
+/** @api */
 interface ObjectType extends Type
 {
     public function signature(): ClassSignature;

--- a/src/Type/Parser/CachedParser.php
+++ b/src/Type/Parser/CachedParser.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Parser;
 
 use CuyZ\Valinor\Type\Type;
 
+/** @internal */
 final class CachedParser implements TypeParser
 {
     private TypeParser $delegate;

--- a/src/Type/Parser/Exception/Generic/AssignedGenericNotFound.php
+++ b/src/Type/Parser/Exception/Generic/AssignedGenericNotFound.php
@@ -9,6 +9,7 @@ use RuntimeException;
 
 use function implode;
 
+/** @internal */
 final class AssignedGenericNotFound extends RuntimeException implements InvalidType
 {
     public function __construct(string $className, string ...$templates)

--- a/src/Type/Parser/Exception/Generic/CannotAssignGeneric.php
+++ b/src/Type/Parser/Exception/Generic/CannotAssignGeneric.php
@@ -10,6 +10,7 @@ use RuntimeException;
 
 use function implode;
 
+/** @internal */
 final class CannotAssignGeneric extends RuntimeException implements InvalidType
 {
     public function __construct(string $className, Type ...$generics)

--- a/src/Type/Parser/Exception/Generic/GenericClosingBracketMissing.php
+++ b/src/Type/Parser/Exception/Generic/GenericClosingBracketMissing.php
@@ -10,6 +10,7 @@ use RuntimeException;
 
 use function implode;
 
+/** @internal */
 final class GenericClosingBracketMissing extends RuntimeException implements InvalidType
 {
     /**

--- a/src/Type/Parser/Exception/Generic/GenericCommaMissing.php
+++ b/src/Type/Parser/Exception/Generic/GenericCommaMissing.php
@@ -10,6 +10,7 @@ use RuntimeException;
 
 use function implode;
 
+/** @internal */
 final class GenericCommaMissing extends RuntimeException implements InvalidType
 {
     /**

--- a/src/Type/Parser/Exception/Generic/InvalidAssignedGeneric.php
+++ b/src/Type/Parser/Exception/Generic/InvalidAssignedGeneric.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use CuyZ\Valinor\Type\Type;
 use RuntimeException;
 
+/** @internal */
 final class InvalidAssignedGeneric extends RuntimeException implements InvalidType
 {
     /**

--- a/src/Type/Parser/Exception/Generic/MissingGenerics.php
+++ b/src/Type/Parser/Exception/Generic/MissingGenerics.php
@@ -12,6 +12,7 @@ use function array_fill;
 use function count;
 use function implode;
 
+/** @internal */
 final class MissingGenerics extends RuntimeException implements InvalidType
 {
     /**

--- a/src/Type/Parser/Exception/InvalidIntersectionType.php
+++ b/src/Type/Parser/Exception/InvalidIntersectionType.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Parser\Exception;
 use CuyZ\Valinor\Type\Type;
 use RuntimeException;
 
+/** @internal */
 final class InvalidIntersectionType extends RuntimeException implements InvalidType
 {
     public function __construct(Type $type)

--- a/src/Type/Parser/Exception/InvalidType.php
+++ b/src/Type/Parser/Exception/InvalidType.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Parser\Exception;
 
 use Throwable;
 
+/** @internal */
 interface InvalidType extends Throwable
 {
 }

--- a/src/Type/Parser/Exception/Iterable/ArrayClosingBracketMissing.php
+++ b/src/Type/Parser/Exception/Iterable/ArrayClosingBracketMissing.php
@@ -10,6 +10,7 @@ use CuyZ\Valinor\Type\Types\ArrayType;
 use CuyZ\Valinor\Type\Types\NonEmptyArrayType;
 use RuntimeException;
 
+/** @internal */
 final class ArrayClosingBracketMissing extends RuntimeException implements InvalidType
 {
     /**

--- a/src/Type/Parser/Exception/Iterable/ArrayCommaMissing.php
+++ b/src/Type/Parser/Exception/Iterable/ArrayCommaMissing.php
@@ -10,6 +10,7 @@ use CuyZ\Valinor\Type\Types\ArrayType;
 use CuyZ\Valinor\Type\Types\NonEmptyArrayType;
 use RuntimeException;
 
+/** @internal */
 final class ArrayCommaMissing extends RuntimeException implements InvalidType
 {
     /**

--- a/src/Type/Parser/Exception/Iterable/InvalidArrayKey.php
+++ b/src/Type/Parser/Exception/Iterable/InvalidArrayKey.php
@@ -10,6 +10,7 @@ use CuyZ\Valinor\Type\Types\ArrayType;
 use CuyZ\Valinor\Type\Types\NonEmptyArrayType;
 use RuntimeException;
 
+/** @internal */
 final class InvalidArrayKey extends RuntimeException implements InvalidType
 {
     /**

--- a/src/Type/Parser/Exception/Iterable/InvalidIterableKey.php
+++ b/src/Type/Parser/Exception/Iterable/InvalidIterableKey.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use CuyZ\Valinor\Type\Type;
 use RuntimeException;
 
+/** @internal */
 final class InvalidIterableKey extends RuntimeException implements InvalidType
 {
     public function __construct(Type $keyType, Type $subType)

--- a/src/Type/Parser/Exception/Iterable/InvalidShapeElementType.php
+++ b/src/Type/Parser/Exception/Iterable/InvalidShapeElementType.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use CuyZ\Valinor\Type\Types\ShapedArrayElement;
 use RuntimeException;
 
+/** @internal */
 final class InvalidShapeElementType extends RuntimeException implements InvalidType
 {
     public function __construct(ShapedArrayElement $element)

--- a/src/Type/Parser/Exception/Iterable/IterableClosingBracketMissing.php
+++ b/src/Type/Parser/Exception/Iterable/IterableClosingBracketMissing.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use CuyZ\Valinor\Type\Type;
 use RuntimeException;
 
+/** @internal */
 final class IterableClosingBracketMissing extends RuntimeException implements InvalidType
 {
     public function __construct(Type $keyType, Type $subtype)

--- a/src/Type/Parser/Exception/Iterable/IterableCommaMissing.php
+++ b/src/Type/Parser/Exception/Iterable/IterableCommaMissing.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use CuyZ\Valinor\Type\Type;
 use RuntimeException;
 
+/** @internal */
 final class IterableCommaMissing extends RuntimeException implements InvalidType
 {
     public function __construct(Type $type)

--- a/src/Type/Parser/Exception/Iterable/ListClosingBracketMissing.php
+++ b/src/Type/Parser/Exception/Iterable/ListClosingBracketMissing.php
@@ -10,6 +10,7 @@ use CuyZ\Valinor\Type\Types\ListType;
 use CuyZ\Valinor\Type\Types\NonEmptyListType;
 use RuntimeException;
 
+/** @internal */
 final class ListClosingBracketMissing extends RuntimeException implements InvalidType
 {
     /**

--- a/src/Type/Parser/Exception/Iterable/ShapedArrayClosingBracketMissing.php
+++ b/src/Type/Parser/Exception/Iterable/ShapedArrayClosingBracketMissing.php
@@ -10,6 +10,7 @@ use RuntimeException;
 
 use function implode;
 
+/** @internal */
 final class ShapedArrayClosingBracketMissing extends RuntimeException implements InvalidType
 {
     /**

--- a/src/Type/Parser/Exception/Iterable/ShapedArrayColonTokenMissing.php
+++ b/src/Type/Parser/Exception/Iterable/ShapedArrayColonTokenMissing.php
@@ -11,6 +11,7 @@ use RuntimeException;
 
 use function implode;
 
+/** @internal */
 final class ShapedArrayColonTokenMissing extends RuntimeException implements InvalidType
 {
     /**

--- a/src/Type/Parser/Exception/Iterable/ShapedArrayCommaMissing.php
+++ b/src/Type/Parser/Exception/Iterable/ShapedArrayCommaMissing.php
@@ -10,6 +10,7 @@ use RuntimeException;
 
 use function implode;
 
+/** @internal */
 final class ShapedArrayCommaMissing extends RuntimeException implements InvalidType
 {
     /**

--- a/src/Type/Parser/Exception/Iterable/ShapedArrayElementDuplicatedKey.php
+++ b/src/Type/Parser/Exception/Iterable/ShapedArrayElementDuplicatedKey.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Parser\Exception\Iterable;
 use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use RuntimeException;
 
+/** @internal */
 final class ShapedArrayElementDuplicatedKey extends RuntimeException implements InvalidType
 {
     public function __construct(string $key, string $signature)

--- a/src/Type/Parser/Exception/Iterable/ShapedArrayElementTypeMissing.php
+++ b/src/Type/Parser/Exception/Iterable/ShapedArrayElementTypeMissing.php
@@ -11,6 +11,7 @@ use RuntimeException;
 
 use function implode;
 
+/** @internal */
 final class ShapedArrayElementTypeMissing extends RuntimeException implements InvalidType
 {
     /**

--- a/src/Type/Parser/Exception/Iterable/ShapedArrayEmptyElements.php
+++ b/src/Type/Parser/Exception/Iterable/ShapedArrayEmptyElements.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Parser\Exception\Iterable;
 use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use RuntimeException;
 
+/** @internal */
 final class ShapedArrayEmptyElements extends RuntimeException implements InvalidType
 {
     public function __construct()

--- a/src/Type/Parser/Exception/Iterable/SimpleArrayClosingBracketMissing.php
+++ b/src/Type/Parser/Exception/Iterable/SimpleArrayClosingBracketMissing.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use CuyZ\Valinor\Type\Type;
 use RuntimeException;
 
+/** @internal */
 final class SimpleArrayClosingBracketMissing extends RuntimeException implements InvalidType
 {
     public function __construct(Type $subType)

--- a/src/Type/Parser/Exception/RightIntersectionTypeMissing.php
+++ b/src/Type/Parser/Exception/RightIntersectionTypeMissing.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Parser\Exception;
 use CuyZ\Valinor\Type\Type;
 use RuntimeException;
 
+/** @internal */
 final class RightIntersectionTypeMissing extends RuntimeException implements InvalidType
 {
     public function __construct(Type $type)

--- a/src/Type/Parser/Exception/RightUnionTypeMissing.php
+++ b/src/Type/Parser/Exception/RightUnionTypeMissing.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Parser\Exception;
 use CuyZ\Valinor\Type\Type;
 use RuntimeException;
 
+/** @internal */
 final class RightUnionTypeMissing extends RuntimeException implements InvalidType
 {
     public function __construct(Type $type)

--- a/src/Type/Parser/Exception/Scalar/ClassStringClosingBracketMissing.php
+++ b/src/Type/Parser/Exception/Scalar/ClassStringClosingBracketMissing.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use CuyZ\Valinor\Type\Type;
 use RuntimeException;
 
+/** @internal */
 final class ClassStringClosingBracketMissing extends RuntimeException implements InvalidType
 {
     public function __construct(Type $type)

--- a/src/Type/Parser/Exception/Scalar/IntegerRangeInvalidMaxValue.php
+++ b/src/Type/Parser/Exception/Scalar/IntegerRangeInvalidMaxValue.php
@@ -9,6 +9,7 @@ use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\IntegerValueType;
 use RuntimeException;
 
+/** @internal */
 final class IntegerRangeInvalidMaxValue extends RuntimeException implements InvalidType
 {
     public function __construct(IntegerValueType $min, Type $type)

--- a/src/Type/Parser/Exception/Scalar/IntegerRangeInvalidMinValue.php
+++ b/src/Type/Parser/Exception/Scalar/IntegerRangeInvalidMinValue.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use CuyZ\Valinor\Type\Type;
 use RuntimeException;
 
+/** @internal */
 final class IntegerRangeInvalidMinValue extends RuntimeException implements InvalidType
 {
     public function __construct(Type $type)

--- a/src/Type/Parser/Exception/Scalar/IntegerRangeMissingClosingBracket.php
+++ b/src/Type/Parser/Exception/Scalar/IntegerRangeMissingClosingBracket.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use CuyZ\Valinor\Type\Types\IntegerValueType;
 use RuntimeException;
 
+/** @internal */
 final class IntegerRangeMissingClosingBracket extends RuntimeException implements InvalidType
 {
     public function __construct(IntegerValueType $min, IntegerValueType $max)

--- a/src/Type/Parser/Exception/Scalar/IntegerRangeMissingComma.php
+++ b/src/Type/Parser/Exception/Scalar/IntegerRangeMissingComma.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use CuyZ\Valinor\Type\Types\IntegerValueType;
 use RuntimeException;
 
+/** @internal */
 final class IntegerRangeMissingComma extends RuntimeException implements InvalidType
 {
     public function __construct(IntegerValueType $min)

--- a/src/Type/Parser/Exception/Scalar/IntegerRangeMissingMaxValue.php
+++ b/src/Type/Parser/Exception/Scalar/IntegerRangeMissingMaxValue.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use CuyZ\Valinor\Type\Types\IntegerValueType;
 use RuntimeException;
 
+/** @internal */
 final class IntegerRangeMissingMaxValue extends RuntimeException implements InvalidType
 {
     public function __construct(IntegerValueType $min)

--- a/src/Type/Parser/Exception/Scalar/IntegerRangeMissingMinValue.php
+++ b/src/Type/Parser/Exception/Scalar/IntegerRangeMissingMinValue.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Parser\Exception\Scalar;
 use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use RuntimeException;
 
+/** @internal */
 final class IntegerRangeMissingMinValue extends RuntimeException implements InvalidType
 {
     public function __construct()

--- a/src/Type/Parser/Exception/Scalar/InvalidClassStringSubType.php
+++ b/src/Type/Parser/Exception/Scalar/InvalidClassStringSubType.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use CuyZ\Valinor\Type\Type;
 use RuntimeException;
 
+/** @internal */
 final class InvalidClassStringSubType extends RuntimeException implements InvalidType
 {
     public function __construct(Type $type)

--- a/src/Type/Parser/Exception/Scalar/ReversedValuesForIntegerRange.php
+++ b/src/Type/Parser/Exception/Scalar/ReversedValuesForIntegerRange.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Parser\Exception\Scalar;
 use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use RuntimeException;
 
+/** @internal */
 final class ReversedValuesForIntegerRange extends RuntimeException implements InvalidType
 {
     public function __construct(int $min, int $max)

--- a/src/Type/Parser/Exception/Scalar/SameValueForIntegerRange.php
+++ b/src/Type/Parser/Exception/Scalar/SameValueForIntegerRange.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Parser\Exception\Scalar;
 use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use RuntimeException;
 
+/** @internal */
 final class SameValueForIntegerRange extends RuntimeException implements InvalidType
 {
     public function __construct(int $value)

--- a/src/Type/Parser/Exception/Stream/TryingToAccessOutboundToken.php
+++ b/src/Type/Parser/Exception/Stream/TryingToAccessOutboundToken.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Parser\Exception\Stream;
 
 use OutOfBoundsException;
 
+/** @internal */
 final class TryingToAccessOutboundToken extends OutOfBoundsException
 {
     public function __construct()

--- a/src/Type/Parser/Exception/Stream/TryingToReadFinishedStream.php
+++ b/src/Type/Parser/Exception/Stream/TryingToReadFinishedStream.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Parser\Exception\Stream;
 
 use OverflowException;
 
+/** @internal */
 final class TryingToReadFinishedStream extends OverflowException
 {
     public function __construct()

--- a/src/Type/Parser/Exception/Stream/WrongTokenType.php
+++ b/src/Type/Parser/Exception/Stream/WrongTokenType.php
@@ -10,6 +10,7 @@ use LogicException;
 
 use function get_class;
 
+/** @internal */
 final class WrongTokenType extends LogicException
 {
     public function __construct(Token $token)

--- a/src/Type/Parser/Exception/Template/DuplicatedTemplateName.php
+++ b/src/Type/Parser/Exception/Template/DuplicatedTemplateName.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Parser\Exception\Template;
 
 use LogicException;
 
+/** @internal */
 final class DuplicatedTemplateName extends LogicException implements InvalidTemplate
 {
     public function __construct(string $template)

--- a/src/Type/Parser/Exception/Template/InvalidClassTemplate.php
+++ b/src/Type/Parser/Exception/Template/InvalidClassTemplate.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Parser\Exception\Template;
 
 use LogicException;
 
+/** @internal */
 final class InvalidClassTemplate extends LogicException implements InvalidTemplate
 {
     /**

--- a/src/Type/Parser/Exception/Template/InvalidTemplate.php
+++ b/src/Type/Parser/Exception/Template/InvalidTemplate.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Parser\Exception\Template;
 
 use Throwable;
 
+/** @internal */
 interface InvalidTemplate extends Throwable
 {
 }

--- a/src/Type/Parser/Exception/Template/InvalidTemplateType.php
+++ b/src/Type/Parser/Exception/Template/InvalidTemplateType.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Parser\Exception\Template;
 use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use LogicException;
 
+/** @internal */
 final class InvalidTemplateType extends LogicException implements InvalidTemplate
 {
     public function __construct(string $type, string $template, InvalidType $exception)

--- a/src/Type/Parser/Exception/UnknownSymbol.php
+++ b/src/Type/Parser/Exception/UnknownSymbol.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Parser\Exception;
 
 use RuntimeException;
 
+/** @internal */
 final class UnknownSymbol extends RuntimeException implements InvalidType
 {
     public function __construct(string $symbol)

--- a/src/Type/Parser/Factory/LexingTypeParserFactory.php
+++ b/src/Type/Parser/Factory/LexingTypeParserFactory.php
@@ -22,6 +22,7 @@ use LogicException;
 
 use function get_class;
 
+/** @internal */
 final class LexingTypeParserFactory implements TypeParserFactory
 {
     private TemplateParser $templateParser;

--- a/src/Type/Parser/Factory/Specifications/ClassAliasSpecification.php
+++ b/src/Type/Parser/Factory/Specifications/ClassAliasSpecification.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Parser\Factory\Specifications;
 
+/** @internal */
 final class ClassAliasSpecification
 {
     /** @var class-string */

--- a/src/Type/Parser/Factory/Specifications/ClassContextSpecification.php
+++ b/src/Type/Parser/Factory/Specifications/ClassContextSpecification.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Parser\Factory\Specifications;
 
+/** @internal */
 final class ClassContextSpecification
 {
     /** @var class-string */

--- a/src/Type/Parser/Factory/Specifications/HandleClassGenericSpecification.php
+++ b/src/Type/Parser/Factory/Specifications/HandleClassGenericSpecification.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Parser\Factory\Specifications;
 
+/** @internal */
 final class HandleClassGenericSpecification
 {
 }

--- a/src/Type/Parser/Factory/Specifications/TypeAliasAssignerSpecification.php
+++ b/src/Type/Parser/Factory/Specifications/TypeAliasAssignerSpecification.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Parser\Factory\Specifications;
 
 use CuyZ\Valinor\Type\Type;
 
+/** @internal */
 final class TypeAliasAssignerSpecification
 {
     /** @var array<string, Type> */

--- a/src/Type/Parser/Factory/TypeParserFactory.php
+++ b/src/Type/Parser/Factory/TypeParserFactory.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Parser\Factory;
 
 use CuyZ\Valinor\Type\Parser\TypeParser;
 
+/** @internal */
 interface TypeParserFactory
 {
     public function get(object ...$specifications): TypeParser;

--- a/src/Type/Parser/LazyParser.php
+++ b/src/Type/Parser/LazyParser.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Parser;
 
 use CuyZ\Valinor\Type\Type;
 
+/** @internal */
 final class LazyParser implements TypeParser
 {
     /** @var callable(): TypeParser */

--- a/src/Type/Parser/Lexer/ClassAliasLexer.php
+++ b/src/Type/Parser/Lexer/ClassAliasLexer.php
@@ -12,6 +12,7 @@ use ReflectionClass;
 use function class_exists;
 use function interface_exists;
 
+/** @internal */
 final class ClassAliasLexer implements TypeLexer
 {
     private TypeLexer $delegate;

--- a/src/Type/Parser/Lexer/ClassContextLexer.php
+++ b/src/Type/Parser/Lexer/ClassContextLexer.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Type\Parser\Lexer\Token\Token;
 use CuyZ\Valinor\Utility\Reflection\Reflection;
 use ReflectionClass;
 
+/** @internal */
 final class ClassContextLexer implements TypeLexer
 {
     private TypeLexer $delegate;

--- a/src/Type/Parser/Lexer/ClassGenericLexer.php
+++ b/src/Type/Parser/Lexer/ClassGenericLexer.php
@@ -10,6 +10,7 @@ use CuyZ\Valinor\Type\Parser\Lexer\Token\GenericClassNameToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\Token;
 use CuyZ\Valinor\Type\Parser\Template\TemplateParser;
 
+/** @internal */
 final class ClassGenericLexer implements TypeLexer
 {
     private TypeLexer $delegate;

--- a/src/Type/Parser/Lexer/NativeLexer.php
+++ b/src/Type/Parser/Lexer/NativeLexer.php
@@ -38,6 +38,7 @@ use function str_starts_with;
 use function strtolower;
 use function substr;
 
+/** @internal */
 final class NativeLexer implements TypeLexer
 {
     public function tokenize(string $symbol): Token

--- a/src/Type/Parser/Lexer/Token/ArrayToken.php
+++ b/src/Type/Parser/Lexer/Token/ArrayToken.php
@@ -25,6 +25,7 @@ use CuyZ\Valinor\Type\Types\ShapedArrayElement;
 use CuyZ\Valinor\Type\Types\ShapedArrayType;
 use CuyZ\Valinor\Type\Types\StringValueType;
 
+/** @internal */
 final class ArrayToken implements TraversingToken
 {
     /** @var class-string<ArrayType|NonEmptyArrayType> */

--- a/src/Type/Parser/Lexer/Token/ClassNameToken.php
+++ b/src/Type/Parser/Lexer/Token/ClassNameToken.php
@@ -10,6 +10,7 @@ use CuyZ\Valinor\Type\Types\ClassType;
 use CuyZ\Valinor\Type\Types\InterfaceType;
 use CuyZ\Valinor\Utility\Reflection\Reflection;
 
+/** @internal */
 final class ClassNameToken implements TraversingToken
 {
     /** @var class-string */

--- a/src/Type/Parser/Lexer/Token/ClassStringToken.php
+++ b/src/Type/Parser/Lexer/Token/ClassStringToken.php
@@ -12,6 +12,7 @@ use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\ClassStringType;
 use CuyZ\Valinor\Utility\IsSingleton;
 
+/** @internal */
 final class ClassStringToken implements TraversingToken
 {
     use IsSingleton;

--- a/src/Type/Parser/Lexer/Token/ClosingBracketToken.php
+++ b/src/Type/Parser/Lexer/Token/ClosingBracketToken.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Parser\Lexer\Token;
 
 use CuyZ\Valinor\Utility\IsSingleton;
 
+/** @internal */
 final class ClosingBracketToken implements Token
 {
     use IsSingleton;

--- a/src/Type/Parser/Lexer/Token/ClosingCurlyBracketToken.php
+++ b/src/Type/Parser/Lexer/Token/ClosingCurlyBracketToken.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Parser\Lexer\Token;
 
 use CuyZ\Valinor\Utility\IsSingleton;
 
+/** @internal */
 final class ClosingCurlyBracketToken implements Token
 {
     use IsSingleton;

--- a/src/Type/Parser/Lexer/Token/ClosingSquareBracketToken.php
+++ b/src/Type/Parser/Lexer/Token/ClosingSquareBracketToken.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Parser\Lexer\Token;
 
 use CuyZ\Valinor\Utility\IsSingleton;
 
+/** @internal */
 final class ClosingSquareBracketToken implements Token
 {
     use IsSingleton;

--- a/src/Type/Parser/Lexer/Token/ColonToken.php
+++ b/src/Type/Parser/Lexer/Token/ColonToken.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Parser\Lexer\Token;
 
 use CuyZ\Valinor\Utility\IsSingleton;
 
+/** @internal */
 final class ColonToken implements Token
 {
     use IsSingleton;

--- a/src/Type/Parser/Lexer/Token/CommaToken.php
+++ b/src/Type/Parser/Lexer/Token/CommaToken.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Parser\Lexer\Token;
 
 use CuyZ\Valinor\Utility\IsSingleton;
 
+/** @internal */
 final class CommaToken implements Token
 {
     use IsSingleton;

--- a/src/Type/Parser/Lexer/Token/EnumNameToken.php
+++ b/src/Type/Parser/Lexer/Token/EnumNameToken.php
@@ -9,6 +9,7 @@ use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\EnumType;
 use UnitEnum;
 
+/** @internal */
 final class EnumNameToken implements TraversingToken
 {
     /** @var class-string<UnitEnum> */

--- a/src/Type/Parser/Lexer/Token/GenericClassNameToken.php
+++ b/src/Type/Parser/Lexer/Token/GenericClassNameToken.php
@@ -32,6 +32,7 @@ use function array_shift;
 use function array_slice;
 use function count;
 
+/** @internal */
 final class GenericClassNameToken implements TraversingToken
 {
     /** @var class-string */

--- a/src/Type/Parser/Lexer/Token/IntegerToken.php
+++ b/src/Type/Parser/Lexer/Token/IntegerToken.php
@@ -17,6 +17,7 @@ use CuyZ\Valinor\Type\Types\IntegerValueType;
 use CuyZ\Valinor\Type\Types\NativeIntegerType;
 use CuyZ\Valinor\Utility\IsSingleton;
 
+/** @internal */
 final class IntegerToken implements TraversingToken
 {
     use IsSingleton;

--- a/src/Type/Parser/Lexer/Token/IntegerValueToken.php
+++ b/src/Type/Parser/Lexer/Token/IntegerValueToken.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Type\Parser\Lexer\TokenStream;
 use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\IntegerValueType;
 
+/** @internal */
 final class IntegerValueToken implements TraversingToken
 {
     private int $value;

--- a/src/Type/Parser/Lexer/Token/IntersectionToken.php
+++ b/src/Type/Parser/Lexer/Token/IntersectionToken.php
@@ -12,6 +12,7 @@ use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\IntersectionType;
 use CuyZ\Valinor\Utility\IsSingleton;
 
+/** @internal */
 final class IntersectionToken implements LeftTraversingToken
 {
     use IsSingleton;

--- a/src/Type/Parser/Lexer/Token/IterableToken.php
+++ b/src/Type/Parser/Lexer/Token/IterableToken.php
@@ -15,6 +15,7 @@ use CuyZ\Valinor\Type\Types\ArrayKeyType;
 use CuyZ\Valinor\Type\Types\IterableType;
 use CuyZ\Valinor\Utility\IsSingleton;
 
+/** @internal */
 final class IterableToken implements TraversingToken
 {
     use IsSingleton;

--- a/src/Type/Parser/Lexer/Token/LeftTraversingToken.php
+++ b/src/Type/Parser/Lexer/Token/LeftTraversingToken.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Parser\Lexer\Token;
 use CuyZ\Valinor\Type\Parser\Lexer\TokenStream;
 use CuyZ\Valinor\Type\Type;
 
+/** @internal */
 interface LeftTraversingToken extends Token
 {
     public function traverse(Type $type, TokenStream $stream): Type;

--- a/src/Type/Parser/Lexer/Token/ListToken.php
+++ b/src/Type/Parser/Lexer/Token/ListToken.php
@@ -10,6 +10,7 @@ use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\ListType;
 use CuyZ\Valinor\Type\Types\NonEmptyListType;
 
+/** @internal */
 final class ListToken implements TraversingToken
 {
     /** @var class-string<ListType|NonEmptyListType> */

--- a/src/Type/Parser/Lexer/Token/NativeToken.php
+++ b/src/Type/Parser/Lexer/Token/NativeToken.php
@@ -19,6 +19,7 @@ use CuyZ\Valinor\Type\Types\UndefinedObjectType;
 
 use function strtolower;
 
+/** @internal */
 final class NativeToken implements TraversingToken
 {
     /** @var array<string, self> */

--- a/src/Type/Parser/Lexer/Token/NullableToken.php
+++ b/src/Type/Parser/Lexer/Token/NullableToken.php
@@ -10,6 +10,7 @@ use CuyZ\Valinor\Type\Types\NullType;
 use CuyZ\Valinor\Type\Types\UnionType;
 use CuyZ\Valinor\Utility\IsSingleton;
 
+/** @internal */
 final class NullableToken implements TraversingToken
 {
     use IsSingleton;

--- a/src/Type/Parser/Lexer/Token/OpeningBracketToken.php
+++ b/src/Type/Parser/Lexer/Token/OpeningBracketToken.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Parser\Lexer\Token;
 
 use CuyZ\Valinor\Utility\IsSingleton;
 
+/** @internal */
 final class OpeningBracketToken implements Token
 {
     use IsSingleton;

--- a/src/Type/Parser/Lexer/Token/OpeningCurlyBracketToken.php
+++ b/src/Type/Parser/Lexer/Token/OpeningCurlyBracketToken.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Parser\Lexer\Token;
 
 use CuyZ\Valinor\Utility\IsSingleton;
 
+/** @internal */
 final class OpeningCurlyBracketToken implements Token
 {
     use IsSingleton;

--- a/src/Type/Parser/Lexer/Token/OpeningSquareBracketToken.php
+++ b/src/Type/Parser/Lexer/Token/OpeningSquareBracketToken.php
@@ -10,6 +10,7 @@ use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\ArrayType;
 use CuyZ\Valinor\Utility\IsSingleton;
 
+/** @internal */
 final class OpeningSquareBracketToken implements LeftTraversingToken
 {
     use IsSingleton;

--- a/src/Type/Parser/Lexer/Token/StringValueToken.php
+++ b/src/Type/Parser/Lexer/Token/StringValueToken.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Type\Parser\Lexer\TokenStream;
 use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\StringValueType;
 
+/** @internal */
 final class StringValueToken implements TraversingToken
 {
     private StringValueType $type;

--- a/src/Type/Parser/Lexer/Token/Token.php
+++ b/src/Type/Parser/Lexer/Token/Token.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Parser\Lexer\Token;
 
+/** @internal */
 interface Token
 {
 }

--- a/src/Type/Parser/Lexer/Token/TraversingToken.php
+++ b/src/Type/Parser/Lexer/Token/TraversingToken.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Parser\Lexer\Token;
 use CuyZ\Valinor\Type\Parser\Lexer\TokenStream;
 use CuyZ\Valinor\Type\Type;
 
+/** @internal */
 interface TraversingToken extends Token
 {
     public function traverse(TokenStream $stream): Type;

--- a/src/Type/Parser/Lexer/Token/TypeToken.php
+++ b/src/Type/Parser/Lexer/Token/TypeToken.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Parser\Lexer\Token;
 use CuyZ\Valinor\Type\Parser\Lexer\TokenStream;
 use CuyZ\Valinor\Type\Type;
 
+/** @internal */
 final class TypeToken implements TraversingToken
 {
     private Type $type;

--- a/src/Type/Parser/Lexer/Token/UnionToken.php
+++ b/src/Type/Parser/Lexer/Token/UnionToken.php
@@ -10,6 +10,7 @@ use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\UnionType;
 use CuyZ\Valinor\Utility\IsSingleton;
 
+/** @internal */
 final class UnionToken implements LeftTraversingToken
 {
     use IsSingleton;

--- a/src/Type/Parser/Lexer/Token/UnknownSymbolToken.php
+++ b/src/Type/Parser/Lexer/Token/UnknownSymbolToken.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Type\Parser\Exception\UnknownSymbol;
 use CuyZ\Valinor\Type\Parser\Lexer\TokenStream;
 use CuyZ\Valinor\Type\Type;
 
+/** @internal */
 final class UnknownSymbolToken implements TraversingToken
 {
     private string $symbol;

--- a/src/Type/Parser/Lexer/TokenStream.php
+++ b/src/Type/Parser/Lexer/TokenStream.php
@@ -12,6 +12,7 @@ use CuyZ\Valinor\Type\Parser\Lexer\Token\Token;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\TraversingToken;
 use CuyZ\Valinor\Type\Type;
 
+/** @internal */
 final class TokenStream
 {
     /** @var Token[] */

--- a/src/Type/Parser/Lexer/TypeAliasLexer.php
+++ b/src/Type/Parser/Lexer/TypeAliasLexer.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Type\Parser\Lexer\Token\Token;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\TypeToken;
 use CuyZ\Valinor\Type\Type;
 
+/** @internal */
 final class TypeAliasLexer implements TypeLexer
 {
     private TypeLexer $delegate;

--- a/src/Type/Parser/Lexer/TypeLexer.php
+++ b/src/Type/Parser/Lexer/TypeLexer.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Parser\Lexer;
 
 use CuyZ\Valinor\Type\Parser\Lexer\Token\Token;
 
+/** @internal */
 interface TypeLexer
 {
     public function tokenize(string $symbol): Token;

--- a/src/Type/Parser/LexingParser.php
+++ b/src/Type/Parser/LexingParser.php
@@ -13,6 +13,7 @@ use function array_map;
 use function preg_split;
 use function str_starts_with;
 
+/** @internal */
 final class LexingParser implements TypeParser
 {
     private TypeLexer $lexer;

--- a/src/Type/Parser/Template/BasicTemplateParser.php
+++ b/src/Type/Parser/Template/BasicTemplateParser.php
@@ -13,6 +13,7 @@ use CuyZ\Valinor\Type\Types\MixedType;
 use function preg_match_all;
 use function trim;
 
+/** @internal */
 final class BasicTemplateParser implements TemplateParser
 {
     public function templates(string $source, TypeParser $typeParser): array

--- a/src/Type/Parser/Template/TemplateParser.php
+++ b/src/Type/Parser/Template/TemplateParser.php
@@ -6,6 +6,7 @@ use CuyZ\Valinor\Type\Parser\Exception\Template\InvalidTemplate;
 use CuyZ\Valinor\Type\Parser\TypeParser;
 use CuyZ\Valinor\Type\Type;
 
+/** @internal */
 interface TemplateParser
 {
     /**

--- a/src/Type/Parser/TypeParser.php
+++ b/src/Type/Parser/TypeParser.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Parser;
 use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use CuyZ\Valinor\Type\Type;
 
+/** @internal */
 interface TypeParser
 {
     /**

--- a/src/Type/Resolver/Exception/CannotResolveObjectTypeFromUnion.php
+++ b/src/Type/Resolver/Exception/CannotResolveObjectTypeFromUnion.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use CuyZ\Valinor\Type\Types\UnionType;
 use RuntimeException;
 
+/** @api */
 final class CannotResolveObjectTypeFromUnion extends RuntimeException implements Message
 {
     public function __construct(UnionType $unionType)

--- a/src/Type/Resolver/Exception/CannotResolveTypeFromInterface.php
+++ b/src/Type/Resolver/Exception/CannotResolveTypeFromInterface.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Resolver\Exception;
 
 use RuntimeException;
 
+/** @internal */
 final class CannotResolveTypeFromInterface extends RuntimeException
 {
     public function __construct(string $interfaceName)

--- a/src/Type/Resolver/Exception/CannotResolveTypeFromUnion.php
+++ b/src/Type/Resolver/Exception/CannotResolveTypeFromUnion.php
@@ -10,6 +10,7 @@ use RuntimeException;
 
 use function get_debug_type;
 
+/** @api */
 final class CannotResolveTypeFromUnion extends RuntimeException implements Message
 {
     /**

--- a/src/Type/Resolver/Exception/InvalidInterfaceResolverReturnType.php
+++ b/src/Type/Resolver/Exception/InvalidInterfaceResolverReturnType.php
@@ -8,6 +8,7 @@ use RuntimeException;
 
 use function get_debug_type;
 
+/** @internal */
 final class InvalidInterfaceResolverReturnType extends RuntimeException
 {
     /**

--- a/src/Type/Resolver/Exception/InvalidTypeResolvedForInterface.php
+++ b/src/Type/Resolver/Exception/InvalidTypeResolvedForInterface.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Resolver\Exception;
 use CuyZ\Valinor\Type\Type;
 use RuntimeException;
 
+/** @internal */
 final class InvalidTypeResolvedForInterface extends RuntimeException
 {
     public function __construct(string $interfaceName, Type $wrongType)

--- a/src/Type/Resolver/Exception/ResolvedTypeForInterfaceIsNotAccepted.php
+++ b/src/Type/Resolver/Exception/ResolvedTypeForInterfaceIsNotAccepted.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Resolver\Exception;
 use CuyZ\Valinor\Type\Types\ClassType;
 use RuntimeException;
 
+/** @internal */
 final class ResolvedTypeForInterfaceIsNotAccepted extends RuntimeException
 {
     public function __construct(string $interfaceName, ClassType $type)

--- a/src/Type/Resolver/Exception/UnionTypeDoesNotAllowNull.php
+++ b/src/Type/Resolver/Exception/UnionTypeDoesNotAllowNull.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use CuyZ\Valinor\Type\Types\UnionType;
 use RuntimeException;
 
+/** @api */
 final class UnionTypeDoesNotAllowNull extends RuntimeException implements Message
 {
     public function __construct(UnionType $unionType)

--- a/src/Type/Resolver/Union/UnionNarrower.php
+++ b/src/Type/Resolver/Union/UnionNarrower.php
@@ -5,6 +5,7 @@ namespace CuyZ\Valinor\Type\Resolver\Union;
 use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\UnionType;
 
+/** @internal */
 interface UnionNarrower
 {
     /**

--- a/src/Type/Resolver/Union/UnionNullNarrower.php
+++ b/src/Type/Resolver/Union/UnionNullNarrower.php
@@ -9,6 +9,7 @@ use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\NullType;
 use CuyZ\Valinor\Type\Types\UnionType;
 
+/** @internal */
 final class UnionNullNarrower implements UnionNarrower
 {
     private UnionNarrower $delegate;

--- a/src/Type/Resolver/Union/UnionObjectNarrower.php
+++ b/src/Type/Resolver/Union/UnionObjectNarrower.php
@@ -20,6 +20,7 @@ use function in_array;
 use function is_array;
 use function ksort;
 
+/** @internal */
 final class UnionObjectNarrower implements UnionNarrower
 {
     private UnionNarrower $delegate;

--- a/src/Type/Resolver/Union/UnionScalarNarrower.php
+++ b/src/Type/Resolver/Union/UnionScalarNarrower.php
@@ -11,6 +11,7 @@ use CuyZ\Valinor\Type\Types\UnionType;
 
 use function count;
 
+/** @internal */
 final class UnionScalarNarrower implements UnionNarrower
 {
     /**

--- a/src/Type/ScalarType.php
+++ b/src/Type/ScalarType.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type;
 
 use CuyZ\Valinor\Type\Types\Exception\CastError;
 
+/** @api */
 interface ScalarType extends Type
 {
     /**

--- a/src/Type/StringType.php
+++ b/src/Type/StringType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type;
 
+/** @api */
 interface StringType extends ScalarType
 {
     public function cast($value): string;

--- a/src/Type/TraversableType.php
+++ b/src/Type/TraversableType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type;
 
+/** @api */
 interface TraversableType extends Type
 {
 }

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type;
 
 use Stringable;
 
+/** @api */
 interface Type extends Stringable
 {
     /**

--- a/src/Type/Types/ArrayKeyType.php
+++ b/src/Type/Types/ArrayKeyType.php
@@ -12,6 +12,7 @@ use CuyZ\Valinor\Type\Types\Exception\CannotCastValue;
 
 use function is_int;
 
+/** @api */
 final class ArrayKeyType implements ScalarType
 {
     private static self $integer;

--- a/src/Type/Types/ArrayType.php
+++ b/src/Type/Types/ArrayType.php
@@ -9,6 +9,7 @@ use CuyZ\Valinor\Type\Type;
 
 use function is_array;
 
+/** @api */
 final class ArrayType implements CompositeTraversableType
 {
     private static self $native;

--- a/src/Type/Types/BooleanType.php
+++ b/src/Type/Types/BooleanType.php
@@ -11,6 +11,7 @@ use CuyZ\Valinor\Utility\IsSingleton;
 
 use function is_bool;
 
+/** @api */
 final class BooleanType implements ScalarType
 {
     use IsSingleton;

--- a/src/Type/Types/ClassStringType.php
+++ b/src/Type/Types/ClassStringType.php
@@ -16,6 +16,7 @@ use function interface_exists;
 use function is_string;
 use function is_subclass_of;
 
+/** @api */
 final class ClassStringType implements StringType
 {
     private ?ObjectType $subType;

--- a/src/Type/Types/ClassType.php
+++ b/src/Type/Types/ClassType.php
@@ -10,6 +10,7 @@ use CuyZ\Valinor\Type\Type;
 
 use function is_subclass_of;
 
+/** @api */
 final class ClassType implements ObjectType
 {
     private ClassSignature $signature;

--- a/src/Type/Types/EnumType.php
+++ b/src/Type/Types/EnumType.php
@@ -12,6 +12,7 @@ use UnitEnum;
 
 use function in_array;
 
+/** @api */
 final class EnumType implements ObjectType
 {
     private ClassSignature $signature;

--- a/src/Type/Types/Exception/CannotCastValue.php
+++ b/src/Type/Types/Exception/CannotCastValue.php
@@ -9,6 +9,7 @@ use RuntimeException;
 
 use function get_debug_type;
 
+/** @api */
 final class CannotCastValue extends RuntimeException implements CastError
 {
     /**

--- a/src/Type/Types/Exception/CastError.php
+++ b/src/Type/Types/Exception/CastError.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Types\Exception;
 use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use Throwable;
 
+/** @internal */
 interface CastError extends Throwable, Message
 {
 }

--- a/src/Type/Types/Exception/ForbiddenMixedType.php
+++ b/src/Type/Types/Exception/ForbiddenMixedType.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Types\Exception;
 use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use LogicException;
 
+/** @internal */
 final class ForbiddenMixedType extends LogicException implements InvalidType
 {
     public function __construct()

--- a/src/Type/Types/Exception/InvalidClassString.php
+++ b/src/Type/Types/Exception/InvalidClassString.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Types\Exception;
 use CuyZ\Valinor\Type\Type;
 use LogicException;
 
+/** @api */
 final class InvalidClassString extends LogicException implements CastError
 {
     public function __construct(string $raw, Type $type)

--- a/src/Type/Types/Exception/InvalidEmptyStringValue.php
+++ b/src/Type/Types/Exception/InvalidEmptyStringValue.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Types\Exception;
 
 use RuntimeException;
 
+/** @api */
 final class InvalidEmptyStringValue extends RuntimeException implements CastError
 {
     public function __construct()

--- a/src/Type/Types/Exception/InvalidIntegerRangeValue.php
+++ b/src/Type/Types/Exception/InvalidIntegerRangeValue.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Types\Exception;
 use CuyZ\Valinor\Type\Types\IntegerRangeType;
 use RuntimeException;
 
+/** @api */
 final class InvalidIntegerRangeValue extends RuntimeException implements CastError
 {
     public function __construct(int $value, IntegerRangeType $type)

--- a/src/Type/Types/Exception/InvalidIntegerValue.php
+++ b/src/Type/Types/Exception/InvalidIntegerValue.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Types\Exception;
 use CuyZ\Valinor\Type\IntegerType;
 use RuntimeException;
 
+/** @api */
 final class InvalidIntegerValue extends RuntimeException implements CastError
 {
     public function __construct(int $value, IntegerType $type)

--- a/src/Type/Types/Exception/InvalidIntegerValueType.php
+++ b/src/Type/Types/Exception/InvalidIntegerValueType.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Types\Exception;
 
 use RuntimeException;
 
+/** @api */
 final class InvalidIntegerValueType extends RuntimeException implements CastError
 {
     /**

--- a/src/Type/Types/Exception/InvalidNegativeIntegerValue.php
+++ b/src/Type/Types/Exception/InvalidNegativeIntegerValue.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Types\Exception;
 
 use RuntimeException;
 
+/** @api */
 final class InvalidNegativeIntegerValue extends RuntimeException implements CastError
 {
     public function __construct(int $value)

--- a/src/Type/Types/Exception/InvalidPositiveIntegerValue.php
+++ b/src/Type/Types/Exception/InvalidPositiveIntegerValue.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Types\Exception;
 
 use RuntimeException;
 
+/** @api */
 final class InvalidPositiveIntegerValue extends RuntimeException implements CastError
 {
     public function __construct(int $value)

--- a/src/Type/Types/Exception/InvalidStringValue.php
+++ b/src/Type/Types/Exception/InvalidStringValue.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Types\Exception;
 
 use RuntimeException;
 
+/** @api */
 final class InvalidStringValue extends RuntimeException implements CastError
 {
     public function __construct(string $value, string $other)

--- a/src/Type/Types/Exception/InvalidStringValueType.php
+++ b/src/Type/Types/Exception/InvalidStringValueType.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Types\Exception;
 
 use RuntimeException;
 
+/** @api */
 final class InvalidStringValueType extends RuntimeException implements CastError
 {
     /**

--- a/src/Type/Types/FloatType.php
+++ b/src/Type/Types/FloatType.php
@@ -12,6 +12,7 @@ use CuyZ\Valinor\Utility\IsSingleton;
 use function is_float;
 use function is_numeric;
 
+/** @api */
 final class FloatType implements ScalarType
 {
     use IsSingleton;

--- a/src/Type/Types/IntegerRangeType.php
+++ b/src/Type/Types/IntegerRangeType.php
@@ -13,6 +13,7 @@ use CuyZ\Valinor\Type\Types\Exception\InvalidIntegerRangeValue;
 
 use function sprintf;
 
+/** @api */
 final class IntegerRangeType implements IntegerType
 {
     private int $min;

--- a/src/Type/Types/IntegerValueType.php
+++ b/src/Type/Types/IntegerValueType.php
@@ -14,6 +14,7 @@ use CuyZ\Valinor\Type\Types\Exception\InvalidIntegerValueType;
 use function filter_var;
 use function is_bool;
 
+/** @api */
 final class IntegerValueType implements IntegerType, FixedType
 {
     private int $value;

--- a/src/Type/Types/InterfaceType.php
+++ b/src/Type/Types/InterfaceType.php
@@ -11,6 +11,7 @@ use CuyZ\Valinor\Type\Type;
 
 use function is_subclass_of;
 
+/** @api */
 final class InterfaceType implements ObjectType
 {
     private ClassSignature $signature;

--- a/src/Type/Types/IntersectionType.php
+++ b/src/Type/Types/IntersectionType.php
@@ -10,6 +10,7 @@ use CuyZ\Valinor\Type\Type;
 
 use function implode;
 
+/** @api */
 final class IntersectionType implements CombiningType
 {
     /** @var ObjectType[] */

--- a/src/Type/Types/IterableType.php
+++ b/src/Type/Types/IterableType.php
@@ -9,6 +9,7 @@ use CuyZ\Valinor\Type\Type;
 
 use function is_iterable;
 
+/** @api */
 final class IterableType implements CompositeTraversableType
 {
     private static self $native;

--- a/src/Type/Types/ListType.php
+++ b/src/Type/Types/ListType.php
@@ -9,6 +9,7 @@ use CuyZ\Valinor\Type\Type;
 
 use function is_array;
 
+/** @api */
 final class ListType implements CompositeTraversableType
 {
     private static self $native;

--- a/src/Type/Types/MixedType.php
+++ b/src/Type/Types/MixedType.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Types;
 use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Utility\IsSingleton;
 
+/** @api */
 final class MixedType implements Type
 {
     use IsSingleton;

--- a/src/Type/Types/NativeIntegerType.php
+++ b/src/Type/Types/NativeIntegerType.php
@@ -13,6 +13,7 @@ use function filter_var;
 use function is_bool;
 use function is_int;
 
+/** @api */
 final class NativeIntegerType implements IntegerType
 {
     use IsSingleton;

--- a/src/Type/Types/NativeStringType.php
+++ b/src/Type/Types/NativeStringType.php
@@ -13,6 +13,7 @@ use Stringable;
 use function is_numeric;
 use function is_string;
 
+/** @api */
 final class NativeStringType implements StringType
 {
     use IsSingleton;

--- a/src/Type/Types/NegativeIntegerType.php
+++ b/src/Type/Types/NegativeIntegerType.php
@@ -14,6 +14,7 @@ use function filter_var;
 use function is_bool;
 use function is_int;
 
+/** @api */
 final class NegativeIntegerType implements IntegerType
 {
     use IsSingleton;

--- a/src/Type/Types/NonEmptyArrayType.php
+++ b/src/Type/Types/NonEmptyArrayType.php
@@ -9,6 +9,7 @@ use CuyZ\Valinor\Type\Type;
 
 use function is_array;
 
+/** @api */
 final class NonEmptyArrayType implements CompositeTraversableType
 {
     private static self $native;

--- a/src/Type/Types/NonEmptyListType.php
+++ b/src/Type/Types/NonEmptyListType.php
@@ -10,6 +10,7 @@ use CuyZ\Valinor\Type\Type;
 use function count;
 use function is_array;
 
+/** @api */
 final class NonEmptyListType implements CompositeTraversableType
 {
     private static self $native;

--- a/src/Type/Types/NonEmptyStringType.php
+++ b/src/Type/Types/NonEmptyStringType.php
@@ -14,6 +14,7 @@ use Stringable;
 use function is_numeric;
 use function is_string;
 
+/** @api */
 final class NonEmptyStringType implements StringType
 {
     use IsSingleton;

--- a/src/Type/Types/NullType.php
+++ b/src/Type/Types/NullType.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Types;
 use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Utility\IsSingleton;
 
+/** @api */
 final class NullType implements Type
 {
     use IsSingleton;

--- a/src/Type/Types/PositiveIntegerType.php
+++ b/src/Type/Types/PositiveIntegerType.php
@@ -14,6 +14,7 @@ use function filter_var;
 use function is_bool;
 use function is_int;
 
+/** @api */
 final class PositiveIntegerType implements IntegerType
 {
     use IsSingleton;

--- a/src/Type/Types/ShapedArrayElement.php
+++ b/src/Type/Types/ShapedArrayElement.php
@@ -9,6 +9,7 @@ use CuyZ\Valinor\Type\Parser\Exception\Iterable\InvalidShapeElementType;
 use CuyZ\Valinor\Type\Type;
 use Stringable;
 
+/** @api */
 final class ShapedArrayElement implements Stringable
 {
     /** @var StringValueType|IntegerValueType */

--- a/src/Type/Types/ShapedArrayType.php
+++ b/src/Type/Types/ShapedArrayType.php
@@ -17,6 +17,7 @@ use function implode;
 use function in_array;
 use function is_array;
 
+/** @api */
 final class ShapedArrayType implements TraversableType
 {
     /** @var ShapedArrayElement[] */

--- a/src/Type/Types/StringValueType.php
+++ b/src/Type/Types/StringValueType.php
@@ -14,6 +14,7 @@ use Stringable;
 use function is_numeric;
 use function is_string;
 
+/** @api */
 final class StringValueType implements StringType, FixedType
 {
     private string $value;

--- a/src/Type/Types/UndefinedObjectType.php
+++ b/src/Type/Types/UndefinedObjectType.php
@@ -10,6 +10,7 @@ use CuyZ\Valinor\Utility\IsSingleton;
 
 use function is_object;
 
+/** @api */
 final class UndefinedObjectType implements Type
 {
     use IsSingleton;

--- a/src/Type/Types/UnionType.php
+++ b/src/Type/Types/UnionType.php
@@ -10,6 +10,7 @@ use CuyZ\Valinor\Type\Types\Exception\ForbiddenMixedType;
 
 use function implode;
 
+/** @api */
 final class UnionType implements CombiningType
 {
     /** @var Type[] */

--- a/src/Type/Types/UnresolvableType.php
+++ b/src/Type/Types/UnresolvableType.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Types;
 use CuyZ\Valinor\Type\Type;
 use LogicException;
 
+/** @api */
 final class UnresolvableType extends LogicException implements Type
 {
     public function __construct(string $message)

--- a/src/Utility/IsSingleton.php
+++ b/src/Utility/IsSingleton.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Utility;
 
+/** @internal */
 trait IsSingleton
 {
     private static self $instance;

--- a/src/Utility/Package.php
+++ b/src/Utility/Package.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Utility;
 
 use Composer\InstalledVersions;
 
+/** @internal */
 final class Package
 {
     private static string $version;

--- a/src/Utility/Priority/HasPriority.php
+++ b/src/Utility/Priority/HasPriority.php
@@ -10,6 +10,8 @@ namespace CuyZ\Valinor\Utility\Priority;
  *
  * The higher the priority is for a given object, the more chance it has to
  * be used first.
+ *
+ * @api
  */
 interface HasPriority
 {

--- a/src/Utility/Priority/PrioritizedList.php
+++ b/src/Utility/Priority/PrioritizedList.php
@@ -8,6 +8,8 @@ use IteratorAggregate;
 use Traversable;
 
 /**
+ * @api
+ *
  * @template T of object
  * @implements IteratorAggregate<T>
  */

--- a/src/Utility/Reflection/ClassAliasParser.php
+++ b/src/Utility/Reflection/ClassAliasParser.php
@@ -13,6 +13,7 @@ use function explode;
 use function implode;
 use function strtolower;
 
+/** @internal */
 final class ClassAliasParser
 {
     use IsSingleton;

--- a/src/Utility/Reflection/Reflection.php
+++ b/src/Utility/Reflection/Reflection.php
@@ -25,6 +25,7 @@ use function preg_match_all;
 use function preg_replace;
 use function trim;
 
+/** @internal */
 final class Reflection
 {
     /** @var array<ReflectionClass<object>> */

--- a/src/Utility/Singleton.php
+++ b/src/Utility/Singleton.php
@@ -9,6 +9,7 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\PhpParser;
 use Doctrine\Common\Annotations\Reader;
 
+/** @internal */
 final class Singleton
 {
     private static Reader $annotationReader;


### PR DESCRIPTION
This change filters the scope of the public API that is provided by this
library.

Any class or interface that is not explicitly marked with an `@api`
annotation should never be used outside this library — any change can
and will be made without taking breaking changes rules into account.

When a breaking change happens inside the public API scope, a major
version will be released; refer to https://semver.org for more
information.

A new PHPStan extension is now part of the quality assurance process,
ensuring that all classes/interfaces must provide either `@internal` or
`@api` annotation.

Fixes #4 