### PR TITLE
Fix camel key modifier when used with non associative array

### DIFF
--- a/src/Mapper/Source/Modifier/CamelCaseKeys.php
+++ b/src/Mapper/Source/Modifier/CamelCaseKeys.php
@@ -11,15 +11,15 @@ use function is_iterable;
 
 /**
  * @api
- * @implements IteratorAggregate<string, mixed>
+ * @implements IteratorAggregate<mixed>
  */
 final class CamelCaseKeys implements IteratorAggregate
 {
-    /** @var array<string, mixed> */
+    /** @var array<mixed> */
     private array $source;
 
     /**
-     * @param iterable<string, mixed> $source
+     * @param iterable<mixed> $source
      */
     public function __construct(iterable $source)
     {
@@ -27,8 +27,8 @@ final class CamelCaseKeys implements IteratorAggregate
     }
 
     /**
-     * @param iterable<string, mixed> $source
-     * @return array<string, mixed>
+     * @param iterable<mixed> $source
+     * @return array<mixed>
      */
     private function replace(iterable $source): array
     {

--- a/src/Mapper/Source/Modifier/CamelCaseKeys.php
+++ b/src/Mapper/Source/Modifier/CamelCaseKeys.php
@@ -39,6 +39,11 @@ final class CamelCaseKeys implements IteratorAggregate
                 $value = $this->replace($value);
             }
 
+            if (! is_string($key)) {
+                $result[$key] = $value;
+                continue;
+            }
+
             $camelCaseKey = $this->camelCaseKeys($key);
 
             if (isset($result[$camelCaseKey])) {

--- a/tests/Unit/Mapper/Source/Modifier/CamelCaseKeysTest.php
+++ b/tests/Unit/Mapper/Source/Modifier/CamelCaseKeysTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Unit\Mapper\Source\Modifier;
+
+use CuyZ\Valinor\Mapper\Source\Modifier\CamelCaseKeys;
+use PHPUnit\Framework\TestCase;
+
+final class CamelCaseKeysTest extends TestCase
+{
+    public function test_replace_space(): void
+    {
+        $source = new CamelCaseKeys(['some key' => 'foo']);
+
+        self::assertSame(['someKey' => 'foo'], iterator_to_array($source));
+    }
+
+    public function test_replace_dash(): void
+    {
+        $source = new CamelCaseKeys(['some-key' => 'foo']);
+
+        self::assertSame(['someKey' => 'foo'], iterator_to_array($source));
+    }
+
+    public function test_replace_underscore(): void
+    {
+        $source = new CamelCaseKeys(['some_key' => 'foo']);
+
+        self::assertSame(['someKey' => 'foo'], iterator_to_array($source));
+    }
+
+    public function test_root_path_is_mapped(): void
+    {
+        $source = new CamelCaseKeys(['level-one' => 'bar']);
+
+        self::assertSame(['levelOne' => 'bar'], iterator_to_array($source));
+    }
+
+    public function test_sub_path_is_mapped(): void
+    {
+        $source = new CamelCaseKeys([
+            'level-one' => [
+                'level-two' => 'foo',
+            ],
+        ]);
+
+        self::assertSame([
+            'levelOne' => [
+                'levelTwo' => 'foo',
+            ],
+        ], iterator_to_array($source));
+    }
+
+    public function test_root_iterable_path_is_mapped(): void
+    {
+        $source = new CamelCaseKeys([
+            ['level-one' => 'foo'],
+            ['level-one' => 'bar'],
+        ]);
+
+        self::assertSame([
+            ['levelOne' => 'foo'],
+            ['levelOne' => 'bar'],
+        ], iterator_to_array($source));
+    }
+
+    public function test_sub_iterable_numeric_path_is_mapped(): void
+    {
+        $source = new CamelCaseKeys([
+            'level-one' => [
+                ['level-two' => 'bar'],
+                ['level-two' => 'buz'],
+            ],
+        ]);
+
+        self::assertSame([
+            'levelOne' => [
+                ['levelTwo' => 'bar'],
+                ['levelTwo' => 'buz'],
+            ],
+        ], iterator_to_array($source));
+    }
+
+    public function test_sub_iterable_string_path_is_mapped(): void
+    {
+        $source = new CamelCaseKeys([
+            'level-one' => [
+                'level-two-a' => ['level-three' => 'bar'],
+                'level-two-b' => ['level-three' => 'buz'],
+            ],
+        ]);
+
+        self::assertSame([
+            'levelOne' => [
+                'levelTwoA' => ['levelThree' => 'bar'],
+                'levelTwoB' => ['levelThree' => 'buz'],
+            ],
+        ], iterator_to_array($source));
+    }
+
+    public function test_path_with_sub_paths_are_mapped(): void
+    {
+        $source = new CamelCaseKeys([
+            'level-one' => [
+                ['level-two' => 'bar'],
+                ['level-two' => 'buz'],
+            ],
+        ]);
+
+        self::assertSame([
+            'levelOne' => [
+                ['levelTwo' => 'bar'],
+                ['levelTwo' => 'buz'],
+            ],
+        ], iterator_to_array($source));
+    }
+}


### PR DESCRIPTION
When using the camel key modifier with a source like:

```
{
  "foo_bar": "test",
  "test": [
     { "foo": "bar" },
     { "foo": "bar" }
   ]
}
```

The camel key modifier throws an exception. 

This fixes the behaviour 