### PR TITLE
feat: handle variadic parameters in constructors

### DIFF
--- a/src/Definition/ParameterDefinition.php
+++ b/src/Definition/ParameterDefinition.php
@@ -17,6 +17,8 @@ final class ParameterDefinition
 
     private bool $isOptional;
 
+    private bool $isVariadic;
+
     /** @var mixed */
     private $defaultValue;
 
@@ -30,6 +32,7 @@ final class ParameterDefinition
         string $signature,
         Type $type,
         bool $isOptional,
+        bool $isVariadic,
         $defaultValue,
         Attributes $attributes
     ) {
@@ -37,6 +40,7 @@ final class ParameterDefinition
         $this->signature = $signature;
         $this->type = $type;
         $this->isOptional = $isOptional;
+        $this->isVariadic = $isVariadic;
         $this->defaultValue = $defaultValue;
         $this->attributes = $attributes;
     }
@@ -59,6 +63,11 @@ final class ParameterDefinition
     public function isOptional(): bool
     {
         return $this->isOptional;
+    }
+
+    public function isVariadic(): bool
+    {
+        return $this->isVariadic;
     }
 
     /**

--- a/src/Definition/Repository/Cache/Compiler/ParameterDefinitionCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/ParameterDefinitionCompiler.php
@@ -22,6 +22,7 @@ final class ParameterDefinitionCompiler
     public function compile(ParameterDefinition $parameter): string
     {
         $isOptional = var_export($parameter->isOptional(), true);
+        $isVariadic = var_export($parameter->isVariadic(), true);
         $defaultValue = var_export($parameter->defaultValue(), true);
         $type = $this->typeCompiler->compile($parameter->type());
         $attributes = $this->attributesCompiler->compile($parameter->attributes());
@@ -32,6 +33,7 @@ final class ParameterDefinitionCompiler
                 '{$parameter->signature()}',
                 $type,
                 $isOptional,
+                $isVariadic,
                 $defaultValue,
                 $attributes
             )

--- a/src/Definition/Repository/Reflection/ReflectionParameterDefinitionBuilder.php
+++ b/src/Definition/Repository/Reflection/ReflectionParameterDefinitionBuilder.php
@@ -27,8 +27,16 @@ final class ReflectionParameterDefinitionBuilder
         $signature = Reflection::signature($reflection);
         $type = $typeResolver->resolveType($reflection);
         $isOptional = $reflection->isOptional();
-        $defaultValue = $reflection->isDefaultValueAvailable() ? $reflection->getDefaultValue() : null;
+        $isVariadic = $reflection->isVariadic();
         $attributes = $this->attributesFactory->for($reflection);
+
+        if ($reflection->isDefaultValueAvailable()) {
+            $defaultValue = $reflection->getDefaultValue();
+        } elseif ($reflection->isVariadic()) {
+            $defaultValue = [];
+        } else {
+            $defaultValue = null;
+        }
 
         if ($isOptional
             && ! $type instanceof UnresolvableType
@@ -37,6 +45,6 @@ final class ReflectionParameterDefinitionBuilder
             throw new InvalidParameterDefaultValue($reflection, $type);
         }
 
-        return new ParameterDefinition($name, $signature, $type, $isOptional, $defaultValue, $attributes);
+        return new ParameterDefinition($name, $signature, $type, $isOptional, $isVariadic, $defaultValue, $attributes);
     }
 }

--- a/src/Definition/Repository/Reflection/ReflectionTypeResolver.php
+++ b/src/Definition/Repository/Reflection/ReflectionTypeResolver.php
@@ -91,6 +91,10 @@ final class ReflectionTypeResolver
 
         $type = Reflection::flattenType($reflectionType);
 
+        if ($reflection instanceof ReflectionParameter && $reflection->isVariadic()) {
+            $type .= '[]';
+        }
+
         return $this->parseType($type, $reflection, $this->nativeParser);
     }
 

--- a/tests/Fake/Definition/FakeParameterDefinition.php
+++ b/tests/Fake/Definition/FakeParameterDefinition.php
@@ -22,6 +22,7 @@ final class FakeParameterDefinition
             $name,
             $type ?? new FakeType(),
             false,
+            false,
             null,
             new FakeAttributes()
         );
@@ -40,6 +41,7 @@ final class FakeParameterDefinition
             'Signature::' . $reflection->name,
             $type,
             $reflection->isOptional(),
+            $reflection->isVariadic(),
             $reflection->isDefaultValueAvailable() ? $reflection->getDefaultValue() : null,
             new FakeAttributes()
         );

--- a/tests/Fake/Definition/Repository/FakeFunctionDefinitionRepository.php
+++ b/tests/Fake/Definition/Repository/FakeFunctionDefinitionRepository.php
@@ -19,7 +19,15 @@ final class FakeFunctionDefinitionRepository implements FunctionDefinitionReposi
             'foo',
             'foo:42-1337',
             new Parameters(
-                new ParameterDefinition('bar', 'foo::bar', NativeStringType::get(), false, 'foo', EmptyAttributes::get())
+                new ParameterDefinition(
+                    'bar',
+                    'foo::bar',
+                    NativeStringType::get(),
+                    false,
+                    false,
+                    'foo',
+                    EmptyAttributes::get()
+                )
             ),
             NativeStringType::get()
         );

--- a/tests/Functional/Definition/Repository/Cache/Compiler/ClassDefinitionCompilerTest.php
+++ b/tests/Functional/Definition/Repository/Cache/Compiler/ClassDefinitionCompilerTest.php
@@ -15,6 +15,7 @@ use ReflectionClass;
 
 use function file_put_contents;
 use function get_class;
+use function implode;
 use function sys_get_temp_dir;
 use function touch;
 use function unlink;
@@ -36,9 +37,9 @@ final class ClassDefinitionCompilerTest extends TestCase
             new class () {
                 public string $property = 'Some property default value';
 
-                public static function method(string $parameter = 'Some parameter default value'): string
+                public static function method(string $parameter = 'Some parameter default value', string ...$variadic): string
                 {
-                    return $parameter;
+                    return $parameter . implode(' / ', $variadic);
                 }
             };
 
@@ -79,7 +80,12 @@ final class ClassDefinitionCompilerTest extends TestCase
         self::assertSame('Signature::parameter', $parameter->signature());
         self::assertSame(NativeStringType::get(), $parameter->type());
         self::assertTrue($parameter->isOptional());
+        self::assertFalse($parameter->isVariadic());
         self::assertSame('Some parameter default value', $parameter->defaultValue());
+
+        $variadic = $method->parameters()->get('variadic');
+
+        self::assertTrue($variadic->isVariadic());
     }
 
     public function test_modifying_class_definition_file_invalids_compiled_class_definition(): void

--- a/tests/Functional/Definition/Repository/Cache/Compiler/FunctionDefinitionCompilerTest.php
+++ b/tests/Functional/Definition/Repository/Cache/Compiler/FunctionDefinitionCompilerTest.php
@@ -30,7 +30,15 @@ final class FunctionDefinitionCompilerTest extends TestCase
             'foo',
             'foo:42-1337',
             new Parameters(
-                new ParameterDefinition('bar', 'foo::bar', NativeStringType::get(), false, 'foo', EmptyAttributes::get())
+                new ParameterDefinition(
+                    'bar',
+                    'foo::bar',
+                    NativeStringType::get(),
+                    false,
+                    false,
+                    'foo',
+                    EmptyAttributes::get()
+                )
             ),
             NativeStringType::get()
         );

--- a/tests/Integration/Mapping/VariadicParameterMappingTest.php
+++ b/tests/Integration/Mapping/VariadicParameterMappingTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Mapping;
+
+use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\Tests\Integration\IntegrationTest;
+
+final class VariadicParameterMappingTest extends IntegrationTest
+{
+    public function test_only_variadic_parameters_are_mapped_properly(): void
+    {
+        try {
+            $object = $this->mapperBuilder->mapper()->map(SomeClassWithOnlyVariadicParameters::class, [
+                'values' => ['foo', 'bar', 'baz']
+            ]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame(['foo', 'bar', 'baz'], $object->values);
+    }
+
+    public function test_named_constructor_with_only_variadic_parameters_are_mapped_properly(): void
+    {
+        try {
+            $object = $this->mapperBuilder->mapper()->map(SomeClassWithNamedConstructorWithOnlyVariadicParameters::class, [
+                'values' => ['foo', 'bar', 'baz']
+            ]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame(['foo', 'bar', 'baz'], $object->values);
+    }
+
+    public function test_non_variadic_and_variadic_parameters_are_mapped_properly(): void
+    {
+        try {
+            $object = $this->mapperBuilder->mapper()->map(SomeClassWithNonVariadicAndVariadicParameters::class, [
+                'int' => 42,
+                'values' => ['foo', 'bar', 'baz']
+            ]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame(42, $object->int);
+        self::assertSame(['foo', 'bar', 'baz'], $object->values);
+    }
+
+    public function test_named_constructor_with_non_variadic_and_variadic_parameters_are_mapped_properly(): void
+    {
+        try {
+            $object = $this->mapperBuilder->mapper()->map(SomeClassWithNamedConstructorWithNonVariadicAndVariadicParameters::class, [
+                'int' => 42,
+                'values' => ['foo', 'bar', 'baz']
+            ]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame(42, $object->int);
+        self::assertSame(['foo', 'bar', 'baz'], $object->values);
+    }
+}
+
+final class SomeClassWithOnlyVariadicParameters
+{
+    /** @var string[] */
+    public array $values;
+
+    public function __construct(string ...$values)
+    {
+        $this->values = $values;
+    }
+}
+
+final class SomeClassWithNamedConstructorWithOnlyVariadicParameters
+{
+    /** @var string[] */
+    public array $values;
+
+    private function __construct(string ...$values)
+    {
+        $this->values = $values;
+    }
+
+    public static function new(string ...$values): self
+    {
+        return new self(...$values);
+    }
+}
+
+final class SomeClassWithNonVariadicAndVariadicParameters
+{
+    public int $int;
+
+    /** @var string[] */
+    public array $values;
+
+    public function __construct(int $int, string ...$values)
+    {
+        $this->int = $int;
+        $this->values = $values;
+    }
+}
+
+final class SomeClassWithNamedConstructorWithNonVariadicAndVariadicParameters
+{
+    public int $int;
+
+    /** @var string[] */
+    public array $values;
+
+    private function __construct(int $int, string ...$values)
+    {
+        $this->int = $int;
+        $this->values = $values;
+    }
+
+    public static function new(int $int, string ...$values): self
+    {
+        return new self($int, ...$values);
+    }
+}

