### PR TITLE
feat: improve mapping error messages

### DIFF
--- a/infection.json.dist
+++ b/infection.json.dist
@@ -5,6 +5,7 @@
             "src"
         ]
     },
+    "tmpDir": "var/cache/infection",
     "logs": {
         "text": "var/infection/infection.log",
         "summary": "var/infection/summary.log",

--- a/src/Definition/Exception/InvalidParameterIndex.php
+++ b/src/Definition/Exception/InvalidParameterIndex.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Definition\Exception;
 
 use CuyZ\Valinor\Definition\Parameters;
-use LogicException;
+use OutOfBoundsException;
 
 /** @internal */
-final class InvalidParameterIndex extends LogicException
+final class InvalidParameterIndex extends OutOfBoundsException
 {
     public function __construct(int $index, Parameters $parameters)
     {

--- a/src/Mapper/Object/Arguments.php
+++ b/src/Mapper/Object/Arguments.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Mapper\Object;
 
 use Countable;
 use CuyZ\Valinor\Mapper\Object\Exception\InvalidArgumentIndex;
+use CuyZ\Valinor\Utility\TypeHelper;
 use IteratorAggregate;
 use Traversable;
 
@@ -36,9 +37,14 @@ final class Arguments implements IteratorAggregate, Countable
     public function signature(): string
     {
         $parameters = array_map(
-            fn (Argument $argument) => $argument->isRequired()
-                ? "{$argument->name()}: {$argument->type()}"
-                : "{$argument->name()}?: {$argument->type()}",
+            function (Argument $argument) {
+                $name = $argument->name();
+                $type = $argument->type();
+
+                $signature = TypeHelper::containsObject($type) ? '?' : $type;
+
+                return $argument->isRequired() ? "$name: $signature" : "$name?: $signature";
+            },
             $this->arguments
         );
 

--- a/src/Mapper/Object/Arguments.php
+++ b/src/Mapper/Object/Arguments.php
@@ -41,14 +41,14 @@ final class Arguments implements IteratorAggregate, Countable
                 $name = $argument->name();
                 $type = $argument->type();
 
-                $signature = TypeHelper::containsObject($type) ? '?' : $type;
+                $signature = TypeHelper::dump($type, false);
 
                 return $argument->isRequired() ? "$name: $signature" : "$name?: $signature";
             },
             $this->arguments
         );
 
-        return 'array{' . implode(', ', $parameters) . '}';
+        return '`array{' . implode(', ', $parameters) . '}`';
     }
 
     public function count(): int

--- a/src/Mapper/Object/Arguments.php
+++ b/src/Mapper/Object/Arguments.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Object;
+
+use Countable;
+use CuyZ\Valinor\Mapper\Object\Exception\InvalidArgumentIndex;
+use IteratorAggregate;
+use Traversable;
+
+/**
+ * @internal
+ *
+ * @implements IteratorAggregate<Argument>
+ */
+final class Arguments implements IteratorAggregate, Countable
+{
+    /** @var Argument[] */
+    private array $arguments;
+
+    public function __construct(Argument ...$arguments)
+    {
+        $this->arguments = $arguments;
+    }
+
+    public function at(int $index): Argument
+    {
+        if ($index >= count($this->arguments)) {
+            throw new InvalidArgumentIndex($index, $this);
+        }
+
+        return $this->arguments[$index];
+    }
+
+    public function signature(): string
+    {
+        $parameters = array_map(
+            fn (Argument $argument) => $argument->isRequired()
+                ? "{$argument->name()}: {$argument->type()}"
+                : "{$argument->name()}?: {$argument->type()}",
+            $this->arguments
+        );
+
+        return 'array{' . implode(', ', $parameters) . '}';
+    }
+
+    public function count(): int
+    {
+        return count($this->arguments);
+    }
+
+    /**
+     * @return Traversable<Argument>
+     */
+    public function getIterator(): Traversable
+    {
+        yield from $this->arguments;
+    }
+}

--- a/src/Mapper/Object/DateTimeObjectBuilder.php
+++ b/src/Mapper/Object/DateTimeObjectBuilder.php
@@ -84,7 +84,7 @@ final class DateTimeObjectBuilder implements ObjectBuilder
 
         if (! $date) {
             // @PHP8.0 use throw exception expression
-            throw new CannotParseToDateTime((string)$datetime, $this->className);
+            throw new CannotParseToDateTime((string)$datetime);
         }
 
         return $date;

--- a/src/Mapper/Object/DateTimeObjectBuilder.php
+++ b/src/Mapper/Object/DateTimeObjectBuilder.php
@@ -68,7 +68,7 @@ final class DateTimeObjectBuilder implements ObjectBuilder
         $format = null;
 
         if (is_array($datetime)) {
-            $format = $datetime['format'];
+            $format = $datetime['format'] ?? null;
             $datetime = $datetime['datetime'];
         }
 

--- a/src/Mapper/Object/DateTimeObjectBuilder.php
+++ b/src/Mapper/Object/DateTimeObjectBuilder.php
@@ -84,7 +84,7 @@ final class DateTimeObjectBuilder implements ObjectBuilder
 
         if (! $date) {
             // @PHP8.0 use throw exception expression
-            throw new CannotParseToDateTime((string)$datetime);
+            throw new CannotParseToDateTime($datetime);
         }
 
         return $date;

--- a/src/Mapper/Object/DateTimeObjectBuilder.php
+++ b/src/Mapper/Object/DateTimeObjectBuilder.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Object;
 
 use CuyZ\Valinor\Mapper\Object\Exception\CannotParseToDateTime;
-use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\NonEmptyStringType;
 use CuyZ\Valinor\Type\Types\NullType;
 use CuyZ\Valinor\Type\Types\PositiveIntegerType;
@@ -29,10 +28,10 @@ final class DateTimeObjectBuilder implements ObjectBuilder
     public const DATE_MYSQL = 'Y-m-d H:i:s';
     public const DATE_PGSQL = 'Y-m-d H:i:s.u';
 
-    private static Type $argumentType;
-
     /** @var class-string<DateTime|DateTimeImmutable> */
     private string $className;
+
+    private Arguments $arguments;
 
     /**
      * @param class-string<DateTime|DateTimeImmutable> $className
@@ -42,24 +41,24 @@ final class DateTimeObjectBuilder implements ObjectBuilder
         $this->className = $className;
     }
 
-    public function describeArguments(): iterable
+    public function describeArguments(): Arguments
     {
-        self::$argumentType ??= new UnionType(
-            new UnionType(PositiveIntegerType::get(), NonEmptyStringType::get()),
-            new ShapedArrayType(
-                new ShapedArrayElement(
-                    new StringValueType('datetime'),
-                    new UnionType(PositiveIntegerType::get(), NonEmptyStringType::get())
-                ),
-                new ShapedArrayElement(
-                    new StringValueType('format'),
-                    new UnionType(NullType::get(), NonEmptyStringType::get()),
-                    true
-                ),
-            )
+        return $this->arguments ??= new Arguments(
+            Argument::required('value', new UnionType(
+                new UnionType(PositiveIntegerType::get(), NonEmptyStringType::get()),
+                new ShapedArrayType(
+                    new ShapedArrayElement(
+                        new StringValueType('datetime'),
+                        new UnionType(PositiveIntegerType::get(), NonEmptyStringType::get())
+                    ),
+                    new ShapedArrayElement(
+                        new StringValueType('format'),
+                        new UnionType(NullType::get(), NonEmptyStringType::get()),
+                        true
+                    ),
+                )
+            ))
         );
-
-        yield Argument::required('value', self::$argumentType);
     }
 
     public function build(array $arguments): DateTimeInterface

--- a/src/Mapper/Object/Exception/CannotFindObjectBuilder.php
+++ b/src/Mapper/Object/Exception/CannotFindObjectBuilder.php
@@ -6,48 +6,65 @@ namespace CuyZ\Valinor\Mapper\Object\Exception;
 
 use CuyZ\Valinor\Mapper\Object\Factory\SuitableObjectBuilderNotFound;
 use CuyZ\Valinor\Mapper\Object\ObjectBuilder;
-use CuyZ\Valinor\Mapper\Tree\Message\Message;
+use CuyZ\Valinor\Mapper\Tree\Message\TranslatableMessage;
+use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 use function array_keys;
 use function count;
-use function implode;
 use function ksort;
 
 /** @api */
-final class CannotFindObjectBuilder extends RuntimeException implements Message, SuitableObjectBuilderNotFound
+final class CannotFindObjectBuilder extends RuntimeException implements TranslatableMessage, SuitableObjectBuilderNotFound
 {
+    private string $body = 'Value {value} does not match any of {allowed_types}.';
+
+    /** @var array<string, string> */
+    private array $parameters;
+
     /**
      * @param mixed $source
      * @param non-empty-list<ObjectBuilder> $builders
      */
     public function __construct($source, array $builders)
     {
-        $value = ValueDumper::dump($source);
+        $this->parameters = [
+            'value' => ValueDumper::dump($source),
+            'allowed_types' => (function () use ($builders) {
+                $signatures = [];
+                $sortedSignatures = [];
 
-        $signatures = [];
-        $sortedSignatures = [];
+                foreach ($builders as $builder) {
+                    $arguments = $builder->describeArguments();
+                    $count = count($arguments);
+                    $signature = $arguments->signature();
 
-        foreach ($builders as $builder) {
-            $arguments = $builder->describeArguments();
-            $count = count($arguments);
-            $signature = $arguments->signature();
+                    $signatures[$count][$signature] = null;
+                }
 
-            $signatures[$count][$signature] = null;
-        }
+                ksort($signatures);
 
-        ksort($signatures);
+                foreach ($signatures as $list) {
+                    foreach (array_keys($list) as $signature) {
+                        $sortedSignatures[] = $signature;
+                    }
+                }
 
-        foreach ($signatures as $list) {
-            foreach (array_keys($list) as $signature) {
-                $sortedSignatures[] = $signature;
-            }
-        }
+                return implode(', ', $sortedSignatures);
+            })(),
+        ];
 
-        parent::__construct(
-            "Value $value does not match any of `" . implode('`, `', $sortedSignatures) . '`.',
-            1642183169
-        );
+        parent::__construct(StringFormatter::for($this), 1642183169);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Mapper/Object/Exception/CannotParseToDateTime.php
+++ b/src/Mapper/Object/Exception/CannotParseToDateTime.php
@@ -4,20 +4,38 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper\Object\Exception;
 
-use CuyZ\Valinor\Mapper\Tree\Message\Message;
+use CuyZ\Valinor\Mapper\Tree\Message\TranslatableMessage;
+use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
-final class CannotParseToDateTime extends RuntimeException implements Message
+final class CannotParseToDateTime extends RuntimeException implements TranslatableMessage
 {
-    public function __construct(string $datetime)
-    {
-        $datetime = ValueDumper::dump($datetime);
+    private string $body = 'Value {value} does not match a valid date format.';
 
-        parent::__construct(
-            "Impossible to parse date with value $datetime.",
-            1630686564
-        );
+    /** @var array<string, string> */
+    private array $parameters;
+
+    /**
+     * @param string|int $datetime
+     */
+    public function __construct($datetime)
+    {
+        $this->parameters = [
+            'value' => ValueDumper::dump($datetime),
+        ];
+
+        parent::__construct(StringFormatter::for($this), 1630686564);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Mapper/Object/Exception/CannotParseToDateTime.php
+++ b/src/Mapper/Object/Exception/CannotParseToDateTime.php
@@ -5,19 +5,18 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Object\Exception;
 
 use CuyZ\Valinor\Mapper\Tree\Message\Message;
-use DateTimeInterface;
+use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
 final class CannotParseToDateTime extends RuntimeException implements Message
 {
-    /**
-     * @param class-string<DateTimeInterface> $dateTimeClassName
-     */
-    public function __construct(string $datetime, string $dateTimeClassName)
+    public function __construct(string $datetime)
     {
+        $datetime = ValueDumper::dump($datetime);
+
         parent::__construct(
-            "Impossible to convert `$datetime` to `$dateTimeClassName`.",
+            "Impossible to parse date with value $datetime.",
             1630686564
         );
     }

--- a/src/Mapper/Object/Exception/InvalidArgumentIndex.php
+++ b/src/Mapper/Object/Exception/InvalidArgumentIndex.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Object\Exception;
+
+use CuyZ\Valinor\Mapper\Object\Arguments;
+use OutOfBoundsException;
+
+/** @internal */
+final class InvalidArgumentIndex extends OutOfBoundsException
+{
+    public function __construct(int $index, Arguments $arguments)
+    {
+        $max = $arguments->count() - 1;
+
+        parent::__construct(
+            "Index $index is out of range, it should be between 0 and $max.",
+            1648672136
+        );
+    }
+}

--- a/src/Mapper/Object/Exception/InvalidSourceForInterface.php
+++ b/src/Mapper/Object/Exception/InvalidSourceForInterface.php
@@ -4,23 +4,38 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper\Object\Exception;
 
-use CuyZ\Valinor\Mapper\Tree\Message\Message;
+use CuyZ\Valinor\Mapper\Tree\Message\TranslatableMessage;
+use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
-final class InvalidSourceForInterface extends RuntimeException implements Message
+final class InvalidSourceForInterface extends RuntimeException implements TranslatableMessage
 {
+    private string $body = 'Invalid value {value}: it must be an array.';
+
+    /** @var array<string, string> */
+    private array $parameters;
+
     /**
      * @param mixed $source
      */
     public function __construct($source)
     {
-        $type = ValueDumper::dump($source);
+        $this->parameters = [
+            'value' => ValueDumper::dump($source),
+        ];
 
-        parent::__construct(
-            "Invalid value $type, it must be an iterable.",
-            1645283485
-        );
+        parent::__construct(StringFormatter::for($this), 1645283485);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Mapper/Object/Exception/InvalidSourceForInterface.php
+++ b/src/Mapper/Object/Exception/InvalidSourceForInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Object\Exception;
 
 use CuyZ\Valinor\Mapper\Tree\Message\Message;
-use CuyZ\Valinor\Utility\Polyfill;
+use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
@@ -16,10 +16,10 @@ final class InvalidSourceForInterface extends RuntimeException implements Messag
      */
     public function __construct($source)
     {
-        $type = Polyfill::get_debug_type($source);
+        $type = ValueDumper::dump($source);
 
         parent::__construct(
-            "Invalid source type `$type`, it must be an iterable.",
+            "Invalid value $type, it must be an iterable.",
             1645283485
         );
     }

--- a/src/Mapper/Object/Exception/InvalidSourceForObject.php
+++ b/src/Mapper/Object/Exception/InvalidSourceForObject.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper\Object\Exception;
 
+use CuyZ\Valinor\Mapper\Object\Arguments;
 use CuyZ\Valinor\Mapper\Tree\Message\Message;
-use CuyZ\Valinor\Utility\Polyfill;
+use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
@@ -14,12 +15,12 @@ final class InvalidSourceForObject extends RuntimeException implements Message
     /**
      * @param mixed $source
      */
-    public function __construct($source)
+    public function __construct($source, Arguments $arguments)
     {
-        $type = Polyfill::get_debug_type($source);
+        $value = ValueDumper::dump($source);
 
         parent::__construct(
-            "Invalid source type `$type`, it must be an iterable.",
+            "Value $value does not match `{$arguments->signature()}`.",
             1632903281
         );
     }

--- a/src/Mapper/Object/Exception/InvalidSourceForObject.php
+++ b/src/Mapper/Object/Exception/InvalidSourceForObject.php
@@ -5,23 +5,39 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Object\Exception;
 
 use CuyZ\Valinor\Mapper\Object\Arguments;
-use CuyZ\Valinor\Mapper\Tree\Message\Message;
+use CuyZ\Valinor\Mapper\Tree\Message\TranslatableMessage;
+use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
-final class InvalidSourceForObject extends RuntimeException implements Message
+final class InvalidSourceForObject extends RuntimeException implements TranslatableMessage
 {
+    private string $body = 'Value {value} does not match type {expected_type}.';
+
+    /** @var array<string, string> */
+    private array $parameters;
+
     /**
      * @param mixed $source
      */
     public function __construct($source, Arguments $arguments)
     {
-        $value = ValueDumper::dump($source);
+        $this->parameters = [
+            'value' => ValueDumper::dump($source),
+            'expected_type' => $arguments->signature(),
+        ];
 
-        parent::__construct(
-            "Value $value does not match `{$arguments->signature()}`.",
-            1632903281
-        );
+        parent::__construct(StringFormatter::for($this), 1632903281);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Mapper/Object/Exception/MissingMethodArgument.php
+++ b/src/Mapper/Object/Exception/MissingMethodArgument.php
@@ -5,11 +5,10 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Object\Exception;
 
 use CuyZ\Valinor\Definition\ParameterDefinition;
-use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use RuntimeException;
 
-/** @api */
-final class MissingMethodArgument extends RuntimeException implements Message
+/** @internal */
+final class MissingMethodArgument extends RuntimeException
 {
     public function __construct(ParameterDefinition $parameter)
     {

--- a/src/Mapper/Object/Exception/MissingPropertyArgument.php
+++ b/src/Mapper/Object/Exception/MissingPropertyArgument.php
@@ -5,11 +5,10 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Object\Exception;
 
 use CuyZ\Valinor\Definition\PropertyDefinition;
-use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use RuntimeException;
 
-/** @api */
-final class MissingPropertyArgument extends RuntimeException implements Message
+/** @internal */
+final class MissingPropertyArgument extends RuntimeException
 {
     public function __construct(PropertyDefinition $property)
     {

--- a/src/Mapper/Object/Exception/SeveralObjectBuildersFound.php
+++ b/src/Mapper/Object/Exception/SeveralObjectBuildersFound.php
@@ -6,7 +6,7 @@ namespace CuyZ\Valinor\Mapper\Object\Exception;
 
 use CuyZ\Valinor\Mapper\Object\Factory\SuitableObjectBuilderNotFound;
 use CuyZ\Valinor\Mapper\Tree\Message\Message;
-use CuyZ\Valinor\Utility\Polyfill;
+use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
@@ -17,10 +17,10 @@ final class SeveralObjectBuildersFound extends RuntimeException implements Messa
      */
     public function __construct($source)
     {
-        $type = Polyfill::get_debug_type($source);
+        $value = ValueDumper::dump($source);
 
         parent::__construct(
-            "Could not map input of type `$type`.",
+            "Value $value is not accepted.",
             1642787246
         );
     }

--- a/src/Mapper/Object/Exception/SeveralObjectBuildersFound.php
+++ b/src/Mapper/Object/Exception/SeveralObjectBuildersFound.php
@@ -5,23 +5,38 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Object\Exception;
 
 use CuyZ\Valinor\Mapper\Object\Factory\SuitableObjectBuilderNotFound;
-use CuyZ\Valinor\Mapper\Tree\Message\Message;
+use CuyZ\Valinor\Mapper\Tree\Message\TranslatableMessage;
+use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
-final class SeveralObjectBuildersFound extends RuntimeException implements Message, SuitableObjectBuilderNotFound
+final class SeveralObjectBuildersFound extends RuntimeException implements TranslatableMessage, SuitableObjectBuilderNotFound
 {
+    private string $body = 'Invalid value {value}.';
+
+    /** @var array<string, string> */
+    private array $parameters;
+
     /**
      * @param mixed $source
      */
     public function __construct($source)
     {
-        $value = ValueDumper::dump($source);
+        $this->parameters = [
+            'value' => ValueDumper::dump($source),
+        ];
 
-        parent::__construct(
-            "Value $value is not accepted.",
-            1642787246
-        );
+        parent::__construct(StringFormatter::for($this), 1642787246);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Mapper/Object/ObjectBuilder.php
+++ b/src/Mapper/Object/ObjectBuilder.php
@@ -7,10 +7,7 @@ namespace CuyZ\Valinor\Mapper\Object;
 /** @internal */
 interface ObjectBuilder
 {
-    /**
-     * @return iterable<Argument>
-     */
-    public function describeArguments(): iterable;
+    public function describeArguments(): Arguments;
 
     /**
      * @param array<string, mixed> $arguments

--- a/src/Mapper/Object/ObjectBuilder.php
+++ b/src/Mapper/Object/ObjectBuilder.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper\Object;
 
-/** @api */
+/** @internal */
 interface ObjectBuilder
 {
     /**

--- a/src/Mapper/Object/ObjectBuilderFilterer.php
+++ b/src/Mapper/Object/ObjectBuilderFilterer.php
@@ -54,7 +54,7 @@ final class ObjectBuilderFilterer
      */
     private function filledArguments(ObjectBuilder $builder, $source)
     {
-        $arguments = [...$builder->describeArguments()];
+        $arguments = $builder->describeArguments();
 
         if (! is_array($source)) {
             return count($arguments) === 1;
@@ -63,10 +63,10 @@ final class ObjectBuilderFilterer
         /** @infection-ignore-all */
         $filled = 0;
 
-        foreach ($arguments as $parameter) {
-            if (isset($source[$parameter->name()])) {
+        foreach ($arguments as $argument) {
+            if (isset($source[$argument->name()])) {
                 $filled++;
-            } elseif ($parameter->isRequired()) {
+            } elseif ($argument->isRequired()) {
                 return false;
             }
         }

--- a/src/Mapper/Source/Exception/SourceNotIterable.php
+++ b/src/Mapper/Source/Exception/SourceNotIterable.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper\Source\Exception;
 
-use CuyZ\Valinor\Utility\Polyfill;
+use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @internal */
@@ -15,10 +15,10 @@ final class SourceNotIterable extends RuntimeException implements SourceExceptio
      */
     public function __construct($value)
     {
-        $type = Polyfill::get_debug_type($value);
+        $value = ValueDumper::dump($value);
 
         parent::__construct(
-            "The configuration is not an iterable but of type `$type`.",
+            "Invalid source $value, expected an iterable.",
             1566307291
         );
     }

--- a/src/Mapper/Tree/Builder/ClassNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ClassNodeBuilder.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Tree\Builder;
 
 use CuyZ\Valinor\Definition\Repository\ClassDefinitionRepository;
-use CuyZ\Valinor\Mapper\Object\Argument;
+use CuyZ\Valinor\Mapper\Object\Arguments;
 use CuyZ\Valinor\Mapper\Object\Exception\InvalidSourceForObject;
 use CuyZ\Valinor\Mapper\Object\Factory\ObjectBuilderFactory;
 use CuyZ\Valinor\Mapper\Object\Factory\SuitableObjectBuilderNotFound;
@@ -58,9 +58,9 @@ final class ClassNodeBuilder implements NodeBuilder
         $source = $shell->value();
 
         $builder = $this->builder($source, ...$classTypes);
-        $arguments = [...$builder->describeArguments()];
+        $arguments = $builder->describeArguments();
 
-        $source = $this->transformSource($source, ...$arguments);
+        $source = $this->transformSource($source, $arguments);
         $children = [];
 
         foreach ($arguments as $argument) {
@@ -129,7 +129,7 @@ final class ClassNodeBuilder implements NodeBuilder
      * @param mixed $source
      * @return mixed[]
      */
-    private function transformSource($source, Argument ...$arguments): array
+    private function transformSource($source, Arguments $arguments): array
     {
         if ($source === null || count($arguments) === 0) {
             return [];
@@ -140,7 +140,7 @@ final class ClassNodeBuilder implements NodeBuilder
         }
 
         if (count($arguments) === 1) {
-            $name = $arguments[0]->name();
+            $name = $arguments->at(0)->name();
 
             if (! is_array($source) || ! array_key_exists($name, $source)) {
                 $source = [$name => $source];

--- a/src/Mapper/Tree/Builder/ClassNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ClassNodeBuilder.php
@@ -148,7 +148,7 @@ final class ClassNodeBuilder implements NodeBuilder
         }
 
         if (! is_array($source)) {
-            throw new InvalidSourceForObject($source);
+            throw new InvalidSourceForObject($source, $arguments);
         }
 
         return $source;

--- a/src/Mapper/Tree/Exception/CannotCastToScalarValue.php
+++ b/src/Mapper/Tree/Exception/CannotCastToScalarValue.php
@@ -4,26 +4,45 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
-use CuyZ\Valinor\Mapper\Tree\Message\Message;
+use CuyZ\Valinor\Mapper\Tree\Message\TranslatableMessage;
 use CuyZ\Valinor\Type\ScalarType;
+use CuyZ\Valinor\Utility\String\StringFormatter;
+use CuyZ\Valinor\Utility\TypeHelper;
 use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
-final class CannotCastToScalarValue extends RuntimeException implements Message
+final class CannotCastToScalarValue extends RuntimeException implements TranslatableMessage
 {
+    private string $body;
+
+    /** @var array<string, string> */
+    private array $parameters;
+
     /**
      * @param mixed $value
      */
     public function __construct($value, ScalarType $type)
     {
-        if ($value === null || $value === []) {
-            $message = "Cannot be empty and must be filled with a value of type `$type`.";
-        } else {
-            $value = ValueDumper::dump($value);
-            $message = "Cannot cast $value to `$type`.";
-        }
+        $this->parameters = [
+            'value' => ValueDumper::dump($value),
+            'expected_type' => TypeHelper::dump($type),
+        ];
 
-        parent::__construct($message, 1618736242);
+        $this->body = $value === null || $value === []
+            ? 'Cannot be empty and must be filled with a value matching type {expected_type}.'
+            : 'Cannot cast {value} to {expected_type}.';
+
+        parent::__construct(StringFormatter::for($this), 1618736242);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Mapper/Tree/Exception/CannotCastToScalarValue.php
+++ b/src/Mapper/Tree/Exception/CannotCastToScalarValue.php
@@ -6,7 +6,7 @@ namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
 use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use CuyZ\Valinor\Type\ScalarType;
-use CuyZ\Valinor\Utility\Polyfill;
+use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
@@ -17,11 +17,11 @@ final class CannotCastToScalarValue extends RuntimeException implements Message
      */
     public function __construct($value, ScalarType $type)
     {
-        $valueType = Polyfill::get_debug_type($value);
-        $message = "Cannot cast value of type `$valueType` to `$type`.";
-
-        if ($value === null) {
+        if ($value === null || $value === []) {
             $message = "Cannot be empty and must be filled with a value of type `$type`.";
+        } else {
+            $value = ValueDumper::dump($value);
+            $message = "Cannot cast $value to `$type`.";
         }
 
         parent::__construct($message, 1618736242);

--- a/src/Mapper/Tree/Exception/InvalidEnumValue.php
+++ b/src/Mapper/Tree/Exception/InvalidEnumValue.php
@@ -6,14 +6,12 @@ namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
 use BackedEnum;
 use CuyZ\Valinor\Mapper\Tree\Message\Message;
-use CuyZ\Valinor\Utility\Polyfill;
+use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 use UnitEnum;
 
 use function array_map;
 use function implode;
-use function is_bool;
-use function is_scalar;
 
 /** @api */
 final class InvalidEnumValue extends RuntimeException implements Message
@@ -26,21 +24,16 @@ final class InvalidEnumValue extends RuntimeException implements Message
     {
         $values = array_map(
             static function (UnitEnum $case) {
-                return $case instanceof BackedEnum
-                    ? $case->value
-                    : $case->name;
+                return ValueDumper::dump($case instanceof BackedEnum ? $case->value : $case->name);
             },
             $enumName::cases()
         );
 
-        $values = implode('`, `', $values);
-
-        if (! is_scalar($value) || is_bool($value)) {
-            $value = Polyfill::get_debug_type($value);
-        }
+        $values = implode(', ', $values);
+        $value = ValueDumper::dump($value);
 
         parent::__construct(
-            "Invalid value `$value`, it must be one of `$values`.",
+            "Invalid value $value, it must be one of $values.",
             1633093113
         );
     }

--- a/src/Mapper/Tree/Exception/InvalidInterfaceResolverReturnType.php
+++ b/src/Mapper/Tree/Exception/InvalidInterfaceResolverReturnType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
 use CuyZ\Valinor\Utility\Polyfill;
+use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @internal */
@@ -15,10 +16,10 @@ final class InvalidInterfaceResolverReturnType extends RuntimeException
      */
     public function __construct(string $interfaceName, $value)
     {
-        $type = Polyfill::get_debug_type($value);
+        $value = ValueDumper::dump($value);
 
         parent::__construct(
-            "Invalid type `$type`; it must be the name of a class that implements `$interfaceName`.",
+            "Invalid value $value; it must be the name of a class that implements `$interfaceName`.",
             1630091260
         );
     }

--- a/src/Mapper/Tree/Exception/InvalidInterfaceResolverReturnType.php
+++ b/src/Mapper/Tree/Exception/InvalidInterfaceResolverReturnType.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
-use CuyZ\Valinor\Utility\Polyfill;
 use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 

--- a/src/Mapper/Tree/Exception/InvalidNodeValue.php
+++ b/src/Mapper/Tree/Exception/InvalidNodeValue.php
@@ -4,25 +4,45 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
-use CuyZ\Valinor\Mapper\Tree\Message\Message;
+use CuyZ\Valinor\Mapper\Tree\Message\TranslatableMessage;
 use CuyZ\Valinor\Type\Type;
+use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\TypeHelper;
 use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
-final class InvalidNodeValue extends RuntimeException implements Message
+final class InvalidNodeValue extends RuntimeException implements TranslatableMessage
 {
+    private string $body;
+
+    /** @var array<string, string> */
+    private array $parameters;
+
     /**
      * @param mixed $value
      */
     public function __construct($value, Type $type)
     {
-        $value = ValueDumper::dump($value);
-        $message = TypeHelper::containsObject($type)
-            ? "Value $value is not accepted."
-            : "Value $value does not match expected `$type`.";
+        $this->parameters = [
+            'value' => ValueDumper::dump($value),
+            'expected_type' => TypeHelper::dump($type),
+        ];
 
-        parent::__construct($message, 1630678334);
+        $this->body = TypeHelper::containsObject($type)
+            ? 'Invalid value {value}.'
+            : 'Value {value} does not match type {expected_type}.';
+
+        parent::__construct(StringFormatter::for($this), 1630678334);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Mapper/Tree/Exception/InvalidNodeValue.php
+++ b/src/Mapper/Tree/Exception/InvalidNodeValue.php
@@ -6,7 +6,8 @@ namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
 use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use CuyZ\Valinor\Type\Type;
-use CuyZ\Valinor\Utility\Polyfill;
+use CuyZ\Valinor\Utility\TypeHelper;
+use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
@@ -17,13 +18,10 @@ final class InvalidNodeValue extends RuntimeException implements Message
      */
     public function __construct($value, Type $type)
     {
-        $valueType = Polyfill::get_debug_type($value);
-
-        $message = "Value of type `$valueType` is not accepted by type `$type`.";
-
-        if ($value === []) {
-            $message = "Empty array is not accepted by `$type`.";
-        }
+        $value = ValueDumper::dump($value);
+        $message = TypeHelper::containsObject($type)
+            ? "Value $value is not accepted."
+            : "Value $value does not match expected `$type`.";
 
         parent::__construct($message, 1630678334);
     }

--- a/src/Mapper/Tree/Exception/InvalidTraversableKey.php
+++ b/src/Mapper/Tree/Exception/InvalidTraversableKey.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
 use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use CuyZ\Valinor\Type\Types\ArrayKeyType;
+use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
@@ -16,8 +17,10 @@ final class InvalidTraversableKey extends RuntimeException implements Message
      */
     public function __construct($key, ArrayKeyType $type)
     {
+        $key = ValueDumper::dump($key);
+
         parent::__construct(
-            "Invalid key `$key`, it must be of type `$type`.",
+            "Invalid key $key, it must be of type `$type`.",
             1630946163
         );
     }

--- a/src/Mapper/Tree/Exception/InvalidTraversableKey.php
+++ b/src/Mapper/Tree/Exception/InvalidTraversableKey.php
@@ -4,24 +4,41 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
-use CuyZ\Valinor\Mapper\Tree\Message\Message;
+use CuyZ\Valinor\Mapper\Tree\Message\TranslatableMessage;
 use CuyZ\Valinor\Type\Types\ArrayKeyType;
+use CuyZ\Valinor\Utility\String\StringFormatter;
+use CuyZ\Valinor\Utility\TypeHelper;
 use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
-final class InvalidTraversableKey extends RuntimeException implements Message
+final class InvalidTraversableKey extends RuntimeException implements TranslatableMessage
 {
+    private string $body = 'Key {key} does not match type {expected_type}.';
+
+    /** @var array<string, string> */
+    private array $parameters;
+
     /**
      * @param string|int $key
      */
     public function __construct($key, ArrayKeyType $type)
     {
-        $key = ValueDumper::dump($key);
+        $this->parameters = [
+            'key' => ValueDumper::dump($key),
+            'expected_type' => TypeHelper::dump($type),
+        ];
 
-        parent::__construct(
-            "Invalid key $key, it must be of type `$type`.",
-            1630946163
-        );
+        parent::__construct(StringFormatter::for($this), 1630946163);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Mapper/Tree/Exception/ShapedArrayElementMissing.php
+++ b/src/Mapper/Tree/Exception/ShapedArrayElementMissing.php
@@ -4,18 +4,37 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
-use CuyZ\Valinor\Mapper\Tree\Message\Message;
+use CuyZ\Valinor\Mapper\Tree\Message\TranslatableMessage;
 use CuyZ\Valinor\Type\Types\ShapedArrayElement;
+use CuyZ\Valinor\Utility\String\StringFormatter;
+use CuyZ\Valinor\Utility\TypeHelper;
 use RuntimeException;
 
 /** @api */
-final class ShapedArrayElementMissing extends RuntimeException implements Message
+final class ShapedArrayElementMissing extends RuntimeException implements TranslatableMessage
 {
+    private string $body = 'Missing element {element} matching type {expected_type}.';
+
+    /** @var array<string, string> */
+    private array $parameters;
+
     public function __construct(ShapedArrayElement $element)
     {
-        parent::__construct(
-            "Missing element `{$element->key()}` of type `{$element->type()}`.",
-            1631613641
-        );
+        $this->parameters = [
+            'element' => "`{$element->key()}`",
+            'expected_type' => TypeHelper::dump($element->type()),
+        ];
+
+        parent::__construct(StringFormatter::for($this), 1631613641);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Mapper/Tree/Exception/ShapedArrayElementMissing.php
+++ b/src/Mapper/Tree/Exception/ShapedArrayElementMissing.php
@@ -14,7 +14,7 @@ final class ShapedArrayElementMissing extends RuntimeException implements Messag
     public function __construct(ShapedArrayElement $element)
     {
         parent::__construct(
-            "Missing value `{$element->key()}` of type `{$element->type()}`.",
+            "Missing element `{$element->key()}` of type `{$element->type()}`.",
             1631613641
         );
     }

--- a/src/Mapper/Tree/Exception/SourceMustBeIterable.php
+++ b/src/Mapper/Tree/Exception/SourceMustBeIterable.php
@@ -6,7 +6,8 @@ namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
 use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use CuyZ\Valinor\Type\Type;
-use CuyZ\Valinor\Utility\Polyfill;
+use CuyZ\Valinor\Utility\TypeHelper;
+use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
@@ -17,12 +18,15 @@ final class SourceMustBeIterable extends RuntimeException implements Message
      */
     public function __construct($value, Type $type)
     {
-        $valueType = Polyfill::get_debug_type($value);
-
-        $message = "Source must be iterable in order to be cast to `$type`, but is of type `$valueType`.";
-
         if ($value === null) {
-            $message = "Cannot cast an empty value to `$type`.";
+            $message = TypeHelper::containsObject($type)
+                ? 'Cannot be empty.'
+                : "Cannot be empty and must be filled with a value matching `$type`.";
+        } else {
+            $value = ValueDumper::dump($value);
+            $message = TypeHelper::containsObject($type)
+                ? "Value $value is not accepted."
+                : "Value $value does not match expected `$type`.";
         }
 
         parent::__construct($message, 1618739163);

--- a/src/Mapper/Tree/Exception/SourceMustBeIterable.php
+++ b/src/Mapper/Tree/Exception/SourceMustBeIterable.php
@@ -4,31 +4,51 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
-use CuyZ\Valinor\Mapper\Tree\Message\Message;
+use CuyZ\Valinor\Mapper\Tree\Message\TranslatableMessage;
 use CuyZ\Valinor\Type\Type;
+use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\TypeHelper;
 use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
-final class SourceMustBeIterable extends RuntimeException implements Message
+final class SourceMustBeIterable extends RuntimeException implements TranslatableMessage
 {
+    private string $body;
+
+    /** @var array<string, string> */
+    private array $parameters;
+
     /**
      * @param mixed $value
      */
     public function __construct($value, Type $type)
     {
+        $this->parameters = [
+            'value' => ValueDumper::dump($value),
+            'expected_type' => TypeHelper::dump($type),
+        ];
+
         if ($value === null) {
-            $message = TypeHelper::containsObject($type)
+            $this->body = TypeHelper::containsObject($type)
                 ? 'Cannot be empty.'
-                : "Cannot be empty and must be filled with a value matching `$type`.";
+                : 'Cannot be empty and must be filled with a value matching type {expected_type}.';
         } else {
-            $value = ValueDumper::dump($value);
-            $message = TypeHelper::containsObject($type)
-                ? "Value $value is not accepted."
-                : "Value $value does not match expected `$type`.";
+            $this->body = TypeHelper::containsObject($type)
+                ? 'Invalid value {value}.'
+                : 'Value {value} does not match type {expected_type}.';
         }
 
-        parent::__construct($message, 1618739163);
+        parent::__construct(StringFormatter::for($this), 1618739163);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Mapper/Tree/Message/DefaultMessage.php
+++ b/src/Mapper/Tree/Message/DefaultMessage.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Tree\Message;
+
+/** @api */
+interface DefaultMessage
+{
+    public const TRANSLATIONS = [
+        'Value {value} does not match expected {expected_value}.' => [
+            'en' => 'Value {value} does not match expected {expected_value}.',
+        ],
+        'Value {value} does not match any of {allowed_values}.' => [
+            'en' => 'Value {value} does not match any of {allowed_values}.',
+        ],
+        'Value {value} does not match any of {allowed_types}.' => [
+            'en' => 'Value {value} does not match any of {allowed_types}.',
+        ],
+        'Value {value} does not match type {expected_type}.' => [
+            'en' => 'Value {value} does not match type {expected_type}.',
+        ],
+        'Value {value} does not match float value {expected_value}.' => [
+            'en' => 'Value {value} does not match float value {expected_value}.',
+        ],
+        'Value {value} does not match integer value {expected_value}.' => [
+            'en' => 'Value {value} does not match integer value {expected_value}.',
+        ],
+        'Value {value} does not match string value {expected_value}.' => [
+            'en' => 'Value {value} does not match string value {expected_value}.',
+        ],
+        'Invalid value {value}.' => [
+            'en' => 'Invalid value {value}.',
+        ],
+        'Invalid value {value}: it must be an array.' => [
+            'en' => 'Invalid value {value}: it must be an array.',
+        ],
+        'Invalid value {value}: it must be an integer between {min} and {max}.' => [
+            'en' => 'Invalid value {value}: it must be an integer between {min} and {max}.',
+        ],
+        'Invalid value {value}: it must be a negative integer.' => [
+            'en' => 'Invalid value {value}: it must be a negative integer.',
+        ],
+        'Invalid value {value}: it must be a positive integer.' => [
+            'en' => 'Invalid value {value}: it must be a positive integer.',
+        ],
+        'Cannot cast {value} to {expected_type}.' => [
+            'en' => 'Cannot cast {value} to {expected_type}.',
+        ],
+        'Cannot be empty.' => [
+            'en' => 'Cannot be empty.',
+        ],
+        'Cannot be empty and must be filled with a valid string value.' => [
+            'en' => 'Cannot be empty and must be filled with a valid string value.',
+        ],
+        'Cannot be empty and must be filled with a value matching type {expected_type}.' => [
+            'en' => 'Cannot be empty and must be filled with a value matching type {expected_type}.',
+        ],
+        'Key {key} does not match type {expected_type}.' => [
+            'en' => 'Key {key} does not match type {expected_type}.',
+        ],
+        'Missing element {element} matching type {expected_type}.' => [
+            'en' => 'Missing element {element} matching type {expected_type}.',
+        ],
+        'Value {value} does not match a valid date format.' => [
+            'en' => 'Value {value} does not match a valid date format.',
+        ],
+        'Invalid class string {value}, it must be one of {expected_class_strings}.' => [
+            'en' => 'Invalid class string {value}, it must be one of {expected_class_strings}.',
+        ],
+        'Invalid class string {value}, it must be a subtype of {expected_class_strings}.' => [
+            'en' => 'Invalid class string {value}, it must be a subtype of {expected_class_strings}.',
+        ],
+        'Invalid class string {value}.' => [
+            'en' => 'Invalid class string {value}.',
+        ],
+    ];
+}

--- a/src/Mapper/Tree/Message/Formatter/AggregateMessageFormatter.php
+++ b/src/Mapper/Tree/Message/Formatter/AggregateMessageFormatter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Tree\Message\Formatter;
+
+use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
+
+/** @api */
+final class AggregateMessageFormatter implements MessageFormatter
+{
+    /** @var MessageFormatter[] */
+    private array $formatters;
+
+    public function __construct(MessageFormatter ...$formatters)
+    {
+        $this->formatters = $formatters;
+    }
+
+    public function format(NodeMessage $message): NodeMessage
+    {
+        foreach ($this->formatters as $formatter) {
+            $message = $formatter->format($message);
+        }
+
+        return $message;
+    }
+}

--- a/src/Mapper/Tree/Message/Formatter/LocaleMessageFormatter.php
+++ b/src/Mapper/Tree/Message/Formatter/LocaleMessageFormatter.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Tree\Message\Formatter;
+
+use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
+
+/** @api */
+final class LocaleMessageFormatter implements MessageFormatter
+{
+    private string $locale;
+
+    public function __construct(string $locale)
+    {
+        $this->locale = $locale;
+    }
+
+    public function format(NodeMessage $message): NodeMessage
+    {
+        return $message->withLocale($this->locale);
+    }
+}

--- a/src/Mapper/Tree/Message/Formatter/MessageFormatter.php
+++ b/src/Mapper/Tree/Message/Formatter/MessageFormatter.php
@@ -9,5 +9,5 @@ use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
 /** @api */
 interface MessageFormatter
 {
-    public function format(NodeMessage $message): string;
+    public function format(NodeMessage $message): NodeMessage;
 }

--- a/src/Mapper/Tree/Message/Formatter/MessageMapFormatter.php
+++ b/src/Mapper/Tree/Message/Formatter/MessageMapFormatter.php
@@ -14,7 +14,7 @@ use function is_callable;
  *
  * The constructor parameter is an array where each key represents either:
  * - The code of the message to be replaced
- * - The content of the message to be replaced
+ * - The body of the message to be replaced
  * - The class name of the message to be replaced
  *
  * If none of those is found, the content of the message will stay unchanged
@@ -23,38 +23,29 @@ use function is_callable;
  * If one of these keys is found, the array entry will be used to replace the
  * content of the message. This entry can be either a plain text or a callable
  * that takes the message as a parameter and returns a string; it is for
- * instance advised to use a callable in cases where a translation service is
- * used — to avoid useless greedy operations.
- *
- * In any case, the content can contain placeholders that can be used the same
- * way as @see \CuyZ\Valinor\Mapper\Tree\Message\NodeMessage::format()
+ * instance advised to use a callable in cases where a custom translation
+ * service is used — to avoid useless greedy operations.
  *
  * See usage examples below:
  *
  * ```php
  * $formatter = (new MessageMapFormatter([
  *     // Will match if the given message has this exact code
- *     'some_code' => 'new content / previous code was: %1$s',
+ *     'some_code' => 'New content / code: {message_code}',
  *
  *     // Will match if the given message has this exact content
- *     'Some message content' => 'new content / previous message: %2$s',
+ *     'Some message content' => 'New content / previous: {original_message}',
  *
  *     // Will match if the given message is an instance of `SomeError`
- *     SomeError::class => '
- *         - Original code of the message: %1$s
- *         - Original content of the message: %2$s
- *         - Node type: %3$s
- *         - Node name: %4$s
- *         - Node path: %5$s
- *     ',
+ *     SomeError::class => 'New content / value: {original_value}',
  *
  *     // A callback can be used to get access to the message instance
  *     OtherError::class => function (NodeMessage $message): string {
- *         if ((string)$message->type() === 'string|int') {
- *             // …
+ *         if ($message->path() === 'foo.bar') {
+ *             return 'Some custom message';
  *         }
  *
- *         return 'Some message content';
+ *         return $message->body();
  *     },
  *
  *     // For greedy operation, it is advised to use a lazy-callback
@@ -85,12 +76,15 @@ final class MessageMapFormatter implements MessageFormatter
         $this->map = $map;
     }
 
-    public function format(NodeMessage $message): string
+    public function format(NodeMessage $message): NodeMessage
     {
         $target = $this->target($message);
-        $text = is_callable($target) ? $target($message) : $target;
 
-        return $message->format($text);
+        if ($target) {
+            return $message->withBody(is_callable($target) ? $target($message) : $target);
+        }
+
+        return $message;
     }
 
     /**
@@ -105,14 +99,14 @@ final class MessageMapFormatter implements MessageFormatter
     }
 
     /**
-     * @return string|callable(NodeMessage): string
+     * @return false|string|callable(NodeMessage): string
      */
     private function target(NodeMessage $message)
     {
         return $this->map[$message->code()]
-            ?? $this->map[(string)$message]
+            ?? $this->map[$message->body()]
             ?? $this->map[get_class($message->originalMessage())]
             ?? $this->default
-            ?? (string)$message;
+            ?? false;
     }
 }

--- a/src/Mapper/Tree/Message/Formatter/PlaceHolderMessageFormatter.php
+++ b/src/Mapper/Tree/Message/Formatter/PlaceHolderMessageFormatter.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Tree\Message\Formatter;
+
+use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
+use CuyZ\Valinor\Utility\TypeHelper;
+use Throwable;
+
+/**
+ * @api
+ *
+ * @deprecated This class is here to replace the old implementation of the
+ * `NodeMessage::format` method; It should not be used anymore
+ *
+ * ---
+ *
+ * Performs a placeholders replace operation on the message body.
+ *
+ * The values to be replaced will be the ones given in the constructor; if none
+ * is given these values will be used instead, in order:
+ *
+ * 1. The original code of this message
+ * 2. The original content of this message
+ * 3. A string representation of the node type
+ * 4. The name of the node
+ * 5. The path of the node
+ */
+final class PlaceHolderMessageFormatter implements MessageFormatter
+{
+    /** @var string[] */
+    private array $values;
+
+    public function __construct(string ...$values)
+    {
+        $this->values = $values;
+    }
+
+    public function format(NodeMessage $message): NodeMessage
+    {
+        $originalMessage = $message->originalMessage();
+
+        $body = sprintf($message->body(), ...$this->values ?: [
+            $message->code(),
+            $originalMessage instanceof Throwable ? $originalMessage->getMessage() : $originalMessage->__toString(),
+            TypeHelper::dump($message->type()),
+            $message->name(),
+            $message->path(),
+        ]);
+
+        return $message->withBody($body);
+    }
+}

--- a/src/Mapper/Tree/Message/Formatter/TranslationMessageFormatter.php
+++ b/src/Mapper/Tree/Message/Formatter/TranslationMessageFormatter.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Tree\Message\Formatter;
+
+use CuyZ\Valinor\Mapper\Tree\Message\DefaultMessage;
+use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
+
+/** @api */
+final class TranslationMessageFormatter implements MessageFormatter
+{
+    /** @var array<string, array<string, string>> */
+    private array $translations = [];
+
+    /**
+     * Returns an instance of the class with the default translations provided
+     * by the library.
+     */
+    public static function default(): self
+    {
+        $instance = new self();
+        $instance->translations = DefaultMessage::TRANSLATIONS;
+
+        return $instance;
+    }
+
+    /**
+     * Creates or overrides a single translation.
+     *
+     * ```php
+     * (TranslationMessageFormatter::default())->withTranslation(
+     *     'fr',
+     *     'Invalid value {value}.',
+     *     'Valeur invalide {value}.',
+     * );
+     * ```
+     */
+    public function withTranslation(string $locale, string $original, string $translation): self
+    {
+        $clone = clone $this;
+        $clone->translations[$original][$locale] = $translation;
+
+        return $clone;
+    }
+
+    /**
+     * Creates or overrides a list of translations.
+     *
+     * The given array consists of messages to be translated and for each one a
+     * list of locales with their associated translations.
+     *
+     * ```php
+     * (TranslationMessageFormatter::default())->withTranslations([
+     *     'Invalid value {value}.' => [
+     *         'fr' => 'Valeur invalide {value}.',
+     *         'es' => 'Valor inválido {value}.',
+     *     ],
+     *     'Some custom message' => [
+     *         // …
+     *     ],
+     * ]);
+     * ```
+     *
+     * @param array<string, array<string, string>> $translations
+     */
+    public function withTranslations(array $translations): self
+    {
+        $clone = clone $this;
+        $clone->translations = array_replace_recursive($this->translations, $translations);
+
+        return $clone;
+    }
+
+    public function format(NodeMessage $message): NodeMessage
+    {
+        $body = $this->translations[$message->body()][$message->locale()] ?? null;
+
+        if ($body) {
+            return $message->withBody($body);
+        }
+
+        return $message;
+    }
+}

--- a/src/Mapper/Tree/Message/TranslatableMessage.php
+++ b/src/Mapper/Tree/Message/TranslatableMessage.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Tree\Message;
+
+/** @api */
+interface TranslatableMessage extends Message
+{
+    public function body(): string;
+
+    /**
+     * @return array<string, string>
+     */
+    public function parameters(): array;
+}

--- a/src/Mapper/Tree/Node.php
+++ b/src/Mapper/Tree/Node.php
@@ -139,10 +139,10 @@ final class Node
 
     public function withMessage(Message $message): self
     {
-        $message = new NodeMessage($this, $message);
+        $message = new NodeMessage($this->shell, $message);
 
         $clone = clone $this;
-        $clone->messages = [...$this->messages, $message];
+        $clone->messages[] = $message;
         $clone->valid = $clone->valid && ! $message->isError();
 
         return $clone;

--- a/src/Type/Resolver/Exception/CannotResolveTypeFromUnion.php
+++ b/src/Type/Resolver/Exception/CannotResolveTypeFromUnion.php
@@ -6,8 +6,11 @@ namespace CuyZ\Valinor\Type\Resolver\Exception;
 
 use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use CuyZ\Valinor\Type\Types\UnionType;
-use CuyZ\Valinor\Utility\Polyfill;
+use CuyZ\Valinor\Utility\TypeHelper;
+use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
+
+use function implode;
 
 /** @api */
 final class CannotResolveTypeFromUnion extends RuntimeException implements Message
@@ -17,11 +20,11 @@ final class CannotResolveTypeFromUnion extends RuntimeException implements Messa
      */
     public function __construct(UnionType $unionType, $value)
     {
-        $type = Polyfill::get_debug_type($value);
+        $value = ValueDumper::dump($value);
+        $message = TypeHelper::containsObject($unionType)
+            ? "Value $value is not accepted."
+            : "Value $value does not match any of `" . implode('`, `', $unionType->types()) . "`.";
 
-        parent::__construct(
-            "Impossible to resolve the type from the union `$unionType` with a value of type `$type`.",
-            1607027306
-        );
+        parent::__construct($message, 1607027306);
     }
 }

--- a/src/Type/Resolver/Exception/UnionTypeDoesNotAllowNull.php
+++ b/src/Type/Resolver/Exception/UnionTypeDoesNotAllowNull.php
@@ -4,20 +4,40 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Resolver\Exception;
 
-use CuyZ\Valinor\Mapper\Tree\Message\Message;
+use CuyZ\Valinor\Mapper\Tree\Message\TranslatableMessage;
 use CuyZ\Valinor\Type\Types\UnionType;
+use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\TypeHelper;
 use RuntimeException;
 
 /** @api */
-final class UnionTypeDoesNotAllowNull extends RuntimeException implements Message
+final class UnionTypeDoesNotAllowNull extends RuntimeException implements TranslatableMessage
 {
+    private string $body;
+
+    /** @var array<string, string> */
+    private array $parameters;
+
     public function __construct(UnionType $unionType)
     {
-        $message = TypeHelper::containsObject($unionType)
-            ? 'Cannot be empty.'
-            : "Cannot be empty and must be filled with a value matching `$unionType`.";
+        $this->parameters = [
+            'expected_type' => TypeHelper::dump($unionType),
+        ];
 
-        parent::__construct($message, 1618742357);
+        $this->body = TypeHelper::containsObject($unionType)
+            ? 'Cannot be empty.'
+            : 'Cannot be empty and must be filled with a value matching type {expected_type}.';
+
+        parent::__construct(StringFormatter::for($this), 1618742357);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Type/Resolver/Exception/UnionTypeDoesNotAllowNull.php
+++ b/src/Type/Resolver/Exception/UnionTypeDoesNotAllowNull.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Resolver\Exception;
 
 use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use CuyZ\Valinor\Type\Types\UnionType;
+use CuyZ\Valinor\Utility\TypeHelper;
 use RuntimeException;
 
 /** @api */
@@ -13,9 +14,10 @@ final class UnionTypeDoesNotAllowNull extends RuntimeException implements Messag
 {
     public function __construct(UnionType $unionType)
     {
-        parent::__construct(
-            "Cannot assign an empty value to union type `$unionType`.",
-            1618742357
-        );
+        $message = TypeHelper::containsObject($unionType)
+            ? 'Cannot be empty.'
+            : "Cannot be empty and must be filled with a value matching `$unionType`.";
+
+        parent::__construct($message, 1618742357);
     }
 }

--- a/src/Type/Types/Exception/CannotCastValue.php
+++ b/src/Type/Types/Exception/CannotCastValue.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Type\Types\Exception;
 
 use CuyZ\Valinor\Type\ScalarType;
-use CuyZ\Valinor\Utility\Polyfill;
+use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
@@ -16,10 +16,10 @@ final class CannotCastValue extends RuntimeException implements CastError
      */
     public function __construct($value, ScalarType $type)
     {
-        $baseType = Polyfill::get_debug_type($value);
+        $value = ValueDumper::dump($value);
 
         parent::__construct(
-            "Cannot cast from `$baseType` to `$type`.",
+            "Cannot cast $value to `$type`.",
             1603216198
         );
     }

--- a/src/Type/Types/Exception/CannotCastValue.php
+++ b/src/Type/Types/Exception/CannotCastValue.php
@@ -5,22 +5,39 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Type\Types\Exception;
 
 use CuyZ\Valinor\Type\ScalarType;
+use CuyZ\Valinor\Utility\String\StringFormatter;
+use CuyZ\Valinor\Utility\TypeHelper;
 use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
 final class CannotCastValue extends RuntimeException implements CastError
 {
+    private string $body = 'Cannot cast {value} to {expected_type}.';
+
+    /** @var array<string, string> */
+    private array $parameters;
+
     /**
      * @param mixed $value
      */
     public function __construct($value, ScalarType $type)
     {
-        $value = ValueDumper::dump($value);
+        $this->parameters = [
+            'value' => ValueDumper::dump($value),
+            'expected_type' => TypeHelper::dump($type),
+        ];
 
-        parent::__construct(
-            "Cannot cast $value to `$type`.",
-            1603216198
-        );
+        parent::__construct(StringFormatter::for($this), 1603216198);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Type/Types/Exception/CastError.php
+++ b/src/Type/Types/Exception/CastError.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Types\Exception;
 
-use CuyZ\Valinor\Mapper\Tree\Message\Message;
+use CuyZ\Valinor\Mapper\Tree\Message\TranslatableMessage;
 use Throwable;
 
 /** @internal */
-interface CastError extends Throwable, Message
+interface CastError extends Throwable, TranslatableMessage
 {
 }

--- a/src/Type/Types/Exception/InvalidClassString.php
+++ b/src/Type/Types/Exception/InvalidClassString.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Type\Types\Exception;
 use CuyZ\Valinor\Type\ObjectType;
 use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\UnionType;
+use CuyZ\Valinor\Utility\String\StringFormatter;
 use LogicException;
 
 use function count;
@@ -15,27 +16,51 @@ use function implode;
 /** @api */
 final class InvalidClassString extends LogicException implements CastError
 {
+    private string $body;
+
+    /** @var array<string, string> */
+    private array $parameters;
+
     /**
      * @param ObjectType|UnionType|null $type
      */
     public function __construct(string $raw, ?Type $type)
     {
-        $types = [];
-
         if ($type instanceof ObjectType) {
-            $types = [$type];
+            $expected = [$type];
         } elseif ($type instanceof UnionType) {
-            $types = $type->types();
+            $expected = $type->types();
+        } else {
+            $expected = [];
         }
 
-        $message = "Invalid class string `$raw`.";
+        $expectedString = count($expected) !== 0
+            ? '`' . implode('`, `', $expected) . '`'
+            : '';
 
-        if (count($types) > 1) {
-            $message = "Invalid class string `$raw`, it must be one of `" . implode('`, `', $types) . "`.";
-        } elseif (count($types) === 1) {
-            $message = "Invalid class string `$raw`, it must be a subtype of `$type`.";
+        $this->parameters = [
+            'value' => "`$raw`",
+            'expected_class_strings' => $expectedString,
+        ];
+
+        if (count($expected) > 1) {
+            $this->body = 'Invalid class string {value}, it must be one of {expected_class_strings}.';
+        } elseif (count($expected) === 1) {
+            $this->body = 'Invalid class string {value}, it must be a subtype of {expected_class_strings}.';
+        } else {
+            $this->body = 'Invalid class string {value}.';
         }
 
-        parent::__construct($message, 1608132562);
+        parent::__construct(StringFormatter::for($this), 1608132562);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Type/Types/Exception/InvalidEmptyStringValue.php
+++ b/src/Type/Types/Exception/InvalidEmptyStringValue.php
@@ -4,16 +4,26 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Types\Exception;
 
+use CuyZ\Valinor\Utility\String\StringFormatter;
 use RuntimeException;
 
 /** @api */
 final class InvalidEmptyStringValue extends RuntimeException implements CastError
 {
+    private string $body = 'Cannot be empty and must be filled with a valid string value.';
+
     public function __construct()
     {
-        parent::__construct(
-            "Cannot be empty and must be filled with a valid string value.",
-            1632925312
-        );
+        parent::__construct(StringFormatter::for($this), 1632925312);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return [];
     }
 }

--- a/src/Type/Types/Exception/InvalidFloatValue.php
+++ b/src/Type/Types/Exception/InvalidFloatValue.php
@@ -4,16 +4,34 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Types\Exception;
 
+use CuyZ\Valinor\Utility\String\StringFormatter;
 use RuntimeException;
 
 /** @api */
 final class InvalidFloatValue extends RuntimeException implements CastError
 {
+    private string $body = 'Value {value} does not match expected {expected_value}.';
+
+    /** @var array<string, string> */
+    private array $parameters;
+
     public function __construct(float $value, float $expected)
     {
-        parent::__construct(
-            "Value $value does not match expected $expected.",
-            1652110115
-        );
+        $this->parameters = [
+            'value' => (string)$value,
+            'expected_value' => (string)$expected,
+        ];
+
+        parent::__construct(StringFormatter::for($this), 1652110115);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Type/Types/Exception/InvalidFloatValue.php
+++ b/src/Type/Types/Exception/InvalidFloatValue.php
@@ -12,7 +12,7 @@ final class InvalidFloatValue extends RuntimeException implements CastError
     public function __construct(float $value, float $expected)
     {
         parent::__construct(
-            "Value `$value` does not match expected value `$expected`.",
+            "Value $value does not match expected $expected.",
             1652110115
         );
     }

--- a/src/Type/Types/Exception/InvalidFloatValueType.php
+++ b/src/Type/Types/Exception/InvalidFloatValueType.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Types\Exception;
 
-use CuyZ\Valinor\Utility\Polyfill;
+use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
@@ -15,10 +15,10 @@ final class InvalidFloatValueType extends RuntimeException implements CastError
      */
     public function __construct($value, float $floatValue)
     {
-        $baseType = Polyfill::get_debug_type($value);
+        $value = ValueDumper::dump($value);
 
         parent::__construct(
-            "Value of type `$baseType` does not match float value `$floatValue`.",
+            "Value $value does not match float value $floatValue.",
             1652110003
         );
     }

--- a/src/Type/Types/Exception/InvalidFloatValueType.php
+++ b/src/Type/Types/Exception/InvalidFloatValueType.php
@@ -4,22 +4,38 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Types\Exception;
 
+use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
 final class InvalidFloatValueType extends RuntimeException implements CastError
 {
+    private string $body = 'Value {value} does not match float value {expected_value}.';
+
+    /** @var array<string, string> */
+    private array $parameters;
+
     /**
      * @param mixed $value
      */
-    public function __construct($value, float $floatValue)
+    public function __construct($value, float $expected)
     {
-        $value = ValueDumper::dump($value);
+        $this->parameters = [
+            'value' => ValueDumper::dump($value),
+            'expected_value' => (string)$expected,
+        ];
 
-        parent::__construct(
-            "Value $value does not match float value $floatValue.",
-            1652110003
-        );
+        parent::__construct(StringFormatter::for($this), 1652110003);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Type/Types/Exception/InvalidIntegerRangeValue.php
+++ b/src/Type/Types/Exception/InvalidIntegerRangeValue.php
@@ -5,16 +5,35 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Type\Types\Exception;
 
 use CuyZ\Valinor\Type\Types\IntegerRangeType;
+use CuyZ\Valinor\Utility\String\StringFormatter;
 use RuntimeException;
 
 /** @api */
 final class InvalidIntegerRangeValue extends RuntimeException implements CastError
 {
+    private string $body = 'Invalid value {value}: it must be an integer between {min} and {max}.';
+
+    /** @var array<string, string> */
+    private array $parameters;
+
     public function __construct(int $value, IntegerRangeType $type)
     {
-        parent::__construct(
-            "Invalid value $value: it must be an integer between {$type->min()} and {$type->max()}.",
-            1638785150
-        );
+        $this->parameters = [
+            'value' => (string)$value,
+            'min' => (string)$type->min(),
+            'max' => (string)$type->max(),
+        ];
+
+        parent::__construct(StringFormatter::for($this), 1638785150);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Type/Types/Exception/InvalidIntegerRangeValue.php
+++ b/src/Type/Types/Exception/InvalidIntegerRangeValue.php
@@ -13,7 +13,7 @@ final class InvalidIntegerRangeValue extends RuntimeException implements CastErr
     public function __construct(int $value, IntegerRangeType $type)
     {
         parent::__construct(
-            "Invalid value `$value`: it must be an integer between {$type->min()} and {$type->max()}.",
+            "Invalid value $value: it must be an integer between {$type->min()} and {$type->max()}.",
             1638785150
         );
     }

--- a/src/Type/Types/Exception/InvalidIntegerValue.php
+++ b/src/Type/Types/Exception/InvalidIntegerValue.php
@@ -4,16 +4,15 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Types\Exception;
 
-use CuyZ\Valinor\Type\IntegerType;
 use RuntimeException;
 
 /** @api */
 final class InvalidIntegerValue extends RuntimeException implements CastError
 {
-    public function __construct(int $value, IntegerType $type)
+    public function __construct(int $value, int $expected)
     {
         parent::__construct(
-            "Value `$value` does not match integer value `$type`.",
+            "Value $value does not match expected $expected.",
             1631090798
         );
     }

--- a/src/Type/Types/Exception/InvalidIntegerValue.php
+++ b/src/Type/Types/Exception/InvalidIntegerValue.php
@@ -4,16 +4,34 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Types\Exception;
 
+use CuyZ\Valinor\Utility\String\StringFormatter;
 use RuntimeException;
 
 /** @api */
 final class InvalidIntegerValue extends RuntimeException implements CastError
 {
+    private string $body = 'Value {value} does not match expected {expected_value}.';
+
+    /** @var array<string, string> */
+    private array $parameters;
+
     public function __construct(int $value, int $expected)
     {
-        parent::__construct(
-            "Value $value does not match expected $expected.",
-            1631090798
-        );
+        $this->parameters = [
+            'value' => (string)$value,
+            'expected_value' => (string)$expected,
+        ];
+
+        parent::__construct(StringFormatter::for($this), 1631090798);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Type/Types/Exception/InvalidIntegerValueType.php
+++ b/src/Type/Types/Exception/InvalidIntegerValueType.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Types\Exception;
 
-use CuyZ\Valinor\Utility\Polyfill;
+use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
@@ -15,10 +15,10 @@ final class InvalidIntegerValueType extends RuntimeException implements CastErro
      */
     public function __construct($value, int $integerValue)
     {
-        $baseType = Polyfill::get_debug_type($value);
+        $value = ValueDumper::dump($value);
 
         parent::__construct(
-            "Value of type `$baseType` does not match integer value `$integerValue`.",
+            "Value $value does not match integer value $integerValue.",
             1631267159
         );
     }

--- a/src/Type/Types/Exception/InvalidIntegerValueType.php
+++ b/src/Type/Types/Exception/InvalidIntegerValueType.php
@@ -4,22 +4,38 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Types\Exception;
 
+use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
 final class InvalidIntegerValueType extends RuntimeException implements CastError
 {
+    private string $body = 'Value {value} does not match integer value {expected_value}.';
+
+    /** @var array<string, string> */
+    private array $parameters;
+
     /**
      * @param mixed $value
      */
-    public function __construct($value, int $integerValue)
+    public function __construct($value, int $expected)
     {
-        $value = ValueDumper::dump($value);
+        $this->parameters = [
+            'value' => ValueDumper::dump($value),
+            'expected_value' => (string)$expected,
+        ];
 
-        parent::__construct(
-            "Value $value does not match integer value $integerValue.",
-            1631267159
-        );
+        parent::__construct(StringFormatter::for($this), 1631267159);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Type/Types/Exception/InvalidNegativeIntegerValue.php
+++ b/src/Type/Types/Exception/InvalidNegativeIntegerValue.php
@@ -12,7 +12,7 @@ final class InvalidNegativeIntegerValue extends RuntimeException implements Cast
     public function __construct(int $value)
     {
         parent::__construct(
-            "Invalid value `$value`: it must be a negative integer.",
+            "Invalid value $value: it must be a negative integer.",
             1632923705
         );
     }

--- a/src/Type/Types/Exception/InvalidNegativeIntegerValue.php
+++ b/src/Type/Types/Exception/InvalidNegativeIntegerValue.php
@@ -4,16 +4,33 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Types\Exception;
 
+use CuyZ\Valinor\Utility\String\StringFormatter;
 use RuntimeException;
 
 /** @api */
 final class InvalidNegativeIntegerValue extends RuntimeException implements CastError
 {
+    private string $body = 'Invalid value {value}: it must be a negative integer.';
+
+    /** @var array<string, string> */
+    private array $parameters;
+
     public function __construct(int $value)
     {
-        parent::__construct(
-            "Invalid value $value: it must be a negative integer.",
-            1632923705
-        );
+        $this->parameters = [
+            'value' => (string)$value,
+        ];
+
+        parent::__construct(StringFormatter::for($this), 1632923705);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Type/Types/Exception/InvalidPositiveIntegerValue.php
+++ b/src/Type/Types/Exception/InvalidPositiveIntegerValue.php
@@ -12,7 +12,7 @@ final class InvalidPositiveIntegerValue extends RuntimeException implements Cast
     public function __construct(int $value)
     {
         parent::__construct(
-            "Invalid value `$value`: it must be a positive integer.",
+            "Invalid value $value: it must be a positive integer.",
             1632923676
         );
     }

--- a/src/Type/Types/Exception/InvalidPositiveIntegerValue.php
+++ b/src/Type/Types/Exception/InvalidPositiveIntegerValue.php
@@ -4,16 +4,33 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Types\Exception;
 
+use CuyZ\Valinor\Utility\String\StringFormatter;
 use RuntimeException;
 
 /** @api */
 final class InvalidPositiveIntegerValue extends RuntimeException implements CastError
 {
+    private string $body = 'Invalid value {value}: it must be a positive integer.';
+
+    /** @var array<string, string> */
+    private array $parameters;
+
     public function __construct(int $value)
     {
-        parent::__construct(
-            "Invalid value $value: it must be a positive integer.",
-            1632923676
-        );
+        $this->parameters = [
+            'value' => (string)$value,
+        ];
+
+        parent::__construct(StringFormatter::for($this), 1632923676);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Type/Types/Exception/InvalidStringValue.php
+++ b/src/Type/Types/Exception/InvalidStringValue.php
@@ -4,15 +4,19 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Types\Exception;
 
+use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
 final class InvalidStringValue extends RuntimeException implements CastError
 {
-    public function __construct(string $value, string $other)
+    public function __construct(string $value, string $expected)
     {
+        $value = ValueDumper::dump($value);
+        $expected = ValueDumper::dump($expected);
+
         parent::__construct(
-            "Values `$value` and `$other` do not match.",
+            "Value $value does not match expected $expected.",
             1631263740
         );
     }

--- a/src/Type/Types/Exception/InvalidStringValue.php
+++ b/src/Type/Types/Exception/InvalidStringValue.php
@@ -4,20 +4,35 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Types\Exception;
 
+use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
 final class InvalidStringValue extends RuntimeException implements CastError
 {
+    private string $body = 'Value {value} does not match expected {expected_value}.';
+
+    /** @var array<string, string> */
+    private array $parameters;
+
     public function __construct(string $value, string $expected)
     {
-        $value = ValueDumper::dump($value);
-        $expected = ValueDumper::dump($expected);
+        $this->parameters = [
+            'value' => ValueDumper::dump($value),
+            'expected_value' => ValueDumper::dump($expected),
+        ];
 
-        parent::__construct(
-            "Value $value does not match expected $expected.",
-            1631263740
-        );
+        parent::__construct(StringFormatter::for($this), 1631263740);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Type/Types/Exception/InvalidStringValueType.php
+++ b/src/Type/Types/Exception/InvalidStringValueType.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Types\Exception;
 
-use CuyZ\Valinor\Utility\Polyfill;
+use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
@@ -15,10 +15,11 @@ final class InvalidStringValueType extends RuntimeException implements CastError
      */
     public function __construct($value, string $stringValue)
     {
-        $baseType = Polyfill::get_debug_type($value);
+        $value = ValueDumper::dump($value);
+        $stringValue = ValueDumper::dump($stringValue);
 
         parent::__construct(
-            "Value of type `$baseType` does not match string value `$stringValue`.",
+            "Value $value does not match string value $stringValue.",
             1631263954
         );
     }

--- a/src/Type/Types/Exception/InvalidStringValueType.php
+++ b/src/Type/Types/Exception/InvalidStringValueType.php
@@ -4,23 +4,38 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Types\Exception;
 
+use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
 final class InvalidStringValueType extends RuntimeException implements CastError
 {
+    private string $body = 'Value {value} does not match string value {expected_value}.';
+
+    /** @var array<string, string> */
+    private array $parameters;
+
     /**
      * @param mixed $value
      */
-    public function __construct($value, string $stringValue)
+    public function __construct($value, string $expected)
     {
-        $value = ValueDumper::dump($value);
-        $stringValue = ValueDumper::dump($stringValue);
+        $this->parameters = [
+            'value' => ValueDumper::dump($value),
+            'expected_value' => ValueDumper::dump($expected),
+        ];
 
-        parent::__construct(
-            "Value $value does not match string value $stringValue.",
-            1631263954
-        );
+        parent::__construct(StringFormatter::for($this), 1631263954);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
     }
 }

--- a/src/Type/Types/IntegerValueType.php
+++ b/src/Type/Types/IntegerValueType.php
@@ -72,7 +72,7 @@ final class IntegerValueType implements IntegerType, FixedType
         $value = (int)$value; // @phpstan-ignore-line
 
         if (! $this->accepts($value)) {
-            throw new InvalidIntegerValue($value, $this);
+            throw new InvalidIntegerValue($value, $this->value);
         }
 
         return $value;

--- a/src/Utility/Polyfill.php
+++ b/src/Utility/Polyfill.php
@@ -4,18 +4,6 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Utility;
 
-use __PHP_Incomplete_Class;
-
-use function class_implements;
-use function get_class;
-use function get_parent_class;
-use function is_array;
-use function is_bool;
-use function is_float;
-use function is_int;
-use function is_object;
-use function is_string;
-use function key;
 use function strlen;
 use function strncmp;
 use function strpos;
@@ -61,52 +49,5 @@ final class Polyfill
         $needleLength = strlen($needle);
 
         return $needleLength <= strlen($haystack) && 0 === substr_compare($haystack, $needle, -$needleLength);
-    }
-
-    /**
-     * @PHP8.0 use native function
-     *
-     * @param mixed $value
-     */
-    public static function get_debug_type($value): string
-    {
-        switch (true) {
-            case null === $value:
-                return 'null';
-            case is_bool($value):
-                return 'bool';
-            case is_string($value):
-                return 'string';
-            case is_array($value):
-                return 'array';
-            case is_int($value):
-                return 'int';
-            case is_float($value):
-                return 'float';
-            case is_object($value):
-                break;
-            case $value instanceof __PHP_Incomplete_Class: // @phpstan-ignore-line
-                return '__PHP_Incomplete_Class';
-            default:
-                // @phpstan-ignore-next-line
-                if (null === $type = @get_resource_type($value)) {
-                    return 'unknown';
-                }
-
-                if ('Unknown' === $type) {
-                    $type = 'closed';
-                }
-
-                return "resource ($type)";
-        }
-
-        $class = get_class($value);
-
-        if (false === strpos($class, '@')) {
-            return $class;
-        }
-
-        // @phpstan-ignore-next-line
-        return (get_parent_class($class) ?: key(class_implements($class)) ?: 'class') . '@anonymous';
     }
 }

--- a/src/Utility/String/StringFormatter.php
+++ b/src/Utility/String/StringFormatter.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Utility\String;
+
+use CuyZ\Valinor\Mapper\Tree\Message\TranslatableMessage;
+use MessageFormatter;
+
+use function class_exists;
+use function preg_match;
+use function preg_quote;
+use function preg_replace;
+
+/** @internal */
+final class StringFormatter
+{
+    public const DEFAULT_LOCALE = 'en';
+
+    /**
+     * @param array<string, string> $parameters
+     */
+    public static function format(string $locale, string $body, array $parameters = []): string
+    {
+        return class_exists(MessageFormatter::class)
+            ? self::formatWithIntl($locale, $body, $parameters)
+            : self::formatWithRegex($body, $parameters);
+    }
+
+    public static function for(TranslatableMessage $message): string
+    {
+        return self::formatWithRegex($message->body(), $message->parameters());
+    }
+
+    /**
+     * @param array<string, string> $parameters
+     */
+    private static function formatWithIntl(string $locale, string $body, array $parameters): string
+    {
+        $message = MessageFormatter::formatMessage($locale, $body, $parameters);
+
+        // @PHP8.0 use throw exception expression
+        if ($message === false) {
+            throw new StringFormatterError($body);
+        }
+
+        return $message;
+    }
+
+    /**
+     * @param array<string, string> $parameters
+     */
+    private static function formatWithRegex(string $body, array $parameters): string
+    {
+        $message = $body;
+
+        if (preg_match('/{\s*[^}]*[^}a-z_]+\s*}?/', $body)) {
+            throw new StringFormatterError($body);
+        }
+
+        foreach ($parameters as $name => $value) {
+            $name = preg_quote($name, '/');
+
+            /** @var string $message */
+            $message = preg_replace("/{\s*$name\s*}/", $value, $message);
+        }
+
+        return $message;
+    }
+}

--- a/src/Utility/String/StringFormatterError.php
+++ b/src/Utility/String/StringFormatterError.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Utility\String;
+
+use RuntimeException;
+
+/** @internal */
+final class StringFormatterError extends RuntimeException
+{
+    public function __construct(string $body)
+    {
+        parent::__construct("Message formatter error using `$body`.", 1652901203);
+    }
+}

--- a/src/Utility/TypeHelper.php
+++ b/src/Utility/TypeHelper.php
@@ -4,31 +4,29 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Utility;
 
-use CuyZ\Valinor\Type\CombiningType;
+use CuyZ\Valinor\Type\CompositeType;
 use CuyZ\Valinor\Type\ObjectType;
 use CuyZ\Valinor\Type\Type;
-use CuyZ\Valinor\Type\Types\ShapedArrayType;
 
 /** @internal */
 final class TypeHelper
 {
+    public static function dump(Type $type, bool $surround = true): string
+    {
+        $text = self::containsObject($type) ? '?' : (string)$type;
+
+        return $surround ? "`$text`" : $text;
+    }
+
     public static function containsObject(Type $type): bool
     {
         if ($type instanceof ObjectType) {
             return true;
         }
 
-        if ($type instanceof CombiningType) {
-            foreach ($type->types() as $subType) {
+        if ($type instanceof CompositeType) {
+            foreach ($type->traverse() as $subType) {
                 if (self::containsObject($subType)) {
-                    return true;
-                }
-            }
-        }
-
-        if ($type instanceof ShapedArrayType) {
-            foreach ($type->elements() as $element) {
-                if (self::containsObject($element->type())) {
                     return true;
                 }
             }

--- a/src/Utility/TypeHelper.php
+++ b/src/Utility/TypeHelper.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Utility;
+
+use CuyZ\Valinor\Type\CombiningType;
+use CuyZ\Valinor\Type\ObjectType;
+use CuyZ\Valinor\Type\Type;
+use CuyZ\Valinor\Type\Types\ShapedArrayType;
+
+/** @internal */
+final class TypeHelper
+{
+    public static function containsObject(Type $type): bool
+    {
+        if ($type instanceof ObjectType) {
+            return true;
+        }
+
+        if ($type instanceof CombiningType) {
+            foreach ($type->types() as $subType) {
+                if (self::containsObject($subType)) {
+                    return true;
+                }
+            }
+        }
+
+        if ($type instanceof ShapedArrayType) {
+            foreach ($type->elements() as $element) {
+                if (self::containsObject($element->type())) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Utility/ValueDumper.php
+++ b/src/Utility/ValueDumper.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Utility;
+
+use BackedEnum;
+use DateTimeInterface;
+use UnitEnum;
+
+use function implode;
+use function is_array;
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_object;
+use function is_string;
+use function str_contains;
+use function str_replace;
+use function strlen;
+
+/** @internal */
+final class ValueDumper
+{
+    private const MAX_STRING_LENGTH = 50;
+    private const MAX_ARRAY_ENTRIES = 5;
+    private const DATE_FORMAT = 'Y/m/d H:i:s';
+
+    /**
+     * @param mixed $value
+     */
+    public static function dump($value): string
+    {
+        return self::doDump($value);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function doDump($value, bool $goDeeper = true): string
+    {
+        if ($value === null) {
+            return 'null';
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return (string)$value;
+        }
+
+        if (is_string($value)) {
+            $value = self::crop($value);
+
+            if (str_contains($value, "'") && str_contains($value, '"')) {
+                return "'" . str_replace("'", "\'", $value) . "'";
+            }
+
+            if (str_contains($value, "'")) {
+                return '"' . $value . '"';
+            }
+
+            return "'" . $value . "'";
+        }
+
+        if ($value instanceof BackedEnum) {
+            return (string)$value->value;
+        }
+
+        if ($value instanceof UnitEnum) {
+            return $value->name;
+        }
+
+        if ($value instanceof DateTimeInterface) {
+            return $value->format(self::DATE_FORMAT);
+        }
+
+        if (is_object($value)) {
+            return 'object(' . get_class($value) . ')';
+        }
+
+        if (is_array($value)) {
+            if (empty($value)) {
+                return 'array (empty)';
+            }
+
+            if (! $goDeeper) {
+                return 'array{…}';
+            }
+
+            $index = 0;
+            $values = [];
+
+            foreach ($value as $key => $val) {
+                $values[] = "$key: " . self::doDump($val, false);
+
+                if ($index++ >= self::MAX_ARRAY_ENTRIES) {
+                    $values[] = '…';
+                    break;
+                }
+            }
+
+            return 'array{' . implode(', ', $values) . '}';
+        }
+
+        // @codeCoverageIgnoreStart
+        return 'unknown';
+        // @codeCoverageIgnoreEnd
+    }
+
+    private static function crop(string $string): string
+    {
+        if (strlen($string) <= self::MAX_STRING_LENGTH) {
+            return $string;
+        }
+
+        $string = substr($string, 0, self::MAX_STRING_LENGTH + 1);
+
+        for ($i = strlen($string) - 1; $i > 10; $i--) {
+            if ($string[$i] === ' ') {
+                return substr($string, 0, $i) . '…';
+            }
+        }
+
+        return $string . '…';
+    }
+}

--- a/tests/Fake/Mapper/FakeNode.php
+++ b/tests/Fake/Mapper/FakeNode.php
@@ -7,7 +7,6 @@ namespace CuyZ\Valinor\Tests\Fake\Mapper;
 use CuyZ\Valinor\Definition\Attributes;
 use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use CuyZ\Valinor\Mapper\Tree\Node;
-use CuyZ\Valinor\Mapper\Tree\Shell;
 use CuyZ\Valinor\Tests\Fake\Definition\FakeAttributes;
 use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeErrorMessage;
 use CuyZ\Valinor\Tests\Fake\Type\FakeType;
@@ -26,7 +25,7 @@ final class FakeNode
      */
     public static function leaf(Type $type, $value): Node
     {
-        $shell = Shell::root($type, $value);
+        $shell = FakeShell::new($type, $value);
 
         return Node::leaf($shell, $value);
     }
@@ -37,7 +36,7 @@ final class FakeNode
      */
     public static function branch(array $children, Type $type = null, $value = null): Node
     {
-        $shell = Shell::root($type ?? FakeType::permissive(), $value);
+        $shell = FakeShell::new($type ?? FakeType::permissive(), $value);
         $nodes = [];
 
         foreach ($children as $key => $child) {
@@ -65,7 +64,7 @@ final class FakeNode
      */
     public static function error(Throwable $error = null): Node
     {
-        $shell = Shell::root(FakeType::permissive(), []);
+        $shell = FakeShell::new(FakeType::permissive(), []);
 
         return Node::error($shell, $error ?? new FakeErrorMessage());
     }

--- a/tests/Fake/Mapper/FakeShell.php
+++ b/tests/Fake/Mapper/FakeShell.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Fake\Mapper;
+
+use CuyZ\Valinor\Mapper\Tree\Shell;
+use CuyZ\Valinor\Tests\Fake\Type\FakeType;
+use CuyZ\Valinor\Type\Type;
+
+final class FakeShell
+{
+    /**
+     * @param mixed $value
+     */
+    public static function new(Type $type, $value = null): Shell
+    {
+        return Shell::root($type, $value);
+    }
+
+    public static function any(): Shell
+    {
+        return self::new(new FakeType(), []);
+    }
+}

--- a/tests/Fake/Mapper/Object/FakeObjectBuilder.php
+++ b/tests/Fake/Mapper/Object/FakeObjectBuilder.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Fake\Mapper\Object;
 
+use CuyZ\Valinor\Mapper\Object\Arguments;
 use CuyZ\Valinor\Mapper\Object\ObjectBuilder;
 use stdClass;
 
 final class FakeObjectBuilder implements ObjectBuilder
 {
-    public function describeArguments(): iterable
+    public function describeArguments(): Arguments
     {
-        return [];
+        return new Arguments();
     }
 
     public function build(array $arguments): object

--- a/tests/Fake/Mapper/Tree/Message/FakeErrorMessage.php
+++ b/tests/Fake/Mapper/Tree/Message/FakeErrorMessage.php
@@ -9,13 +9,8 @@ use Exception;
 
 final class FakeErrorMessage extends Exception implements Message
 {
-    public function __construct(string $message = 'some error message')
+    public function __construct(string $message = 'some error message', int $code = 1652883436)
     {
-        parent::__construct($message);
-    }
-
-    public function __toString(): string
-    {
-        return $this->message;
+        parent::__construct($message, $code);
     }
 }

--- a/tests/Fake/Mapper/Tree/Message/FakeNodeMessage.php
+++ b/tests/Fake/Mapper/Tree/Message/FakeNodeMessage.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message;
+
+use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
+use CuyZ\Valinor\Tests\Fake\Mapper\FakeShell;
+
+final class FakeNodeMessage
+{
+    public static function any(): NodeMessage
+    {
+        return new NodeMessage(FakeShell::any(), new FakeMessage());
+    }
+}

--- a/tests/Fake/Mapper/Tree/Message/FakeTranslatableMessage.php
+++ b/tests/Fake/Mapper/Tree/Message/FakeTranslatableMessage.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message;
+
+use CuyZ\Valinor\Mapper\Tree\Message\HasCode;
+use CuyZ\Valinor\Mapper\Tree\Message\TranslatableMessage;
+
+final class FakeTranslatableMessage implements TranslatableMessage, HasCode
+{
+    private string $body;
+
+    /** @var array<string, string> */
+    private array $parameters;
+
+    /**
+     * @param array<string, string> $parameters
+     */
+    public function __construct(string $body = 'some message', array $parameters = [])
+    {
+        $this->body = $body;
+        $this->parameters = $parameters;
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
+    }
+
+    public function code(): string
+    {
+        return '1652902453';
+    }
+
+    public function __toString()
+    {
+        return "$this->body (toString)";
+    }
+}

--- a/tests/Fake/Mapper/Tree/Message/Formatter/FakeMessageFormatter.php
+++ b/tests/Fake/Mapper/Tree/Message/Formatter/FakeMessageFormatter.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\Formatter;
+
+use CuyZ\Valinor\Mapper\Tree\Message\Formatter\MessageFormatter;
+use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
+
+final class FakeMessageFormatter implements MessageFormatter
+{
+    private string $body;
+
+    public function __construct(string $body = null)
+    {
+        if ($body) {
+            $this->body = $body;
+        }
+    }
+
+    public function format(NodeMessage $message): NodeMessage
+    {
+        return $message->withBody($this->body ?? "formatted: {$message->body()}");
+    }
+}

--- a/tests/Fake/Type/FakeObjectType.php
+++ b/tests/Fake/Type/FakeObjectType.php
@@ -15,11 +15,10 @@ final class FakeObjectType implements ObjectType
     /** @var class-string */
     private string $className;
 
-    /** @var Type[] */
-    private array $matching = [];
+    private Type $matching;
 
-    /** @var mixed[] */
-    private array $accepting = [];
+    /** @var object[] */
+    private array $accepting;
 
     /**
      * @param class-string $className
@@ -27,6 +26,22 @@ final class FakeObjectType implements ObjectType
     public function __construct(string $className = stdClass::class)
     {
         $this->className = $className;
+    }
+
+    public static function accepting(object ...$objects): self
+    {
+        $instance = new self();
+        $instance->accepting = $objects;
+
+        return $instance;
+    }
+
+    public static function matching(Type $other): self
+    {
+        $instance = new self();
+        $instance->matching = $other;
+
+        return $instance;
     }
 
     public function className(): string
@@ -41,22 +56,12 @@ final class FakeObjectType implements ObjectType
 
     public function accepts($value): bool
     {
-        return in_array($value, $this->accepting, true);
+        return isset($this->accepting) && in_array($value, $this->accepting, true);
     }
 
     public function matches(Type $other): bool
     {
-        return in_array($other, $this->matching, true);
-    }
-
-    public function willAccept(object $object): void
-    {
-        $this->accepting[] = $object;
-    }
-
-    public function willMatch(Type ...$others): void
-    {
-        $this->matching = [...$this->matching, ...$others];
+        return $other === ($this->matching ?? null);
     }
 
     public function __toString(): string

--- a/tests/Integration/Mapping/ConstructorRegistrationMappingTest.php
+++ b/tests/Integration/Mapping/ConstructorRegistrationMappingTest.php
@@ -290,7 +290,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTest
             $error = $exception->node()->messages()[0];
 
             self::assertSame('1642787246', $error->code());
-            self::assertSame('Value array (empty) is not accepted.', (string)$error);
+            self::assertSame('Invalid value array (empty).', (string)$error);
         }
     }
 
@@ -299,8 +299,8 @@ final class ConstructorRegistrationMappingTest extends IntegrationTest
         try {
             $this->mapperBuilder
                 ->registerConstructor(
-                    fn (string $foo): stdClass => new stdClass(),
                     fn (int $bar, float $baz = 1337.404): stdClass => new stdClass(),
+                    fn (string $foo): stdClass => new stdClass(),
                 )
                 ->mapper()
                 ->map(stdClass::class, []);

--- a/tests/Integration/Mapping/ConstructorRegistrationMappingTest.php
+++ b/tests/Integration/Mapping/ConstructorRegistrationMappingTest.php
@@ -290,7 +290,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTest
             $error = $exception->node()->messages()[0];
 
             self::assertSame('1642787246', $error->code());
-            self::assertSame('Could not map input of type `array`.', (string)$error);
+            self::assertSame('Value array (empty) is not accepted.', (string)$error);
         }
     }
 
@@ -308,7 +308,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTest
             $error = $exception->node()->messages()[0];
 
             self::assertSame('1642183169', $error->code());
-            self::assertSame('Invalid value, got `array` but expected one of `array{foo: string}`, `array{bar: int, baz?: float}`.', (string)$error);
+            self::assertSame('Value array (empty) does not match any of `array{foo: string}`, `array{bar: int, baz?: float}`.', (string)$error);
         }
     }
 

--- a/tests/Integration/Mapping/InterfaceInferringMappingTest.php
+++ b/tests/Integration/Mapping/InterfaceInferringMappingTest.php
@@ -158,7 +158,7 @@ final class InterfaceInferringMappingTest extends IntegrationTest
             $error = $exception->node()->messages()[0];
 
             self::assertSame('1645283485', $error->code());
-            self::assertSame('Invalid value 42, it must be an iterable.', (string)$error);
+            self::assertSame('Invalid value 42: it must be an array.', (string)$error);
         }
     }
 

--- a/tests/Integration/Mapping/InterfaceInferringMappingTest.php
+++ b/tests/Integration/Mapping/InterfaceInferringMappingTest.php
@@ -113,7 +113,7 @@ final class InterfaceInferringMappingTest extends IntegrationTest
     {
         $this->expectException(InvalidInterfaceResolverReturnType::class);
         $this->expectExceptionCode(1630091260);
-        $this->expectExceptionMessage('Invalid type `int`; it must be the name of a class that implements `DateTimeInterface`.');
+        $this->expectExceptionMessage('Invalid value 42; it must be the name of a class that implements `DateTimeInterface`.');
 
         $this->mapperBuilder
             ->infer(DateTimeInterface::class, fn () => 42)
@@ -158,7 +158,7 @@ final class InterfaceInferringMappingTest extends IntegrationTest
             $error = $exception->node()->messages()[0];
 
             self::assertSame('1645283485', $error->code());
-            self::assertSame('Invalid source type `int`, it must be an iterable.', (string)$error);
+            self::assertSame('Invalid value 42, it must be an iterable.', (string)$error);
         }
     }
 
@@ -175,7 +175,7 @@ final class InterfaceInferringMappingTest extends IntegrationTest
             $error = $exception->node()->children()['key']->messages()[0];
 
             self::assertSame('1618736242', $error->code());
-            self::assertSame('Cannot cast value of type `string` to `int`.', (string)$error);
+            self::assertSame("Cannot cast 'foo' to `int`.", (string)$error);
         }
     }
 

--- a/tests/Integration/Mapping/Message/MessageFormatterTest.php
+++ b/tests/Integration/Mapping/Message/MessageFormatterTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Mapping\Message;
+
+use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\Mapper\Tree\Message\Formatter\AggregateMessageFormatter;
+use CuyZ\Valinor\Mapper\Tree\Message\Formatter\LocaleMessageFormatter;
+use CuyZ\Valinor\Mapper\Tree\Message\Formatter\MessageMapFormatter;
+use CuyZ\Valinor\Mapper\Tree\Message\Formatter\TranslationMessageFormatter;
+use CuyZ\Valinor\Tests\Integration\IntegrationTest;
+
+final class MessageFormatterTest extends IntegrationTest
+{
+    public function test_message_is_formatted_correctly(): void
+    {
+        try {
+            $this->mapperBuilder->mapper()->map('int', 'foo');
+        } catch (MappingError $error) {
+            $formatter = new AggregateMessageFormatter(
+                new LocaleMessageFormatter('fr'),
+                new MessageMapFormatter([
+                    'Cannot cast {value} to {expected_type}.' => 'New message: {value} / {expected_type}',
+                ]),
+                (new TranslationMessageFormatter())->withTranslation(
+                    'fr',
+                    'New message: {value} / {expected_type}',
+                    'Nouveau message : {value} / {expected_type}',
+                ),
+            );
+
+            $message = $formatter->format($error->node()->messages()[0]);
+
+            self::assertSame("Nouveau message : 'foo' / `int`", (string)$message);
+        }
+    }
+}

--- a/tests/Integration/Mapping/Object/ArrayValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ArrayValuesMappingTest.php
@@ -76,7 +76,7 @@ final class ArrayValuesMappingTest extends IntegrationTest
             $error = $exception->node()->children()['nonEmptyArraysOfStrings']->messages()[0];
 
             self::assertSame('1630678334', $error->code());
-            self::assertSame('Empty array is not accepted by `non-empty-array<string>`.', (string)$error);
+            self::assertSame('Value array (empty) does not match expected `non-empty-array<string>`.', (string)$error);
         }
     }
 
@@ -90,7 +90,7 @@ final class ArrayValuesMappingTest extends IntegrationTest
             $error = $exception->node()->children()['integers']->children()[0]->messages()[0];
 
             self::assertSame('1618736242', $error->code());
-            self::assertSame('Cannot cast value of type `string` to `int`.', (string)$error);
+            self::assertSame("Cannot cast 'foo' to `int`.", (string)$error);
         }
     }
 }

--- a/tests/Integration/Mapping/Object/ArrayValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ArrayValuesMappingTest.php
@@ -76,7 +76,7 @@ final class ArrayValuesMappingTest extends IntegrationTest
             $error = $exception->node()->children()['nonEmptyArraysOfStrings']->messages()[0];
 
             self::assertSame('1630678334', $error->code());
-            self::assertSame('Value array (empty) does not match expected `non-empty-array<string>`.', (string)$error);
+            self::assertSame('Value array (empty) does not match type `non-empty-array<string>`.', (string)$error);
         }
     }
 

--- a/tests/Integration/Mapping/Object/DateTimeMappingTest.php
+++ b/tests/Integration/Mapping/Object/DateTimeMappingTest.php
@@ -20,6 +20,9 @@ final class DateTimeMappingTest extends IntegrationTest
         $dateTimeInterface = new DateTimeImmutable('@' . $this->buildRandomTimestamp());
         $dateTimeImmutable = new DateTimeImmutable('@' . $this->buildRandomTimestamp());
         $dateTimeFromTimestamp = $this->buildRandomTimestamp();
+        $dateTimeFromTimestampWithOutFormat = [
+            'datetime' => $this->buildRandomTimestamp(),
+        ];
         $dateTimeFromTimestampWithFormat = [
             'datetime' => $this->buildRandomTimestamp(),
             'format' => 'U',
@@ -37,6 +40,7 @@ final class DateTimeMappingTest extends IntegrationTest
                 'dateTimeInterface' => $dateTimeInterface,
                 'dateTimeImmutable' => $dateTimeImmutable,
                 'dateTimeFromTimestamp' => $dateTimeFromTimestamp,
+                'dateTimeFromTimestampWithOutFormat' => $dateTimeFromTimestampWithOutFormat,
                 'dateTimeFromTimestampWithFormat' => $dateTimeFromTimestampWithFormat,
                 'dateTimeFromAtomFormat' => $dateTimeFromAtomFormat,
                 'dateTimeFromArray' => $dateTimeFromArray,
@@ -53,6 +57,7 @@ final class DateTimeMappingTest extends IntegrationTest
         self::assertEquals($dateTimeImmutable, $result->dateTimeImmutable);
         self::assertEquals(new DateTimeImmutable("@$dateTimeFromTimestamp"), $result->dateTimeFromTimestamp);
         self::assertEquals(new DateTimeImmutable("@{$dateTimeFromTimestampWithFormat['datetime']}"), $result->dateTimeFromTimestampWithFormat);
+        self::assertEquals(new DateTimeImmutable("@{$dateTimeFromTimestampWithOutFormat['datetime']}"), $result->dateTimeFromTimestampWithOutFormat);
         self::assertEquals(DateTimeImmutable::createFromFormat(DATE_ATOM, $dateTimeFromAtomFormat), $result->dateTimeFromAtomFormat);
         self::assertEquals(DateTimeImmutable::createFromFormat($dateTimeFromArray['format'], $dateTimeFromArray['datetime']), $result->dateTimeFromArray);
         self::assertEquals(DateTimeImmutable::createFromFormat(DateTimeObjectBuilder::DATE_MYSQL, $mysqlDate), $result->mysqlDate);
@@ -133,6 +138,8 @@ final class AllDateTimeValues
     public DateTimeImmutable $dateTimeImmutable;
 
     public DateTime $dateTimeFromTimestamp;
+
+    public DateTime $dateTimeFromTimestampWithOutFormat;
 
     public DateTime $dateTimeFromTimestampWithFormat;
 

--- a/tests/Integration/Mapping/Object/DateTimeMappingTest.php
+++ b/tests/Integration/Mapping/Object/DateTimeMappingTest.php
@@ -76,7 +76,7 @@ final class DateTimeMappingTest extends IntegrationTest
             $error = $exception->node()->children()['dateTime']->messages()[0];
 
             self::assertSame('1630686564', $error->code());
-            self::assertSame("Impossible to parse date with value 'invalid datetime'.", (string)$error);
+            self::assertSame("Value 'invalid datetime' does not match a valid date format.", (string)$error);
         }
     }
 
@@ -95,7 +95,7 @@ final class DateTimeMappingTest extends IntegrationTest
             $error = $exception->node()->children()['dateTime']->messages()[0];
 
             self::assertSame('1630686564', $error->code());
-            self::assertSame("Impossible to parse date with value '1337'.", (string)$error);
+            self::assertSame("Value 1337 does not match a valid date format.", (string)$error);
         }
     }
 

--- a/tests/Integration/Mapping/Object/DateTimeMappingTest.php
+++ b/tests/Integration/Mapping/Object/DateTimeMappingTest.php
@@ -76,7 +76,7 @@ final class DateTimeMappingTest extends IntegrationTest
             $error = $exception->node()->children()['dateTime']->messages()[0];
 
             self::assertSame('1630686564', $error->code());
-            self::assertSame('Impossible to convert `invalid datetime` to `DateTime`.', (string)$error);
+            self::assertSame("Impossible to parse date with value 'invalid datetime'.", (string)$error);
         }
     }
 
@@ -95,7 +95,7 @@ final class DateTimeMappingTest extends IntegrationTest
             $error = $exception->node()->children()['dateTime']->messages()[0];
 
             self::assertSame('1630686564', $error->code());
-            self::assertSame('Impossible to convert `1337` to `DateTime`.', (string)$error);
+            self::assertSame("Impossible to parse date with value '1337'.", (string)$error);
         }
     }
 

--- a/tests/Integration/Mapping/Object/ListValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ListValuesMappingTest.php
@@ -76,7 +76,7 @@ final class ListValuesMappingTest extends IntegrationTest
             $error = $exception->node()->children()['nonEmptyListOfStrings']->messages()[0];
 
             self::assertSame('1630678334', $error->code());
-            self::assertSame('Empty array is not accepted by `non-empty-list<string>`.', (string)$error);
+            self::assertSame('Value array (empty) does not match expected `non-empty-list<string>`.', (string)$error);
         }
     }
 
@@ -90,7 +90,7 @@ final class ListValuesMappingTest extends IntegrationTest
             $error = $exception->node()->children()['integers']->children()['0']->messages()[0];
 
             self::assertSame('1618736242', $error->code());
-            self::assertSame('Cannot cast value of type `string` to `int`.', (string)$error);
+            self::assertSame("Cannot cast 'foo' to `int`.", (string)$error);
         }
     }
 }

--- a/tests/Integration/Mapping/Object/ListValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ListValuesMappingTest.php
@@ -76,7 +76,7 @@ final class ListValuesMappingTest extends IntegrationTest
             $error = $exception->node()->children()['nonEmptyListOfStrings']->messages()[0];
 
             self::assertSame('1630678334', $error->code());
-            self::assertSame('Value array (empty) does not match expected `non-empty-list<string>`.', (string)$error);
+            self::assertSame('Value array (empty) does not match type `non-empty-list<string>`.', (string)$error);
         }
     }
 

--- a/tests/Integration/Mapping/Object/ObjectValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ObjectValuesMappingTest.php
@@ -41,7 +41,7 @@ final class ObjectValuesMappingTest extends IntegrationTest
                 $error = $exception->node()->messages()[0];
 
                 self::assertSame('1632903281', $error->code());
-                self::assertSame('Invalid source type `string`, it must be an iterable.', (string)$error);
+                self::assertSame("Value 'foo' does not match `array{object: ?, string: string}`.", (string)$error);
             }
         }
     }

--- a/tests/Integration/Mapping/Object/ObjectValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ObjectValuesMappingTest.php
@@ -41,7 +41,7 @@ final class ObjectValuesMappingTest extends IntegrationTest
                 $error = $exception->node()->messages()[0];
 
                 self::assertSame('1632903281', $error->code());
-                self::assertSame("Value 'foo' does not match `array{object: ?, string: string}`.", (string)$error);
+                self::assertSame("Value 'foo' does not match type `array{object: ?, string: string}`.", (string)$error);
             }
         }
     }

--- a/tests/Integration/Mapping/Object/ScalarValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ScalarValuesMappingTest.php
@@ -92,7 +92,7 @@ final class ScalarValuesMappingTest extends IntegrationTest
             $error = $exception->node()->children()['value']->messages()[0];
 
             self::assertSame('1618736242', $error->code());
-            self::assertSame('Cannot be empty and must be filled with a value of type `string`.', (string)$error);
+            self::assertSame('Cannot be empty and must be filled with a value matching type `string`.', (string)$error);
         }
     }
 }

--- a/tests/Integration/Mapping/Object/ScalarValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ScalarValuesMappingTest.php
@@ -78,7 +78,7 @@ final class ScalarValuesMappingTest extends IntegrationTest
             $error = $exception->node()->children()['value']->messages()[0];
 
             self::assertSame('1618736242', $error->code());
-            self::assertSame('Cannot cast value of type `stdClass` to `string`.', (string)$error);
+            self::assertSame('Cannot cast object(stdClass) to `string`.', (string)$error);
         }
     }
 

--- a/tests/Integration/Mapping/Object/ShapedArrayValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ShapedArrayValuesMappingTest.php
@@ -75,7 +75,7 @@ final class ShapedArrayValuesMappingTest extends IntegrationTest
             $error = $exception->node()->children()['basicShapedArrayWithStringKeys']->children()['foo']->messages()[0];
 
             self::assertSame('1618736242', $error->code());
-            self::assertSame('Cannot cast value of type `stdClass` to `string`.', (string)$error);
+            self::assertSame('Cannot cast object(stdClass) to `string`.', (string)$error);
         }
     }
 }

--- a/tests/Integration/Mapping/Source/SourceTest.php
+++ b/tests/Integration/Mapping/Source/SourceTest.php
@@ -54,6 +54,9 @@ final class SourceTest extends IntegrationTest
         self::assertSame('foo', $object->someNestedValue->someValue);
     }
 
+    /**
+     * @requires extension yaml
+     */
     public function test_yaml_source(): void
     {
         try {

--- a/tests/Integration/Mapping/VisitorMappingTest.php
+++ b/tests/Integration/Mapping/VisitorMappingTest.php
@@ -35,7 +35,7 @@ final class VisitorMappingTest extends IntegrationTest
                 ->mapper()
                 ->map(SimpleObject::class, ['value' => 'foo']);
         } catch (MappingError $exception) {
-            self::assertSame((string)$error, (string)$exception->node()->messages()[0]);
+            self::assertSame('some error message', (string)$exception->node()->messages()[0]);
         }
 
         self::assertSame(['#1', '#2'], $visits);

--- a/tests/Unit/Mapper/Object/ArgumentsTest.php
+++ b/tests/Unit/Mapper/Object/ArgumentsTest.php
@@ -7,7 +7,9 @@ namespace CuyZ\Valinor\Tests\Unit\Mapper\Object;
 use CuyZ\Valinor\Mapper\Object\Argument;
 use CuyZ\Valinor\Mapper\Object\Arguments;
 use CuyZ\Valinor\Mapper\Object\Exception\InvalidArgumentIndex;
+use CuyZ\Valinor\Tests\Fake\Type\FakeObjectType;
 use CuyZ\Valinor\Tests\Fake\Type\FakeType;
+use CuyZ\Valinor\Type\Types\UnionType;
 use PHPUnit\Framework\TestCase;
 
 final class ArgumentsTest extends TestCase
@@ -26,13 +28,17 @@ final class ArgumentsTest extends TestCase
     public function test_signature_is_correct(): void
     {
         $typeA = FakeType::permissive();
-        $typeB = FakeType::permissive();
+        $typeB = new FakeObjectType();
+        $typeC = new UnionType(new FakeObjectType(), new FakeObjectType());
+        $typeD = FakeType::permissive();
 
         $arguments = new Arguments(
-            Argument::required('someArgumentA', $typeA),
-            Argument::optional('someArgumentB', $typeB, 'defaultValue')
+            Argument::required('someArgument', $typeA),
+            Argument::required('someArgumentOfObject', $typeB),
+            Argument::required('someArgumentWithUnionOfObject', $typeC),
+            Argument::optional('someOptionalArgument', $typeD, 'defaultValue')
         );
 
-        self::assertSame("array{someArgumentA: $typeA, someArgumentB?: $typeB}", $arguments->signature());
+        self::assertSame("array{someArgument: $typeA, someArgumentOfObject: ?, someArgumentWithUnionOfObject: ?, someOptionalArgument?: $typeD}", $arguments->signature());
     }
 }

--- a/tests/Unit/Mapper/Object/ArgumentsTest.php
+++ b/tests/Unit/Mapper/Object/ArgumentsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Unit\Mapper\Object;
+
+use CuyZ\Valinor\Mapper\Object\Argument;
+use CuyZ\Valinor\Mapper\Object\Arguments;
+use CuyZ\Valinor\Mapper\Object\Exception\InvalidArgumentIndex;
+use CuyZ\Valinor\Tests\Fake\Type\FakeType;
+use PHPUnit\Framework\TestCase;
+
+final class ArgumentsTest extends TestCase
+{
+    public function test_get_argument_at_invalid_index_throws_exception(): void
+    {
+        $this->expectException(InvalidArgumentIndex::class);
+        $this->expectExceptionCode(1648672136);
+        $this->expectExceptionMessage("Index 1 is out of range, it should be between 0 and 0.");
+
+        (new Arguments(
+            Argument::required('someArgument', FakeType::permissive())
+        ))->at(1);
+    }
+
+    public function test_signature_is_correct(): void
+    {
+        $typeA = FakeType::permissive();
+        $typeB = FakeType::permissive();
+
+        $arguments = new Arguments(
+            Argument::required('someArgumentA', $typeA),
+            Argument::optional('someArgumentB', $typeB, 'defaultValue')
+        );
+
+        self::assertSame("array{someArgumentA: $typeA, someArgumentB?: $typeB}", $arguments->signature());
+    }
+}

--- a/tests/Unit/Mapper/Object/ArgumentsTest.php
+++ b/tests/Unit/Mapper/Object/ArgumentsTest.php
@@ -39,6 +39,9 @@ final class ArgumentsTest extends TestCase
             Argument::optional('someOptionalArgument', $typeD, 'defaultValue')
         );
 
-        self::assertSame("array{someArgument: $typeA, someArgumentOfObject: ?, someArgumentWithUnionOfObject: ?, someOptionalArgument?: $typeD}", $arguments->signature());
+        self::assertSame(
+            "`array{someArgument: $typeA, someArgumentOfObject: ?, someArgumentWithUnionOfObject: ?, someOptionalArgument?: $typeD}`",
+            $arguments->signature()
+        );
     }
 }

--- a/tests/Unit/Mapper/Object/DateTimeObjectBuilderTest.php
+++ b/tests/Unit/Mapper/Object/DateTimeObjectBuilderTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Unit\Mapper\Object;
+
+use CuyZ\Valinor\Mapper\Object\DateTimeObjectBuilder;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+
+final class DateTimeObjectBuilderTest extends TestCase
+{
+    public function test_arguments_instance_stays_the_same(): void
+    {
+        $objectBuilder = new DateTimeObjectBuilder(DateTimeImmutable::class);
+
+        $argumentsA = $objectBuilder->describeArguments();
+        $argumentsB = $objectBuilder->describeArguments();
+
+        self::assertSame($argumentsA, $argumentsB);
+    }
+}

--- a/tests/Unit/Mapper/Object/FunctionObjectBuilderTest.php
+++ b/tests/Unit/Mapper/Object/FunctionObjectBuilderTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Unit\Mapper\Object;
+
+use CuyZ\Valinor\Mapper\Object\FunctionObjectBuilder;
+use CuyZ\Valinor\Tests\Fake\Definition\FakeFunctionDefinition;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class FunctionObjectBuilderTest extends TestCase
+{
+    public function test_arguments_instance_stays_the_same(): void
+    {
+        $objectBuilder = new FunctionObjectBuilder(FakeFunctionDefinition::new(), fn () => new stdClass());
+
+        $argumentsA = $objectBuilder->describeArguments();
+        $argumentsB = $objectBuilder->describeArguments();
+
+        self::assertSame($argumentsA, $argumentsB);
+    }
+}

--- a/tests/Unit/Mapper/Object/MethodObjectBuilderTest.php
+++ b/tests/Unit/Mapper/Object/MethodObjectBuilderTest.php
@@ -151,6 +151,26 @@ final class MethodObjectBuilderTest extends TestCase
         $class = FakeClassDefinition::fromReflection(new ReflectionClass($classWithPrivateNativeConstructor));
         new MethodObjectBuilder($class, 'someConstructor');
     }
+
+    public function test_arguments_instance_stays_the_same(): void
+    {
+        $class = new class ('foo') {
+            public string $string;
+
+            public function __construct(string $string)
+            {
+                $this->string = $string;
+            }
+        };
+        $class = FakeClassDefinition::fromReflection(new ReflectionClass($class));
+
+        $objectBuilder = new MethodObjectBuilder($class, '__construct');
+
+        $argumentsA = $objectBuilder->describeArguments();
+        $argumentsB = $objectBuilder->describeArguments();
+
+        self::assertSame($argumentsA, $argumentsB);
+    }
 }
 
 final class ObjectWithPrivateNativeConstructor

--- a/tests/Unit/Mapper/Object/ReflectionObjectBuilderTest.php
+++ b/tests/Unit/Mapper/Object/ReflectionObjectBuilderTest.php
@@ -50,6 +50,17 @@ final class ReflectionObjectBuilderTest extends TestCase
         self::assertSame('valueC', $result->valueC()); // @phpstan-ignore-line
     }
 
+    public function test_arguments_instance_stays_the_same(): void
+    {
+        $class = FakeClassDefinition::new();
+        $objectBuilder = new ReflectionObjectBuilder($class);
+
+        $argumentsA = $objectBuilder->describeArguments();
+        $argumentsB = $objectBuilder->describeArguments();
+
+        self::assertSame($argumentsA, $argumentsB);
+    }
+
     public function test_missing_arguments_throws_exception(): void
     {
         $object = new class () {

--- a/tests/Unit/Mapper/Source/JsonSourceTest.php
+++ b/tests/Unit/Mapper/Source/JsonSourceTest.php
@@ -33,7 +33,7 @@ final class JsonSourceTest extends TestCase
     {
         $this->expectException(SourceNotIterable::class);
         $this->expectExceptionCode(1566307291);
-        $this->expectExceptionMessage('The configuration is not an iterable but of type `bool`.');
+        $this->expectExceptionMessage('Invalid source true, expected an iterable.');
 
         new JsonSource('true');
     }

--- a/tests/Unit/Mapper/Source/YamlSourceTest.php
+++ b/tests/Unit/Mapper/Source/YamlSourceTest.php
@@ -36,7 +36,7 @@ final class YamlSourceTest extends TestCase
     {
         $this->expectException(SourceNotIterable::class);
         $this->expectExceptionCode(1566307291);
-        $this->expectExceptionMessage('The configuration is not an iterable but of type `string`.');
+        $this->expectExceptionMessage("Invalid source 'foo', expected an iterable.");
 
         new YamlSource('foo');
     }

--- a/tests/Unit/Mapper/Tree/Builder/ArrayNodeBuilderTest.php
+++ b/tests/Unit/Mapper/Tree/Builder/ArrayNodeBuilderTest.php
@@ -9,7 +9,7 @@ use CuyZ\Valinor\Mapper\Tree\Builder\RootNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\ArrayNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Exception\InvalidTraversableKey;
 use CuyZ\Valinor\Mapper\Tree\Exception\SourceMustBeIterable;
-use CuyZ\Valinor\Mapper\Tree\Shell;
+use CuyZ\Valinor\Tests\Fake\Mapper\FakeShell;
 use CuyZ\Valinor\Tests\Fake\Type\FakeType;
 use CuyZ\Valinor\Type\Types\ArrayKeyType;
 use CuyZ\Valinor\Type\Types\ArrayType;
@@ -20,7 +20,7 @@ final class ArrayNodeBuilderTest extends TestCase
 {
     public function test_build_with_null_value_returns_empty_branch_node(): void
     {
-        $node = (new RootNodeBuilder(new ArrayNodeBuilder()))->build(Shell::root(ArrayType::native(), null));
+        $node = (new RootNodeBuilder(new ArrayNodeBuilder()))->build(FakeShell::new(ArrayType::native()));
 
         self::assertSame([], $node->value());
         self::assertEmpty($node->children());
@@ -30,29 +30,29 @@ final class ArrayNodeBuilderTest extends TestCase
     {
         $this->expectException(AssertionError::class);
 
-        (new RootNodeBuilder(new ArrayNodeBuilder()))->build(Shell::root(new FakeType(), []));
+        (new RootNodeBuilder(new ArrayNodeBuilder()))->build(FakeShell::new(new FakeType()));
     }
 
     public function test_build_with_invalid_source_throws_exception(): void
     {
         $this->expectException(SourceMustBeIterable::class);
         $this->expectExceptionCode(1618739163);
-        $this->expectExceptionMessage("Value 'foo' does not match expected `array`.");
+        $this->expectExceptionMessage("Value 'foo' does not match type `array`.");
 
-        (new RootNodeBuilder(new ArrayNodeBuilder()))->build(Shell::root(ArrayType::native(), 'foo'));
+        (new RootNodeBuilder(new ArrayNodeBuilder()))->build(FakeShell::new(ArrayType::native(), 'foo'));
     }
 
     public function test_invalid_source_key_throws_exception(): void
     {
         $this->expectException(InvalidTraversableKey::class);
         $this->expectExceptionCode(1630946163);
-        $this->expectExceptionMessage("Invalid key 'foo', it must be of type `int`.");
+        $this->expectExceptionMessage("Key 'foo' does not match type `int`.");
 
         $type = new ArrayType(ArrayKeyType::integer(), NativeStringType::get());
         $value = [
             'foo' => 'key is not ok',
         ];
 
-        (new RootNodeBuilder(new ArrayNodeBuilder()))->build(Shell::root($type, $value));
+        (new RootNodeBuilder(new ArrayNodeBuilder()))->build(FakeShell::new($type, $value));
     }
 }

--- a/tests/Unit/Mapper/Tree/Builder/ArrayNodeBuilderTest.php
+++ b/tests/Unit/Mapper/Tree/Builder/ArrayNodeBuilderTest.php
@@ -37,7 +37,7 @@ final class ArrayNodeBuilderTest extends TestCase
     {
         $this->expectException(SourceMustBeIterable::class);
         $this->expectExceptionCode(1618739163);
-        $this->expectExceptionMessage('Source must be iterable in order to be cast to `array`, but is of type `string`.');
+        $this->expectExceptionMessage("Value 'foo' does not match expected `array`.");
 
         (new RootNodeBuilder(new ArrayNodeBuilder()))->build(Shell::root(ArrayType::native(), 'foo'));
     }
@@ -46,7 +46,7 @@ final class ArrayNodeBuilderTest extends TestCase
     {
         $this->expectException(InvalidTraversableKey::class);
         $this->expectExceptionCode(1630946163);
-        $this->expectExceptionMessage('Invalid key `foo`, it must be of type `int`.');
+        $this->expectExceptionMessage("Invalid key 'foo', it must be of type `int`.");
 
         $type = new ArrayType(ArrayKeyType::integer(), NativeStringType::get());
         $value = [

--- a/tests/Unit/Mapper/Tree/Builder/CasterNodeBuilderTest.php
+++ b/tests/Unit/Mapper/Tree/Builder/CasterNodeBuilderTest.php
@@ -7,7 +7,7 @@ namespace CuyZ\Valinor\Tests\Unit\Mapper\Tree\Builder;
 use CuyZ\Valinor\Mapper\Tree\Builder\CasterNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\RootNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Exception\NoCasterForType;
-use CuyZ\Valinor\Mapper\Tree\Shell;
+use CuyZ\Valinor\Tests\Fake\Mapper\FakeShell;
 use CuyZ\Valinor\Tests\Fake\Type\FakeType;
 use PHPUnit\Framework\TestCase;
 
@@ -21,6 +21,6 @@ final class CasterNodeBuilderTest extends TestCase
         $this->expectExceptionCode(1630693475);
         $this->expectExceptionMessage("No caster was found to convert to type `$type`.");
 
-        (new RootNodeBuilder(new CasterNodeBuilder([])))->build(Shell::root($type, []));
+        (new RootNodeBuilder(new CasterNodeBuilder([])))->build(FakeShell::new($type));
     }
 }

--- a/tests/Unit/Mapper/Tree/Builder/EnumNodeBuilderTest.php
+++ b/tests/Unit/Mapper/Tree/Builder/EnumNodeBuilderTest.php
@@ -44,7 +44,7 @@ final class EnumNodeBuilderTest extends TestCase
 
         $this->expectException(InvalidEnumValue::class);
         $this->expectExceptionCode(1633093113);
-        $this->expectExceptionMessage('Invalid value `foo`, it must be one of `FOO`, `BAR`.');
+        $this->expectExceptionMessage("Invalid value 'foo', it must be one of 'FOO', 'BAR'.");
 
         $this->builder->build(Shell::root($type, 'foo'));
     }
@@ -55,7 +55,7 @@ final class EnumNodeBuilderTest extends TestCase
 
         $this->expectException(InvalidEnumValue::class);
         $this->expectExceptionCode(1633093113);
-        $this->expectExceptionMessage('Invalid value `stdClass`, it must be one of `foo`, `bar`.');
+        $this->expectExceptionMessage("Invalid value object(stdClass), it must be one of 'foo', 'bar'.");
 
         $this->builder->build(Shell::root($type, new stdClass()));
     }
@@ -66,7 +66,7 @@ final class EnumNodeBuilderTest extends TestCase
 
         $this->expectException(InvalidEnumValue::class);
         $this->expectExceptionCode(1633093113);
-        $this->expectExceptionMessage('Invalid value `bool`, it must be one of `42`, `1337`.');
+        $this->expectExceptionMessage('Invalid value false, it must be one of 42, 1337.');
 
         $this->builder->build(Shell::root($type, false));
     }
@@ -77,7 +77,7 @@ final class EnumNodeBuilderTest extends TestCase
 
         $this->expectException(InvalidEnumValue::class);
         $this->expectExceptionCode(1633093113);
-        $this->expectExceptionMessage('Invalid value `stdClass`, it must be one of `42`, `1337`.');
+        $this->expectExceptionMessage('Invalid value object(stdClass), it must be one of 42, 1337.');
 
         $this->builder->build(Shell::root($type, new stdClass()));
     }

--- a/tests/Unit/Mapper/Tree/Builder/EnumNodeBuilderTest.php
+++ b/tests/Unit/Mapper/Tree/Builder/EnumNodeBuilderTest.php
@@ -8,8 +8,7 @@ use AssertionError;
 use CuyZ\Valinor\Mapper\Tree\Builder\EnumNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\RootNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Exception\InvalidEnumValue;
-use CuyZ\Valinor\Mapper\Tree\Shell;
-use CuyZ\Valinor\Tests\Fake\Type\FakeType;
+use CuyZ\Valinor\Tests\Fake\Mapper\FakeShell;
 use CuyZ\Valinor\Tests\Fixture\Enum\BackedIntegerEnum;
 use CuyZ\Valinor\Tests\Fixture\Enum\BackedStringEnum;
 use CuyZ\Valinor\Tests\Fixture\Enum\PureEnum;
@@ -35,7 +34,7 @@ final class EnumNodeBuilderTest extends TestCase
     {
         $this->expectException(AssertionError::class);
 
-        $this->builder->build(Shell::root(new FakeType(), []));
+        $this->builder->build(FakeShell::any());
     }
 
     public function test_invalid_value_throws_exception(): void
@@ -44,9 +43,9 @@ final class EnumNodeBuilderTest extends TestCase
 
         $this->expectException(InvalidEnumValue::class);
         $this->expectExceptionCode(1633093113);
-        $this->expectExceptionMessage("Invalid value 'foo', it must be one of 'FOO', 'BAR'.");
+        $this->expectExceptionMessage("Value 'foo' does not match any of 'FOO', 'BAR'.");
 
-        $this->builder->build(Shell::root($type, 'foo'));
+        $this->builder->build(FakeShell::new($type, 'foo'));
     }
 
     public function test_invalid_string_value_throws_exception(): void
@@ -55,9 +54,9 @@ final class EnumNodeBuilderTest extends TestCase
 
         $this->expectException(InvalidEnumValue::class);
         $this->expectExceptionCode(1633093113);
-        $this->expectExceptionMessage("Invalid value object(stdClass), it must be one of 'foo', 'bar'.");
+        $this->expectExceptionMessage("Value object(stdClass) does not match any of 'foo', 'bar'.");
 
-        $this->builder->build(Shell::root($type, new stdClass()));
+        $this->builder->build(FakeShell::new($type, new stdClass()));
     }
 
     public function test_boolean_instead_of_integer_value_throws_exception(): void
@@ -66,9 +65,9 @@ final class EnumNodeBuilderTest extends TestCase
 
         $this->expectException(InvalidEnumValue::class);
         $this->expectExceptionCode(1633093113);
-        $this->expectExceptionMessage('Invalid value false, it must be one of 42, 1337.');
+        $this->expectExceptionMessage('Value false does not match any of 42, 1337.');
 
-        $this->builder->build(Shell::root($type, false));
+        $this->builder->build(FakeShell::new($type, false));
     }
 
     public function test_invalid_integer_value_throws_exception(): void
@@ -77,8 +76,8 @@ final class EnumNodeBuilderTest extends TestCase
 
         $this->expectException(InvalidEnumValue::class);
         $this->expectExceptionCode(1633093113);
-        $this->expectExceptionMessage('Invalid value object(stdClass), it must be one of 42, 1337.');
+        $this->expectExceptionMessage('Value object(stdClass) does not match any of 42, 1337.');
 
-        $this->builder->build(Shell::root($type, new stdClass()));
+        $this->builder->build(FakeShell::new($type, new stdClass()));
     }
 }

--- a/tests/Unit/Mapper/Tree/Builder/ListNodeBuilderTest.php
+++ b/tests/Unit/Mapper/Tree/Builder/ListNodeBuilderTest.php
@@ -8,7 +8,7 @@ use AssertionError;
 use CuyZ\Valinor\Mapper\Tree\Builder\ListNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\RootNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Exception\SourceMustBeIterable;
-use CuyZ\Valinor\Mapper\Tree\Shell;
+use CuyZ\Valinor\Tests\Fake\Mapper\FakeShell;
 use CuyZ\Valinor\Tests\Fake\Type\FakeType;
 use CuyZ\Valinor\Type\Types\ListType;
 use PHPUnit\Framework\TestCase;
@@ -17,7 +17,7 @@ final class ListNodeBuilderTest extends TestCase
 {
     public function test_build_with_null_value_returns_empty_branch_node(): void
     {
-        $node = (new RootNodeBuilder(new ListNodeBuilder()))->build(Shell::root(ListType::native(), null));
+        $node = (new RootNodeBuilder(new ListNodeBuilder()))->build(FakeShell::new(ListType::native()));
 
         self::assertSame([], $node->value());
         self::assertEmpty($node->children());
@@ -27,15 +27,15 @@ final class ListNodeBuilderTest extends TestCase
     {
         $this->expectException(AssertionError::class);
 
-        (new RootNodeBuilder(new ListNodeBuilder()))->build(Shell::root(new FakeType(), []));
+        (new RootNodeBuilder(new ListNodeBuilder()))->build(FakeShell::new(new FakeType()));
     }
 
     public function test_build_with_invalid_source_throws_exception(): void
     {
         $this->expectException(SourceMustBeIterable::class);
         $this->expectExceptionCode(1618739163);
-        $this->expectExceptionMessage("Value 'foo' does not match expected `list`.");
+        $this->expectExceptionMessage("Value 'foo' does not match type `list`.");
 
-        (new RootNodeBuilder(new ListNodeBuilder()))->build(Shell::root(ListType::native(), 'foo'));
+        (new RootNodeBuilder(new ListNodeBuilder()))->build(FakeShell::new(ListType::native(), 'foo'));
     }
 }

--- a/tests/Unit/Mapper/Tree/Builder/ListNodeBuilderTest.php
+++ b/tests/Unit/Mapper/Tree/Builder/ListNodeBuilderTest.php
@@ -34,7 +34,7 @@ final class ListNodeBuilderTest extends TestCase
     {
         $this->expectException(SourceMustBeIterable::class);
         $this->expectExceptionCode(1618739163);
-        $this->expectExceptionMessage('Source must be iterable in order to be cast to `list`, but is of type `string`.');
+        $this->expectExceptionMessage("Value 'foo' does not match expected `list`.");
 
         (new RootNodeBuilder(new ListNodeBuilder()))->build(Shell::root(ListType::native(), 'foo'));
     }

--- a/tests/Unit/Mapper/Tree/Builder/ScalarNodeBuilderTest.php
+++ b/tests/Unit/Mapper/Tree/Builder/ScalarNodeBuilderTest.php
@@ -7,8 +7,7 @@ namespace CuyZ\Valinor\Tests\Unit\Mapper\Tree\Builder;
 use AssertionError;
 use CuyZ\Valinor\Mapper\Tree\Builder\RootNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\ScalarNodeBuilder;
-use CuyZ\Valinor\Mapper\Tree\Shell;
-use CuyZ\Valinor\Tests\Fake\Type\FakeType;
+use CuyZ\Valinor\Tests\Fake\Mapper\FakeShell;
 use PHPUnit\Framework\TestCase;
 
 final class ScalarNodeBuilderTest extends TestCase
@@ -17,6 +16,6 @@ final class ScalarNodeBuilderTest extends TestCase
     {
         $this->expectException(AssertionError::class);
 
-        (new RootNodeBuilder(new ScalarNodeBuilder()))->build(Shell::root(new FakeType(), []));
+        (new RootNodeBuilder(new ScalarNodeBuilder()))->build(FakeShell::any());
     }
 }

--- a/tests/Unit/Mapper/Tree/Builder/ShapedArrayNodeBuilderTest.php
+++ b/tests/Unit/Mapper/Tree/Builder/ShapedArrayNodeBuilderTest.php
@@ -9,7 +9,7 @@ use CuyZ\Valinor\Mapper\Tree\Builder\RootNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\ShapedArrayNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Exception\ShapedArrayElementMissing;
 use CuyZ\Valinor\Mapper\Tree\Exception\SourceMustBeIterable;
-use CuyZ\Valinor\Mapper\Tree\Shell;
+use CuyZ\Valinor\Tests\Fake\Mapper\FakeShell;
 use CuyZ\Valinor\Tests\Fake\Type\FakeObjectType;
 use CuyZ\Valinor\Tests\Fake\Type\FakeType;
 use CuyZ\Valinor\Type\Types\ShapedArrayElement;
@@ -23,7 +23,7 @@ final class ShapedArrayNodeBuilderTest extends TestCase
     {
         $this->expectException(AssertionError::class);
 
-        (new RootNodeBuilder(new ShapedArrayNodeBuilder()))->build(Shell::root(new FakeType(), []));
+        (new RootNodeBuilder(new ShapedArrayNodeBuilder()))->build(FakeShell::any());
     }
 
     public function test_build_with_invalid_source_throws_exception(): void
@@ -32,9 +32,9 @@ final class ShapedArrayNodeBuilderTest extends TestCase
 
         $this->expectException(SourceMustBeIterable::class);
         $this->expectExceptionCode(1618739163);
-        $this->expectExceptionMessage("Value 'foo' does not match expected `array{foo: SomeType}`.");
+        $this->expectExceptionMessage("Value 'foo' does not match type `array{foo: SomeType}`.");
 
-        (new RootNodeBuilder(new ShapedArrayNodeBuilder()))->build(Shell::root($type, 'foo'));
+        (new RootNodeBuilder(new ShapedArrayNodeBuilder()))->build(FakeShell::new($type, 'foo'));
     }
 
     public function test_build_with_invalid_source_for_shaped_array_containing_object_type_throws_exception(): void
@@ -43,9 +43,9 @@ final class ShapedArrayNodeBuilderTest extends TestCase
 
         $this->expectException(SourceMustBeIterable::class);
         $this->expectExceptionCode(1618739163);
-        $this->expectExceptionMessage("Value 'foo' is not accepted.");
+        $this->expectExceptionMessage("Invalid value 'foo'.");
 
-        (new RootNodeBuilder(new ShapedArrayNodeBuilder()))->build(Shell::root($type, 'foo'));
+        (new RootNodeBuilder(new ShapedArrayNodeBuilder()))->build(FakeShell::new($type, 'foo'));
     }
 
     public function test_build_with_null_source_throws_exception(): void
@@ -54,19 +54,19 @@ final class ShapedArrayNodeBuilderTest extends TestCase
 
         $this->expectException(SourceMustBeIterable::class);
         $this->expectExceptionCode(1618739163);
-        $this->expectExceptionMessage("Cannot be empty and must be filled with a value matching `array{foo: SomeType}`.");
+        $this->expectExceptionMessage("Cannot be empty and must be filled with a value matching type `array{foo: SomeType}`.");
 
-        (new RootNodeBuilder(new ShapedArrayNodeBuilder()))->build(Shell::root($type, null));
+        (new RootNodeBuilder(new ShapedArrayNodeBuilder()))->build(FakeShell::new($type));
     }
 
     public function test_build_with_missing_key_throws_exception(): void
     {
         $this->expectException(ShapedArrayElementMissing::class);
         $this->expectExceptionCode(1631613641);
-        $this->expectExceptionMessage("Missing element `foo` of type `SomeType`.");
+        $this->expectExceptionMessage("Missing element `foo` matching type `SomeType`.");
 
         $type = new ShapedArrayType(new ShapedArrayElement(new StringValueType('foo'), new FakeType('SomeType')));
 
-        (new RootNodeBuilder(new ShapedArrayNodeBuilder()))->build(Shell::root($type, []));
+        (new RootNodeBuilder(new ShapedArrayNodeBuilder()))->build(FakeShell::new($type, []));
     }
 }

--- a/tests/Unit/Mapper/Tree/Builder/ShapedArrayNodeBuilderTest.php
+++ b/tests/Unit/Mapper/Tree/Builder/ShapedArrayNodeBuilderTest.php
@@ -10,6 +10,7 @@ use CuyZ\Valinor\Mapper\Tree\Builder\ShapedArrayNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Exception\ShapedArrayElementMissing;
 use CuyZ\Valinor\Mapper\Tree\Exception\SourceMustBeIterable;
 use CuyZ\Valinor\Mapper\Tree\Shell;
+use CuyZ\Valinor\Tests\Fake\Type\FakeObjectType;
 use CuyZ\Valinor\Tests\Fake\Type\FakeType;
 use CuyZ\Valinor\Type\Types\ShapedArrayElement;
 use CuyZ\Valinor\Type\Types\ShapedArrayType;
@@ -31,7 +32,18 @@ final class ShapedArrayNodeBuilderTest extends TestCase
 
         $this->expectException(SourceMustBeIterable::class);
         $this->expectExceptionCode(1618739163);
-        $this->expectExceptionMessage("Source must be iterable in order to be cast to `$type`, but is of type `string`.");
+        $this->expectExceptionMessage("Value 'foo' does not match expected `array{foo: SomeType}`.");
+
+        (new RootNodeBuilder(new ShapedArrayNodeBuilder()))->build(Shell::root($type, 'foo'));
+    }
+
+    public function test_build_with_invalid_source_for_shaped_array_containing_object_type_throws_exception(): void
+    {
+        $type = new ShapedArrayType(new ShapedArrayElement(new StringValueType('foo'), new FakeObjectType()));
+
+        $this->expectException(SourceMustBeIterable::class);
+        $this->expectExceptionCode(1618739163);
+        $this->expectExceptionMessage("Value 'foo' is not accepted.");
 
         (new RootNodeBuilder(new ShapedArrayNodeBuilder()))->build(Shell::root($type, 'foo'));
     }
@@ -42,7 +54,7 @@ final class ShapedArrayNodeBuilderTest extends TestCase
 
         $this->expectException(SourceMustBeIterable::class);
         $this->expectExceptionCode(1618739163);
-        $this->expectExceptionMessage("Cannot cast an empty value to `$type`.");
+        $this->expectExceptionMessage("Cannot be empty and must be filled with a value matching `array{foo: SomeType}`.");
 
         (new RootNodeBuilder(new ShapedArrayNodeBuilder()))->build(Shell::root($type, null));
     }
@@ -51,7 +63,7 @@ final class ShapedArrayNodeBuilderTest extends TestCase
     {
         $this->expectException(ShapedArrayElementMissing::class);
         $this->expectExceptionCode(1631613641);
-        $this->expectExceptionMessage("Missing value `foo` of type `SomeType`.");
+        $this->expectExceptionMessage("Missing element `foo` of type `SomeType`.");
 
         $type = new ShapedArrayType(new ShapedArrayElement(new StringValueType('foo'), new FakeType('SomeType')));
 

--- a/tests/Unit/Mapper/Tree/Message/Formatter/AggregateMessageFormatterTest.php
+++ b/tests/Unit/Mapper/Tree/Message/Formatter/AggregateMessageFormatterTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Unit\Mapper\Tree\Message\Formatter;
+
+use CuyZ\Valinor\Mapper\Tree\Message\Formatter\AggregateMessageFormatter;
+use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeNodeMessage;
+use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\Formatter\FakeMessageFormatter;
+use PHPUnit\Framework\TestCase;
+
+final class AggregateMessageFormatterTest extends TestCase
+{
+    public function test_formatters_are_called_in_correct_order(): void
+    {
+        $formatter = new AggregateMessageFormatter(
+            new FakeMessageFormatter('message A'),
+            new FakeMessageFormatter('message B'),
+        );
+
+        $message = $formatter->format(FakeNodeMessage::any());
+
+        self::assertSame('message B', (string)$message);
+    }
+}

--- a/tests/Unit/Mapper/Tree/Message/Formatter/LocaleMessageFormatterTest.php
+++ b/tests/Unit/Mapper/Tree/Message/Formatter/LocaleMessageFormatterTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Unit\Mapper\Tree\Message\Formatter;
+
+use CuyZ\Valinor\Mapper\Tree\Message\Formatter\LocaleMessageFormatter;
+use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeNodeMessage;
+use PHPUnit\Framework\TestCase;
+
+final class LocaleMessageFormatterTest extends TestCase
+{
+    public function test_locale_is_updated_for_message(): void
+    {
+        $message = FakeNodeMessage::any();
+        $message = (new LocaleMessageFormatter('fr'))->format($message);
+
+        self::assertSame('fr', $message->locale());
+    }
+}

--- a/tests/Unit/Mapper/Tree/Message/Formatter/MessageMapFormatterTest.php
+++ b/tests/Unit/Mapper/Tree/Message/Formatter/MessageMapFormatterTest.php
@@ -6,65 +6,76 @@ namespace CuyZ\Valinor\Tests\Unit\Mapper\Tree\Message\Formatter;
 
 use CuyZ\Valinor\Mapper\Tree\Message\Formatter\MessageMapFormatter;
 use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
-use CuyZ\Valinor\Tests\Fake\Mapper\FakeNode;
 use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeMessage;
+use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeNodeMessage;
 use PHPUnit\Framework\TestCase;
 
 final class MessageMapFormatterTest extends TestCase
 {
     public function test_format_finds_code_returns_formatted_content(): void
     {
-        $message = new NodeMessage(FakeNode::any(), new FakeMessage());
-        $formatter = new MessageMapFormatter([
-            'some_code' => 'foo',
-        ]);
+        $formatter = (new MessageMapFormatter([
+            'some_code' => 'ok',
+            'some message' => 'nope',
+            FakeMessage::class => 'nope',
+        ]))->defaultsTo('nope');
 
-        self::assertSame('foo', $formatter->format($message));
+        $message = $formatter->format(FakeNodeMessage::any());
+
+        self::assertSame('ok', (string)$message);
     }
 
     public function test_format_finds_code_returns_formatted_content_from_callback(): void
     {
-        $message = new NodeMessage(FakeNode::any(), new FakeMessage());
-        $formatter = new MessageMapFormatter([
-            'some_code' => fn (NodeMessage $message) => "foo $message",
-        ]);
+        $formatter = (new MessageMapFormatter([
+            'some_code' => fn (NodeMessage $message) => "ok $message",
+            'some message' => 'nope',
+            FakeMessage::class => 'nope',
+        ]))->defaultsTo('nope');
 
-        self::assertSame('foo some message', $formatter->format($message));
+        $message = $formatter->format(FakeNodeMessage::any());
+
+        self::assertSame('ok some message', (string)$message);
     }
 
-    public function test_format_finds_content_returns_formatted_content(): void
+    public function test_format_finds_body_returns_formatted_content(): void
     {
-        $message = new NodeMessage(FakeNode::any(), new FakeMessage());
-        $formatter = new MessageMapFormatter([
-            'some message' => 'foo',
-        ]);
+        $formatter = (new MessageMapFormatter([
+            'some message' => 'ok',
+            FakeMessage::class => 'nope',
+        ]))->defaultsTo('nope');
 
-        self::assertSame('foo', $formatter->format($message));
+        $message = $formatter->format(FakeNodeMessage::any());
+
+        self::assertSame('ok', (string)$message);
     }
 
     public function test_format_finds_class_name_returns_formatted_content(): void
     {
-        $message = new NodeMessage(FakeNode::any(), new FakeMessage());
-        $formatter = new MessageMapFormatter([
+        $formatter = (new MessageMapFormatter([
             FakeMessage::class => 'foo',
-        ]);
+        ]))->defaultsTo('nope');
 
-        self::assertSame('foo', $formatter->format($message));
+        $message = $formatter->format(FakeNodeMessage::any());
+
+        self::assertSame('foo', (string)$message);
     }
 
     public function test_format_does_not_find_any_returns_default(): void
     {
-        $message = new NodeMessage(FakeNode::any(), new FakeMessage());
         $formatter = (new MessageMapFormatter([]))->defaultsTo('foo');
 
-        self::assertSame('foo', $formatter->format($message));
+        $message = $formatter->format(FakeNodeMessage::any());
+
+        self::assertSame('foo', (string)$message);
     }
 
     public function test_format_does_not_find_any_returns_message_content(): void
     {
-        $message = new NodeMessage(FakeNode::any(), new FakeMessage());
         $formatter = new MessageMapFormatter([]);
 
-        self::assertSame('some message', $formatter->format($message));
+        $message = $formatter->format(FakeNodeMessage::any());
+
+        self::assertSame('some message', (string)$message);
     }
 }

--- a/tests/Unit/Mapper/Tree/Message/Formatter/PlaceHolderMessageFormatterTest.php
+++ b/tests/Unit/Mapper/Tree/Message/Formatter/PlaceHolderMessageFormatterTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Unit\Mapper\Tree\Message\Formatter;
+
+use CuyZ\Valinor\Mapper\Tree\Message\Formatter\PlaceHolderMessageFormatter;
+use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
+use CuyZ\Valinor\Tests\Fake\Mapper\FakeShell;
+use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeErrorMessage;
+use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeMessage;
+use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\Formatter\FakeMessageFormatter;
+use CuyZ\Valinor\Tests\Fake\Type\FakeType;
+use PHPUnit\Framework\TestCase;
+
+final class PlaceHolderMessageFormatterTest extends TestCase
+{
+    public function test_format_message_replaces_placeholders_with_default_values(): void
+    {
+        $type = FakeType::permissive();
+        $shell = FakeShell::any()->child('foo', $type, 'some value');
+
+        $message = new NodeMessage($shell, new FakeMessage('some message'));
+        $message = (new FakeMessageFormatter('%1$s / %2$s / %3$s / %4$s / %5$s'))->format($message);
+        $message = (new PlaceHolderMessageFormatter())->format($message);
+
+        self::assertSame("some_code / some message / `$type` / foo / foo", (string)$message);
+    }
+
+    public function test_format_message_replaces_correct_original_value_if_throwable(): void
+    {
+        $message = new NodeMessage(FakeShell::any(), new FakeErrorMessage('some error message'));
+        $message = (new FakeMessageFormatter('original: %2$s'))->format($message);
+        $message = (new PlaceHolderMessageFormatter())->format($message);
+
+        self::assertSame('original: some error message', (string)$message);
+    }
+
+    public function test_format_message_replaces_placeholders_with_given_values(): void
+    {
+        $formatter = new PlaceHolderMessageFormatter('foo', 'bar');
+
+        $message = new NodeMessage(FakeShell::any(), new FakeMessage('%1$s / %2$s'));
+        $message = $formatter->format($message);
+
+        self::assertSame('foo / bar', (string)$message);
+    }
+}

--- a/tests/Unit/Mapper/Tree/Message/Formatter/TranslationMessageFormatterTest.php
+++ b/tests/Unit/Mapper/Tree/Message/Formatter/TranslationMessageFormatterTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Unit\Mapper\Tree\Message\Formatter;
+
+use CuyZ\Valinor\Mapper\Tree\Message\Formatter\TranslationMessageFormatter;
+use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
+use CuyZ\Valinor\Tests\Fake\Mapper\FakeShell;
+use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeMessage;
+use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeNodeMessage;
+use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeTranslatableMessage;
+use PHPUnit\Framework\TestCase;
+
+final class TranslationMessageFormatterTest extends TestCase
+{
+    public function test_format_message_formats_message_correctly(): void
+    {
+        $formatter = (new TranslationMessageFormatter())->withTranslations([
+            'some key' => [
+                'en' => 'some message',
+            ],
+        ]);
+
+        $message = new NodeMessage(FakeShell::any(), new FakeMessage('some key'));
+        $message = $formatter->format($message);
+
+        self::assertSame('some message', (string)$message);
+    }
+
+    public function test_format_message_with_added_translation_formats_message_correctly(): void
+    {
+        $formatter = (new TranslationMessageFormatter())->withTranslations([
+            'some key' => [
+                'en' => 'some message',
+            ],
+        ])->withTranslation(
+            'en',
+            'some key',
+            'some other message'
+        );
+
+        $message = new NodeMessage(FakeShell::any(), new FakeMessage('some key'));
+        $message = $formatter->format($message);
+
+        self::assertSame('some other message', (string)$message);
+    }
+
+    public function test_format_message_with_overridden_translations_formats_message_correctly(): void
+    {
+        $formatter = (new TranslationMessageFormatter())
+            ->withTranslations([
+                'some key' => [
+                    'en' => 'some message',
+                ],
+            ])->withTranslations([
+                'some key' => [
+                    'en' => 'some other message',
+                ],
+            ]);
+
+        $message = new NodeMessage(FakeShell::any(), new FakeMessage('some key'));
+        $message = $formatter->format($message);
+
+        self::assertSame('some other message', (string)$message);
+    }
+
+    public function test_format_message_with_overridden_translations_keeps_other_translations(): void
+    {
+        $formatter = (new TranslationMessageFormatter())
+            ->withTranslations([
+                'some key' => [
+                    'en' => 'some message',
+                ],
+                'some other key' => [
+                    'en' => 'some other message',
+                ],
+            ])->withTranslations([
+                'some key' => [
+                    'en' => 'some new message',
+                ],
+            ]);
+
+        $message = new NodeMessage(FakeShell::any(), new FakeMessage('some other key'));
+        $message = $formatter->format($message);
+
+        self::assertSame('some other message', (string)$message);
+    }
+
+    public function test_format_message_with_default_translations_formats_message_correctly(): void
+    {
+        $formatter = TranslationMessageFormatter::default()->withTranslation(
+            'en',
+            'Value {value} is not accepted.',
+            'Value {value} is not accepted!'
+        );
+
+        $originalMessage = new FakeTranslatableMessage('Value {value} is not accepted.', ['value' => 'foo']);
+        $message = new NodeMessage(FakeShell::any(), $originalMessage);
+        $message = $formatter->format($message);
+
+        self::assertSame('Value foo is not accepted!', (string)$message);
+    }
+
+    public function test_format_message_with_unknown_translation_returns_same_instance(): void
+    {
+        $messageA = FakeNodeMessage::any();
+        $messageB = (new TranslationMessageFormatter())->format($messageA);
+
+        self::assertSame($messageA, $messageB);
+    }
+
+    public function test_with_translation_returns_clone(): void
+    {
+        $formatterA = new TranslationMessageFormatter();
+        $formatterB = $formatterA->withTranslation('en', 'some message', 'some other message');
+
+        self::assertNotSame($formatterA, $formatterB);
+    }
+
+    public function test_with_translations_returns_clone(): void
+    {
+        $formatterA = new TranslationMessageFormatter();
+        $formatterB = $formatterA->withTranslations([
+            'some message' => [
+                'en' => 'some other message',
+            ],
+        ]);
+
+        self::assertNotSame($formatterA, $formatterB);
+    }
+}

--- a/tests/Unit/Mapper/Tree/Message/NodeMessageTest.php
+++ b/tests/Unit/Mapper/Tree/Message/NodeMessageTest.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Unit\Mapper\Tree\Message;
 
+use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
 use CuyZ\Valinor\Tests\Fake\Definition\FakeAttributes;
-use CuyZ\Valinor\Tests\Fake\Mapper\FakeNode;
+use CuyZ\Valinor\Tests\Fake\Mapper\FakeShell;
 use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeErrorMessage;
 use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeMessage;
+use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeNodeMessage;
+use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeTranslatableMessage;
+use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\Formatter\FakeMessageFormatter;
 use CuyZ\Valinor\Tests\Fake\Type\FakeType;
 use PHPUnit\Framework\TestCase;
 
@@ -20,15 +24,8 @@ final class NodeMessageTest extends TestCase
         $type = FakeType::permissive();
         $attributes = new FakeAttributes();
 
-        $node = FakeNode::branch([[
-            'name' => 'foo',
-            'type' => $type,
-            'value' => 'some value',
-            'attributes' => $attributes,
-            'message' => $originalMessage
-        ]])->children()['foo'];
-
-        $message = new NodeMessage($node, $originalMessage);
+        $shell = FakeShell::any()->child('foo', $type, 'some value', $attributes);
+        $message = new NodeMessage($shell, $originalMessage);
 
         self::assertSame('foo', $message->name());
         self::assertSame('foo', $message->path());
@@ -38,42 +35,84 @@ final class NodeMessageTest extends TestCase
         self::assertSame($originalMessage, $message->originalMessage());
     }
 
-    public function test_value_from_invalid_node_returns_null(): void
+    public function test_message_is_error_if_original_message_is_throwable(): void
     {
         $originalMessage = new FakeErrorMessage();
-        $node = FakeNode::leaf(FakeType::permissive(), 'foo')->withMessage($originalMessage);
+        $message = new NodeMessage(FakeShell::any(), $originalMessage);
 
-        $message = new NodeMessage($node, $originalMessage);
-
-        self::assertNull($message->value());
+        self::assertTrue($message->isError());
+        self::assertSame('1652883436', $message->code());
+        self::assertSame('some error message', $message->body());
     }
 
-    public function test_format_message_replaces_placeholders_with_default_values(): void
+    public function test_parameters_are_replaced_in_body(): void
     {
-        $originalMessage = new FakeMessage();
+        $originalMessage = new FakeTranslatableMessage('some original message', ['some_parameter' => 'some parameter value']);
         $type = FakeType::permissive();
+        $shell = FakeShell::any()->child('foo', $type, 'some value');
 
-        $node = FakeNode::branch([[
-            'name' => 'foo',
-            'type' => $type,
-            'value' => 'some value',
-            'message' => $originalMessage
-        ]])->children()['foo'];
+        $message = new NodeMessage($shell, $originalMessage);
+        $message = $message->withBody('{message_code} / {node_name} / {node_path} / {node_type} / {original_value} / {original_message} / {some_parameter}');
 
-        $message = new NodeMessage($node, $originalMessage);
-        $text = $message->format('%1$s / %2$s / %3$s / %4$s / %5$s');
-
-        self::assertSame("some_code / some message / $type / foo / foo", $text);
+        self::assertSame("1652902453 / foo / foo / `$type` / 'some value' / some original message (toString) / some parameter value", (string)$message);
     }
 
-    public function test_format_message_replaces_placeholders_with_given_values(): void
+    public function test_replaces_correct_original_message_if_throwable(): void
     {
-        $originalMessage = new FakeMessage();
-        $node = FakeNode::any();
+        $message = new NodeMessage(FakeShell::any(), new FakeErrorMessage('some error message'));
+        $message = $message->withBody('original: {original_message}');
 
-        $message = new NodeMessage($node, $originalMessage);
-        $text = $message->format('%1$s / %2$s', 'foo', 'bar');
+        self::assertSame('original: some error message', (string)$message);
+    }
 
-        self::assertSame('foo / bar', $text);
+    public function test_format_message_uses_formatter_to_replace_content(): void
+    {
+        $originalMessage = new FakeMessage('some message');
+
+        $message = new NodeMessage(FakeShell::any(), $originalMessage);
+        $formattedMessage = (new FakeMessageFormatter())->format($message);
+
+        self::assertNotSame($message, $formattedMessage);
+        self::assertSame('formatted: some message', (string)$formattedMessage);
+    }
+
+    public function test_custom_body_returns_clone(): void
+    {
+        $messageA = FakeNodeMessage::any();
+        $messageB = $messageA->withBody('some other message');
+
+        self::assertNotSame($messageA, $messageB);
+    }
+
+    public function test_custom_locale_returns_clone(): void
+    {
+        $messageA = FakeNodeMessage::any();
+        $messageB = $messageA->withLocale('fr');
+
+        self::assertNotSame($messageA, $messageB);
+    }
+
+    public function test_custom_locale_is_used(): void
+    {
+        $originalMessage = new FakeTranslatableMessage('un message: {value, spellout}', ['value' => '42']);
+
+        $message = new NodeMessage(FakeShell::any(), $originalMessage);
+        $message = $message->withLocale('fr');
+
+        self::assertSame('un message: quarante-deux', (string)$message);
+    }
+
+    public function test_message_with_no_code_returns_unknown(): void
+    {
+        $originalMessage = new class () implements Message {
+            public function __toString(): string
+            {
+                return 'some message';
+            }
+        };
+
+        $message = new NodeMessage(FakeShell::any(), $originalMessage);
+
+        self::assertSame('unknown', $message->code());
     }
 }

--- a/tests/Unit/Mapper/Tree/NodeTest.php
+++ b/tests/Unit/Mapper/Tree/NodeTest.php
@@ -11,8 +11,10 @@ use CuyZ\Valinor\Tests\Fake\Definition\FakeAttributes;
 use CuyZ\Valinor\Tests\Fake\Mapper\FakeNode;
 use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeErrorMessage;
 use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeMessage;
+use CuyZ\Valinor\Tests\Fake\Type\FakeObjectType;
 use CuyZ\Valinor\Tests\Fake\Type\FakeType;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 final class NodeTest extends TestCase
 {
@@ -35,7 +37,7 @@ final class NodeTest extends TestCase
 
         $this->expectException(InvalidNodeValue::class);
         $this->expectExceptionCode(1630678334);
-        $this->expectExceptionMessage("Value of type `string` is not accepted by type `$type`.");
+        $this->expectExceptionMessage("Value 'foo' does not match expected `$type`.");
 
         FakeNode::leaf($type, 'foo');
     }
@@ -80,7 +82,7 @@ final class NodeTest extends TestCase
 
         $this->expectException(InvalidNodeValue::class);
         $this->expectExceptionCode(1630678334);
-        $this->expectExceptionMessage("Value of type `string` is not accepted by type `$type`.");
+        $this->expectExceptionMessage("Value 'foo' does not match expected `$type`.");
 
         FakeNode::branch([], $type, 'foo');
     }
@@ -131,9 +133,21 @@ final class NodeTest extends TestCase
 
         $this->expectException(InvalidNodeValue::class);
         $this->expectExceptionCode(1630678334);
-        $this->expectExceptionMessage("Value of type `int` is not accepted by type `$type`.");
+        $this->expectExceptionMessage("Value 1337 does not match expected `$type`.");
 
         FakeNode::leaf($type, 'foo')->withValue(1337);
+    }
+
+    public function test_node_with_invalid_value_for_object_type_returns_invalid_node(): void
+    {
+        $object = new stdClass();
+        $type = FakeObjectType::accepting($object);
+
+        $this->expectException(InvalidNodeValue::class);
+        $this->expectExceptionCode(1630678334);
+        $this->expectExceptionMessage("Value 1337 is not accepted.");
+
+        FakeNode::leaf($type, $object)->withValue(1337);
     }
 
     public function test_node_with_messages_returns_node_with_messages(): void

--- a/tests/Unit/Mapper/Tree/NodeTest.php
+++ b/tests/Unit/Mapper/Tree/NodeTest.php
@@ -37,7 +37,7 @@ final class NodeTest extends TestCase
 
         $this->expectException(InvalidNodeValue::class);
         $this->expectExceptionCode(1630678334);
-        $this->expectExceptionMessage("Value 'foo' does not match expected `$type`.");
+        $this->expectExceptionMessage("Value 'foo' does not match type `$type`.");
 
         FakeNode::leaf($type, 'foo');
     }
@@ -82,7 +82,7 @@ final class NodeTest extends TestCase
 
         $this->expectException(InvalidNodeValue::class);
         $this->expectExceptionCode(1630678334);
-        $this->expectExceptionMessage("Value 'foo' does not match expected `$type`.");
+        $this->expectExceptionMessage("Value 'foo' does not match type `$type`.");
 
         FakeNode::branch([], $type, 'foo');
     }
@@ -93,7 +93,7 @@ final class NodeTest extends TestCase
         $node = FakeNode::error($message);
 
         self::assertFalse($node->isValid());
-        self::assertSame((string)$message, (string)$node->messages()[0]);
+        self::assertSame('some error message', (string)$node->messages()[0]);
     }
 
     public function test_get_value_from_invalid_node_throws_exception(): void
@@ -133,7 +133,7 @@ final class NodeTest extends TestCase
 
         $this->expectException(InvalidNodeValue::class);
         $this->expectExceptionCode(1630678334);
-        $this->expectExceptionMessage("Value 1337 does not match expected `$type`.");
+        $this->expectExceptionMessage("Value 1337 does not match type `$type`.");
 
         FakeNode::leaf($type, 'foo')->withValue(1337);
     }
@@ -145,7 +145,7 @@ final class NodeTest extends TestCase
 
         $this->expectException(InvalidNodeValue::class);
         $this->expectExceptionCode(1630678334);
-        $this->expectExceptionMessage("Value 1337 is not accepted.");
+        $this->expectExceptionMessage('Invalid value 1337.');
 
         FakeNode::leaf($type, $object)->withValue(1337);
     }
@@ -174,7 +174,7 @@ final class NodeTest extends TestCase
 
         self::assertNotSame($nodeA, $nodeB);
         self::assertFalse($nodeB->isValid());
-        self::assertSame((string)$message, (string)$nodeB->messages()[0]);
-        self::assertSame((string)$errorMessage, (string)$nodeB->messages()[1]);
+        self::assertSame('some message', (string)$nodeB->messages()[0]);
+        self::assertSame('some error message', (string)$nodeB->messages()[1]);
     }
 }

--- a/tests/Unit/Type/Resolver/Union/UnionNullNarrowerTest.php
+++ b/tests/Unit/Type/Resolver/Union/UnionNullNarrowerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Unit\Type\Resolver\Union;
 
+use CuyZ\Valinor\Tests\Fake\Type\FakeObjectType;
 use CuyZ\Valinor\Tests\Fake\Type\FakeType;
 use CuyZ\Valinor\Tests\Fake\Type\Resolver\Union\FakeUnionNarrower;
 use CuyZ\Valinor\Type\Resolver\Exception\UnionTypeDoesNotAllowNull;
@@ -53,7 +54,18 @@ final class UnionNullNarrowerTest extends TestCase
 
         $this->expectException(UnionTypeDoesNotAllowNull::class);
         $this->expectExceptionCode(1618742357);
-        $this->expectExceptionMessage("Cannot assign an empty value to union type `$unionType`.");
+        $this->expectExceptionMessage("Cannot be empty and must be filled with a value matching `$unionType`.");
+
+        $this->unionNullNarrower->narrow($unionType, null);
+    }
+
+    public function test_null_value_not_allowed_by_union_type_containing_object_type_throws_exception(): void
+    {
+        $unionType = new UnionType(new FakeType(), new FakeObjectType());
+
+        $this->expectException(UnionTypeDoesNotAllowNull::class);
+        $this->expectExceptionCode(1618742357);
+        $this->expectExceptionMessage('Cannot be empty.');
 
         $this->unionNullNarrower->narrow($unionType, null);
     }

--- a/tests/Unit/Type/Resolver/Union/UnionNullNarrowerTest.php
+++ b/tests/Unit/Type/Resolver/Union/UnionNullNarrowerTest.php
@@ -54,7 +54,7 @@ final class UnionNullNarrowerTest extends TestCase
 
         $this->expectException(UnionTypeDoesNotAllowNull::class);
         $this->expectExceptionCode(1618742357);
-        $this->expectExceptionMessage("Cannot be empty and must be filled with a value matching `$unionType`.");
+        $this->expectExceptionMessage("Cannot be empty and must be filled with a value matching type `$unionType`.");
 
         $this->unionNullNarrower->narrow($unionType, null);
     }

--- a/tests/Unit/Type/Resolver/Union/UnionScalarNarrowerTest.php
+++ b/tests/Unit/Type/Resolver/Union/UnionScalarNarrowerTest.php
@@ -112,7 +112,7 @@ final class UnionScalarNarrowerTest extends TestCase
 
         $this->expectException(CannotResolveTypeFromUnion::class);
         $this->expectExceptionCode(1607027306);
-        $this->expectExceptionMessage("Value 'foo' is not accepted.");
+        $this->expectExceptionMessage("Invalid value 'foo'.");
 
         $this->unionScalarNarrower->narrow($unionType, 'foo');
     }

--- a/tests/Unit/Type/Resolver/Union/UnionScalarNarrowerTest.php
+++ b/tests/Unit/Type/Resolver/Union/UnionScalarNarrowerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Unit\Type\Resolver\Union;
 
-use CuyZ\Valinor\Tests\Fake\Type\FakeType;
+use CuyZ\Valinor\Tests\Fake\Type\FakeObjectType;
 use CuyZ\Valinor\Type\IntegerType;
 use CuyZ\Valinor\Type\Resolver\Exception\CannotResolveTypeFromUnion;
 use CuyZ\Valinor\Type\Resolver\Union\UnionScalarNarrower;
@@ -101,18 +101,29 @@ final class UnionScalarNarrowerTest extends TestCase
 
         $this->expectException(CannotResolveTypeFromUnion::class);
         $this->expectExceptionCode(1607027306);
-        $this->expectExceptionMessage("Impossible to resolve the type from the union `$unionType` with a value of type `string`.");
+        $this->expectExceptionMessage("Value 'foo' does not match any of `bool`, `int`, `float`.");
 
-        $this->unionScalarNarrower->narrow($unionType, '42');
+        $this->unionScalarNarrower->narrow($unionType, 'foo');
+    }
+
+    public function test_several_possible_types_with_object_throws_exception(): void
+    {
+        $unionType = new UnionType(new FakeObjectType(), NativeIntegerType::get(), NativeFloatType::get());
+
+        $this->expectException(CannotResolveTypeFromUnion::class);
+        $this->expectExceptionCode(1607027306);
+        $this->expectExceptionMessage("Value 'foo' is not accepted.");
+
+        $this->unionScalarNarrower->narrow($unionType, 'foo');
     }
 
     public function test_null_value_but_null_not_in_union_throws_exception(): void
     {
-        $unionType = new UnionType(new FakeType(), new FakeType());
+        $unionType = new UnionType(NativeBooleanType::get(), NativeIntegerType::get(), NativeFloatType::get());
 
         $this->expectException(CannotResolveTypeFromUnion::class);
         $this->expectExceptionCode(1607027306);
-        $this->expectExceptionMessage("Impossible to resolve the type from the union `$unionType` with a value of type `null`.");
+        $this->expectExceptionMessage("Value null does not match any of `bool`, `int`, `float`.");
 
         $this->unionScalarNarrower->narrow($unionType, null);
     }

--- a/tests/Unit/Type/Types/ArrayKeyTypeTest.php
+++ b/tests/Unit/Type/Types/ArrayKeyTypeTest.php
@@ -110,7 +110,7 @@ final class ArrayKeyTypeTest extends TestCase
     {
         $this->expectException(CannotCastValue::class);
         $this->expectExceptionCode(1603216198);
-        $this->expectExceptionMessage('Cannot cast from `stdClass` to `array-key`.');
+        $this->expectExceptionMessage('Cannot cast object(stdClass) to `array-key`.');
 
         ArrayKeyType::default()->cast(new stdClass());
     }

--- a/tests/Unit/Type/Types/BooleanValueTypeTest.php
+++ b/tests/Unit/Type/Types/BooleanValueTypeTest.php
@@ -112,7 +112,7 @@ final class BooleanValueTypeTest extends TestCase
     {
         $this->expectException(CannotCastValue::class);
         $this->expectExceptionCode(1603216198);
-        $this->expectExceptionMessage('Cannot cast from `string` to `true`.');
+        $this->expectExceptionMessage("Cannot cast 'foo' to `true`.");
 
         BooleanValueType::true()->cast('foo');
     }
@@ -121,7 +121,7 @@ final class BooleanValueTypeTest extends TestCase
     {
         $this->expectException(CannotCastValue::class);
         $this->expectExceptionCode(1603216198);
-        $this->expectExceptionMessage('Cannot cast from `string` to `false`.');
+        $this->expectExceptionMessage("Cannot cast 'foo' to `false`.");
 
         BooleanValueType::false()->cast('foo');
     }

--- a/tests/Unit/Type/Types/ClassStringTypeTest.php
+++ b/tests/Unit/Type/Types/ClassStringTypeTest.php
@@ -144,7 +144,7 @@ final class ClassStringTypeTest extends TestCase
     {
         $this->expectException(CannotCastValue::class);
         $this->expectExceptionCode(1603216198);
-        $this->expectExceptionMessage('Cannot cast from `int` to `class-string`.');
+        $this->expectExceptionMessage('Cannot cast 42 to `class-string`.');
 
         (new ClassStringType())->cast(42);
     }

--- a/tests/Unit/Type/Types/ClassStringTypeTest.php
+++ b/tests/Unit/Type/Types/ClassStringTypeTest.php
@@ -200,10 +200,9 @@ final class ClassStringTypeTest extends TestCase
     public function test_matches_same_type_with_object_type(): void
     {
         $objectTypeA = new FakeObjectType();
-        $objectTypeB = new FakeObjectType();
-        $objectTypeA->willMatch($objectTypeB);
+        $objectTypeB = FakeObjectType::matching($objectTypeA);
 
-        self::assertTrue((new ClassStringType($objectTypeA))->matches(new ClassStringType($objectTypeB)));
+        self::assertTrue((new ClassStringType($objectTypeB))->matches(new ClassStringType($objectTypeA)));
     }
 
     public function test_does_not_match_same_type_with_no_object_type(): void
@@ -242,16 +241,15 @@ final class ClassStringTypeTest extends TestCase
     public function test_matches_union_containing_valid_type(): void
     {
         $objectTypeA = new FakeObjectType();
-        $objectTypeB = new FakeObjectType();
-        $objectTypeA->willMatch($objectTypeB);
+        $objectTypeB = FakeObjectType::matching($objectTypeA);
 
         $unionType = new UnionType(
             new FakeType(),
-            new ClassStringType($objectTypeB),
+            new ClassStringType($objectTypeA),
             new FakeType(),
         );
 
-        self::assertTrue((new ClassStringType($objectTypeA))->matches($unionType));
+        self::assertTrue((new ClassStringType($objectTypeB))->matches($unionType));
     }
 
     public function test_does_not_match_union_containing_invalid_type(): void

--- a/tests/Unit/Type/Types/FloatValueTypeTest.php
+++ b/tests/Unit/Type/Types/FloatValueTypeTest.php
@@ -72,7 +72,7 @@ final class FloatValueTypeTest extends TestCase
     {
         $this->expectException(InvalidFloatValueType::class);
         $this->expectExceptionCode(1652110003);
-        $this->expectExceptionMessage('Value of type `string` does not match float value `1337.42`.');
+        $this->expectExceptionMessage("Value 'foo' does not match float value 1337.42.");
 
         $this->floatValueType->cast('foo');
     }
@@ -81,7 +81,7 @@ final class FloatValueTypeTest extends TestCase
     {
         $this->expectException(InvalidFloatValue::class);
         $this->expectExceptionCode(1652110115);
-        $this->expectExceptionMessage('Value `404.42` does not match expected value `1337.42`.');
+        $this->expectExceptionMessage('Value 404.42 does not match expected 1337.42.');
 
         $this->floatValueType->cast('404.42');
     }

--- a/tests/Unit/Type/Types/IntegerRangeTypeTest.php
+++ b/tests/Unit/Type/Types/IntegerRangeTypeTest.php
@@ -115,7 +115,7 @@ final class IntegerRangeTypeTest extends TestCase
     {
         $this->expectException(CannotCastValue::class);
         $this->expectExceptionCode(1603216198);
-        $this->expectExceptionMessage("Cannot cast from `string` to `$this->type`.");
+        $this->expectExceptionMessage("Cannot cast 'foo' to `$this->type`.");
 
         $this->type->cast('foo');
     }
@@ -124,7 +124,7 @@ final class IntegerRangeTypeTest extends TestCase
     {
         $this->expectException(InvalidIntegerRangeValue::class);
         $this->expectExceptionCode(1638785150);
-        $this->expectExceptionMessage("Invalid value `1337`: it must be an integer between {$this->type->min()} and {$this->type->max()}.");
+        $this->expectExceptionMessage("Invalid value 1337: it must be an integer between {$this->type->min()} and {$this->type->max()}.");
 
         $this->type->cast(1337);
     }

--- a/tests/Unit/Type/Types/IntegerValueTypeTest.php
+++ b/tests/Unit/Type/Types/IntegerValueTypeTest.php
@@ -98,7 +98,7 @@ final class IntegerValueTypeTest extends TestCase
     {
         $this->expectException(InvalidIntegerValueType::class);
         $this->expectExceptionCode(1631267159);
-        $this->expectExceptionMessage('Value of type `string` does not match integer value `1337`.');
+        $this->expectExceptionMessage("Value 'foo' does not match integer value 1337.");
 
         $this->type->cast('foo');
     }
@@ -107,7 +107,7 @@ final class IntegerValueTypeTest extends TestCase
     {
         $this->expectException(InvalidIntegerValue::class);
         $this->expectExceptionCode(1631090798);
-        $this->expectExceptionMessage('Value `42` does not match integer value `1337`.');
+        $this->expectExceptionMessage('Value 42 does not match expected 1337.');
 
         $this->type->cast('42');
     }

--- a/tests/Unit/Type/Types/IntersectionTypeTest.php
+++ b/tests/Unit/Type/Types/IntersectionTypeTest.php
@@ -41,15 +41,11 @@ final class IntersectionTypeTest extends TestCase
 
     public function test_accepts_correct_values(): void
     {
-        $typeA = new FakeObjectType();
-        $typeB = new FakeObjectType();
-        $typeC = new FakeObjectType();
-
         $object = new stdClass();
 
-        $typeA->willAccept($object);
-        $typeB->willAccept($object);
-        $typeC->willAccept($object);
+        $typeA = FakeObjectType::accepting($object);
+        $typeB = FakeObjectType::accepting($object);
+        $typeC = FakeObjectType::accepting($object);
 
         $intersectionType = new IntersectionType($typeA, $typeB, $typeC);
 
@@ -76,15 +72,12 @@ final class IntersectionTypeTest extends TestCase
     public function test_matches_valid_type(): void
     {
         $objectTypeA = new FakeObjectType();
-        $objectTypeB = new FakeObjectType();
-        $objectTypeC = new FakeObjectType();
+        $objectTypeB = FakeObjectType::matching($objectTypeA);
+        $objectTypeC = FakeObjectType::matching($objectTypeA);
 
-        $intersectionType = new IntersectionType($objectTypeA, $objectTypeB);
+        $intersectionType = new IntersectionType($objectTypeB, $objectTypeC);
 
-        $objectTypeA->willMatch($objectTypeC);
-        $objectTypeB->willMatch($objectTypeC);
-
-        self::assertTrue($intersectionType->matches($objectTypeC));
+        self::assertTrue($intersectionType->matches($objectTypeA));
     }
 
     public function test_does_not_match_invalid_type(): void
@@ -111,16 +104,14 @@ final class IntersectionTypeTest extends TestCase
     public function test_matches_union_containing_valid_type(): void
     {
         $objectTypeA = new FakeObjectType();
-        $objectTypeB = new FakeObjectType();
-        $objectTypeC = new FakeObjectType();
-        $objectTypeA->willMatch($objectTypeC);
-        $objectTypeB->willMatch($objectTypeC);
+        $objectTypeB = FakeObjectType::matching($objectTypeA);
+        $objectTypeC = FakeObjectType::matching($objectTypeA);
 
-        $intersectionType = new IntersectionType($objectTypeA, $objectTypeB);
+        $intersectionType = new IntersectionType($objectTypeB, $objectTypeC);
 
         $unionType = new UnionType(
             new FakeType(),
-            $objectTypeC,
+            $objectTypeA,
             new FakeType(),
         );
 

--- a/tests/Unit/Type/Types/NativeBooleanTypeTest.php
+++ b/tests/Unit/Type/Types/NativeBooleanTypeTest.php
@@ -111,7 +111,7 @@ final class NativeBooleanTypeTest extends TestCase
     {
         $this->expectException(CannotCastValue::class);
         $this->expectExceptionCode(1603216198);
-        $this->expectExceptionMessage('Cannot cast from `string` to `bool`.');
+        $this->expectExceptionMessage("Cannot cast 'foo' to `bool`.");
 
         $this->booleanType->cast('foo');
     }

--- a/tests/Unit/Type/Types/NativeFloatTypeTest.php
+++ b/tests/Unit/Type/Types/NativeFloatTypeTest.php
@@ -89,7 +89,7 @@ final class NativeFloatTypeTest extends TestCase
     {
         $this->expectException(CannotCastValue::class);
         $this->expectExceptionCode(1603216198);
-        $this->expectExceptionMessage('Cannot cast from `string` to `float`.');
+        $this->expectExceptionMessage("Cannot cast 'foo' to `float`.");
 
         $this->floatType->cast('foo');
     }

--- a/tests/Unit/Type/Types/NativeIntegerTypeTest.php
+++ b/tests/Unit/Type/Types/NativeIntegerTypeTest.php
@@ -108,7 +108,7 @@ final class NativeIntegerTypeTest extends TestCase
     {
         $this->expectException(CannotCastValue::class);
         $this->expectExceptionCode(1603216198);
-        $this->expectExceptionMessage('Cannot cast from `string` to `int`.');
+        $this->expectExceptionMessage("Cannot cast 'foo' to `int`.");
 
         $this->integerType->cast('foo');
     }

--- a/tests/Unit/Type/Types/NativeStringTypeTest.php
+++ b/tests/Unit/Type/Types/NativeStringTypeTest.php
@@ -94,7 +94,7 @@ final class NativeStringTypeTest extends TestCase
     {
         $this->expectException(CannotCastValue::class);
         $this->expectExceptionCode(1603216198);
-        $this->expectExceptionMessage('Cannot cast from `stdClass` to `string`.');
+        $this->expectExceptionMessage('Cannot cast object(stdClass) to `string`.');
 
         $this->stringType->cast(new stdClass());
     }

--- a/tests/Unit/Type/Types/NegativeIntegerTypeTest.php
+++ b/tests/Unit/Type/Types/NegativeIntegerTypeTest.php
@@ -96,7 +96,7 @@ final class NegativeIntegerTypeTest extends TestCase
     {
         $this->expectException(CannotCastValue::class);
         $this->expectExceptionCode(1603216198);
-        $this->expectExceptionMessage('Cannot cast from `string` to `negative-int`.');
+        $this->expectExceptionMessage("Cannot cast 'foo' to `negative-int`.");
 
         $this->negativeIntegerType->cast('foo');
     }
@@ -105,7 +105,7 @@ final class NegativeIntegerTypeTest extends TestCase
     {
         $this->expectException(InvalidNegativeIntegerValue::class);
         $this->expectExceptionCode(1632923705);
-        $this->expectExceptionMessage('Invalid value `1337`: it must be a negative integer.');
+        $this->expectExceptionMessage('Invalid value 1337: it must be a negative integer.');
 
         $this->negativeIntegerType->cast(1337);
     }
@@ -114,7 +114,7 @@ final class NegativeIntegerTypeTest extends TestCase
     {
         $this->expectException(InvalidNegativeIntegerValue::class);
         $this->expectExceptionCode(1632923705);
-        $this->expectExceptionMessage('Invalid value `0`: it must be a negative integer.');
+        $this->expectExceptionMessage('Invalid value 0: it must be a negative integer.');
 
         $this->negativeIntegerType->cast(0);
     }

--- a/tests/Unit/Type/Types/NonEmptyStringTypeTest.php
+++ b/tests/Unit/Type/Types/NonEmptyStringTypeTest.php
@@ -97,7 +97,7 @@ final class NonEmptyStringTypeTest extends TestCase
     {
         $this->expectException(CannotCastValue::class);
         $this->expectExceptionCode(1603216198);
-        $this->expectExceptionMessage('Cannot cast from `stdClass` to `non-empty-string`.');
+        $this->expectExceptionMessage('Cannot cast object(stdClass) to `non-empty-string`.');
 
         $this->nonEmptyStringType->cast(new stdClass());
     }

--- a/tests/Unit/Type/Types/PositiveIntegerTypeTest.php
+++ b/tests/Unit/Type/Types/PositiveIntegerTypeTest.php
@@ -96,7 +96,7 @@ final class PositiveIntegerTypeTest extends TestCase
     {
         $this->expectException(CannotCastValue::class);
         $this->expectExceptionCode(1603216198);
-        $this->expectExceptionMessage('Cannot cast from `string` to `positive-int`.');
+        $this->expectExceptionMessage("Cannot cast 'foo' to `positive-int`.");
 
         $this->positiveIntegerType->cast('foo');
     }
@@ -105,7 +105,7 @@ final class PositiveIntegerTypeTest extends TestCase
     {
         $this->expectException(InvalidPositiveIntegerValue::class);
         $this->expectExceptionCode(1632923676);
-        $this->expectExceptionMessage('Invalid value `-1337`: it must be a positive integer.');
+        $this->expectExceptionMessage('Invalid value -1337: it must be a positive integer.');
 
         $this->positiveIntegerType->cast(-1337);
     }
@@ -114,7 +114,7 @@ final class PositiveIntegerTypeTest extends TestCase
     {
         $this->expectException(InvalidPositiveIntegerValue::class);
         $this->expectExceptionCode(1632923676);
-        $this->expectExceptionMessage('Invalid value `0`: it must be a positive integer.');
+        $this->expectExceptionMessage('Invalid value 0: it must be a positive integer.');
 
         $this->positiveIntegerType->cast(0);
     }

--- a/tests/Unit/Type/Types/StringValueTypeTest.php
+++ b/tests/Unit/Type/Types/StringValueTypeTest.php
@@ -108,7 +108,7 @@ final class StringValueTypeTest extends TestCase
     {
         $this->expectException(InvalidStringValueType::class);
         $this->expectExceptionCode(1631263954);
-        $this->expectExceptionMessage('Value of type `stdClass` does not match string value `Schwifty!`.');
+        $this->expectExceptionMessage("Value object(stdClass) does not match string value 'Schwifty!'.");
 
         $this->type->cast(new stdClass());
     }
@@ -117,7 +117,7 @@ final class StringValueTypeTest extends TestCase
     {
         $this->expectException(InvalidStringValue::class);
         $this->expectExceptionCode(1631263740);
-        $this->expectExceptionMessage('Values `Schwifty?` and `Schwifty!` do not match.');
+        $this->expectExceptionMessage("Value 'Schwifty?' does not match expected 'Schwifty!'.");
 
         $typeA = new StringValueType('Schwifty!');
         $typeB = new StringValueType('Schwifty?');

--- a/tests/Unit/Utility/String/StringFormatterTest.php
+++ b/tests/Unit/Utility/String/StringFormatterTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Unit\Utility\String;
+
+use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeTranslatableMessage;
+use CuyZ\Valinor\Utility\String\StringFormatter;
+use CuyZ\Valinor\Utility\String\StringFormatterError;
+use PHPUnit\Framework\TestCase;
+
+final class StringFormatterTest extends TestCase
+{
+    /**
+     * @requires extension intl
+     */
+    public function test_wrong_intl_format_throws_exception(): void
+    {
+        $this->expectException(StringFormatterError::class);
+        $this->expectExceptionMessage('Message formatter error using `some {wrong.format}`.');
+        $this->expectExceptionCode(1652901203);
+
+        StringFormatter::format('en', 'some {wrong.format}', []);
+    }
+
+    public function test_wrong_message_body_format_throws_exception(): void
+    {
+        $this->expectException(StringFormatterError::class);
+        $this->expectExceptionMessage('Message formatter error using `some message with {invalid format}`.');
+        $this->expectExceptionCode(1652901203);
+
+        StringFormatter::for(new FakeTranslatableMessage('some message with {invalid format}'));
+    }
+
+    public function test_parameters_are_replaced_correctly(): void
+    {
+        $message = new FakeTranslatableMessage('some message with {valid_parameter}', [
+            'invalid )( parameter' => 'invalid value',
+            'valid_parameter' => 'valid value',
+        ]);
+
+        self::assertSame('some message with valid value', StringFormatter::for($message));
+    }
+}

--- a/tests/Unit/Utility/ValueDumperTest.php
+++ b/tests/Unit/Utility/ValueDumperTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Unit\Utility;
+
+use CuyZ\Valinor\Tests\Fixture\Enum\BackedIntegerEnum;
+use CuyZ\Valinor\Tests\Fixture\Enum\BackedStringEnum;
+use CuyZ\Valinor\Tests\Fixture\Enum\PureEnum;
+use CuyZ\Valinor\Utility\ValueDumper;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class ValueDumperTest extends TestCase
+{
+    /**
+     * @dataProvider dump_value_returns_correct_signature_data_provider
+     *
+     * @param mixed $value
+     */
+    public function test_dump_value_returns_correct_signature($value, string $expected): void
+    {
+        self::assertSame($expected, ValueDumper::dump($value));
+    }
+
+    public function dump_value_returns_correct_signature_data_provider(): array
+    {
+        return [
+            'null' => [null, 'null'],
+            'boolean true' => [true, 'true'],
+            'boolean false' => [false, 'false'],
+            'integer' => [42, '42'],
+            'float' => [1337.404, '1337.404'],
+            'string with single quote' => ['foo', "'foo'"],
+            'string with double quote' => ["foo'bar", '"foo\'bar"'],
+            'string with both quotes' => ['"foo\'bar"', '\'"foo\\\'bar"\''],
+            'string with exact max length' => ['Lorem ipsum dolor sit amet, consectetur adipiscing', "'Lorem ipsum dolor sit amet, consectetur adipiscing'"],
+            'string cropped' => ['Lorem ipsum dolor sit amet, consectetur adipiscing elit.', "'Lorem ipsum dolor sit amet, consectetur adipiscing…'"],
+            'string cropped only after threshold' => ['Lorem12345 ipsumdolorsitamet,consecteturadipiscingelit.Curabitur', "'Lorem12345 ipsumdolorsitamet,consecteturadipiscinge…'"],
+            'string without space cropped' => ['Loremipsumdolorsitamet,consecteturadipiscingelit.Curabitur',"'Loremipsumdolorsitamet,consecteturadipiscingelit.Cu…'"],
+            'date' => [new DateTimeImmutable('@1648733888'), '2022/03/31 13:38:08'],
+            'object' => [new stdClass(), 'object(stdClass)'],
+            'array' => [['foo' => 'bar', 'baz'], "array{foo: 'bar', 0: 'baz'}"],
+            'array with in-depth entries' => [['foo' => ['bar' => 'baz']], "array{foo: array{…}}"],
+            'array with too much entries' => [[0, 1, 2, 3, 4, 5, 6, 7], "array{0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, …}"],
+        ];
+    }
+
+    /**
+     * @PHP8.1 move to data provider
+     *
+     * @requires PHP >= 8.1
+     */
+    public function test_dump_enum_value_returns_correct_signature(): void
+    {
+        self::assertSame('FOO', ValueDumper::dump(PureEnum::FOO));
+        self::assertSame('foo', ValueDumper::dump(BackedStringEnum::FOO));
+        self::assertSame('42', ValueDumper::dump(BackedIntegerEnum::FOO));
+    }
+}


### PR DESCRIPTION
Enhances most of the messages for the end users.

Two major changes can be noticed:

1. In most cases no class name will be written in the message; it
   prevents users that potentially have no access to the codebase to
   get a useless/unclear information.

2. The input values are now properly formatted; for instance a string
   value will now be written directly instead of the type `string`;
   arrays are also handled with the array shape format, for instance:
   `array{foo: 'some string'}`.