### PR TITLE
fix: correct regex that detects `@internal` or `@api` annotations

### DIFF
--- a/qa/PHPStan/Extension/ApiAndInternalAnnotationCheck.php
+++ b/qa/PHPStan/Extension/ApiAndInternalAnnotationCheck.php
@@ -42,7 +42,7 @@ final class ApiAndInternalAnnotationCheck implements Rule
             return [];
         }
 
-        if (! preg_match('/@api|internal\s+/', $reflection->getResolvedPhpDoc()?->getPhpDocString() ?? '')) {
+        if (! preg_match('/@(api|internal)\s+/', $reflection->getResolvedPhpDoc()?->getPhpDocString() ?? '')) {
             return [
                 RuleErrorBuilder::message(
                     'Missing annotation `@api` or `@internal`.'


### PR DESCRIPTION
The regex matched `@api` or `internal<whitespace>`.
Now it matches `@` followed by `api` or `internal` followed by `<whitespace>`.