### PR TITLE
misc!: change `Attributes::ofType` return type to `array`

### DIFF
--- a/src/Definition/Attributes.php
+++ b/src/Definition/Attributes.php
@@ -25,5 +25,5 @@ interface Attributes extends IteratorAggregate, Countable
      * @param class-string<T> $className
      * @return list<T>
      */
-    public function ofType(string $className): iterable;
+    public function ofType(string $className): array;
 }

--- a/src/Definition/AttributesContainer.php
+++ b/src/Definition/AttributesContainer.php
@@ -32,7 +32,7 @@ final class AttributesContainer implements Attributes
         return false;
     }
 
-    public function ofType(string $className): iterable
+    public function ofType(string $className): array
     {
         return array_values(array_filter(
             $this->attributes,

--- a/src/Definition/CombinedAttributes.php
+++ b/src/Definition/CombinedAttributes.php
@@ -44,7 +44,7 @@ final class CombinedAttributes implements Attributes
         return $this->delegate->has($className);
     }
 
-    public function ofType(string $className): iterable
+    public function ofType(string $className): array
     {
         return $this->delegate->ofType($className);
     }

--- a/src/Definition/DoctrineAnnotations.php
+++ b/src/Definition/DoctrineAnnotations.php
@@ -32,7 +32,7 @@ final class DoctrineAnnotations implements Attributes
         return $this->delegate->has($className);
     }
 
-    public function ofType(string $className): iterable
+    public function ofType(string $className): array
     {
         return $this->delegate->ofType($className);
     }

--- a/src/Definition/EmptyAttributes.php
+++ b/src/Definition/EmptyAttributes.php
@@ -17,7 +17,7 @@ final class EmptyAttributes implements Attributes
         return false;
     }
 
-    public function ofType(string $className): iterable
+    public function ofType(string $className): array
     {
         return [];
     }

--- a/src/Definition/NativeAttributes.php
+++ b/src/Definition/NativeAttributes.php
@@ -41,7 +41,7 @@ final class NativeAttributes implements Attributes
         return $this->delegate->has($className);
     }
 
-    public function ofType(string $className): iterable
+    public function ofType(string $className): array
     {
         return $this->delegate->ofType($className);
     }

--- a/src/Mapper/Object/Factory/AttributeObjectBuilderFactory.php
+++ b/src/Mapper/Object/Factory/AttributeObjectBuilderFactory.php
@@ -22,7 +22,6 @@ final class AttributeObjectBuilderFactory implements ObjectBuilderFactory
 
     public function for(ClassDefinition $class, $source): ObjectBuilder
     {
-        /** @var ObjectBuilderFactory[] $attributes */
         $attributes = $class->attributes()->ofType(ObjectBuilderFactory::class);
 
         if (count($attributes) === 0) {

--- a/src/Mapper/Tree/Visitor/AttributeShellVisitor.php
+++ b/src/Mapper/Tree/Visitor/AttributeShellVisitor.php
@@ -11,7 +11,6 @@ final class AttributeShellVisitor implements ShellVisitor
 {
     public function visit(Shell $shell): Shell
     {
-        /** @var ShellVisitor[] $visitors */
         $visitors = $shell->attributes()->ofType(ShellVisitor::class);
 
         foreach ($visitors as $visitor) {

--- a/tests/Fake/Definition/FakeAttributes.php
+++ b/tests/Fake/Definition/FakeAttributes.php
@@ -14,7 +14,7 @@ final class FakeAttributes implements Attributes
         return false;
     }
 
-    public function ofType(string $className): iterable
+    public function ofType(string $className): array
     {
         return [];
     }

--- a/tests/Fake/Definition/FakeNonEmptyAttributes.php
+++ b/tests/Fake/Definition/FakeNonEmptyAttributes.php
@@ -14,7 +14,7 @@ final class FakeNonEmptyAttributes implements Attributes
         return true;
     }
 
-    public function ofType(string $className): iterable
+    public function ofType(string $className): array
     {
         return [];
     }

--- a/tests/Unit/Definition/AttributesContainerTest.php
+++ b/tests/Unit/Definition/AttributesContainerTest.php
@@ -40,8 +40,8 @@ final class AttributesContainerTest extends TestCase
         $attributes = new AttributesContainer($object, $date);
         $filteredAttributes = $attributes->ofType(DateTimeInterface::class);
 
-        self::assertNotSame($filteredAttributes, $attributes);
         self::assertContainsEquals($date, $filteredAttributes);
         self::assertNotContains($object, $filteredAttributes);
+        self::assertSame($date, $filteredAttributes[0]);
     }
 }


### PR DESCRIPTION
There was no benefits having the return type as `iterable`, but it would
make it harder to use the result of the method.