--- a/tests/Unit/Definition/ParameterDefinitionTest.php
+++ b/tests/Unit/Definition/ParameterDefinitionTest.php
@@ -17,6 +17,7 @@ final class ParameterDefinitionTest extends TestCase
         $signature = 'someParameterSignature';
         $type = new FakeType();
         $isOptional = true;
+        $isVariadic = true;
         $defaultValue = 'Some parameter default value';
         $attributes = new FakeAttributes();
 
@@ -25,6 +26,7 @@ final class ParameterDefinitionTest extends TestCase
             $signature,
             $type,
             $isOptional,
+            $isVariadic,
             $defaultValue,
             $attributes
         );
@@ -33,6 +35,7 @@ final class ParameterDefinitionTest extends TestCase
         self::assertSame($signature, $parameter->signature());
         self::assertSame($type, $parameter->type());
         self::assertSame($isOptional, $parameter->isOptional());
+        self::assertSame($isVariadic, $parameter->isVariadic());
         self::assertSame($defaultValue, $parameter->defaultValue());
         self::assertSame($attributes, $parameter->attributes());
     }


### PR DESCRIPTION
Using variadic parameters is now handled properly by the library,
meaning the following example will run:

```php
final class SomeClass
{
    /** @var string[] */
    private array $values;

    public function __construct(string ...$values)
    {
        $this->values = $values;
    }
}

(new \CuyZ\Valinor\MapperBuilder())
    ->mapper()
    ->map(SomeClass::class, ['foo', 'bar', 'baz']);
```