### PR TITLE
Feature: Support for `psalm-` and `phpstan-` prefixes in `@var`, `@param` and `@return` annotations

### DIFF
--- a/src/Utility/Reflection/Reflection.php
+++ b/src/Utility/Reflection/Reflection.php
@@ -139,13 +139,21 @@ final class Reflection
     {
         $docComment = self::sanitizeDocComment($reflection);
 
-        $expression = sprintf('/@%s?return\s+%s(\W*|$)/', self::TOOL_EXPRESSION, self::TYPE_EXPRESSION);
+        $expression = sprintf('/@%s?return\s+%s/', self::TOOL_EXPRESSION, self::TYPE_EXPRESSION);
 
-        if (! preg_match($expression, $docComment, $matches)) {
+        if (! preg_match_all($expression, $docComment, $matches)) {
             return null;
         }
 
-        return trim($matches['type']);
+        foreach ($matches['tool'] as $index => $tool) {
+            if ($tool === self::TOOL_NONE) {
+                continue;
+            }
+
+            return trim($matches['type'][$index]);
+        }
+
+        return trim($matches['type'][0]);
     }
 
     /**

--- a/src/Utility/Reflection/Reflection.php
+++ b/src/Utility/Reflection/Reflection.php
@@ -20,7 +20,6 @@ use RuntimeException;
 
 use function get_class;
 use function implode;
-use function preg_match;
 use function preg_match_all;
 use function preg_replace;
 use function spl_object_hash;

--- a/src/Utility/Reflection/Reflection.php
+++ b/src/Utility/Reflection/Reflection.php
@@ -129,10 +129,10 @@ final class Reflection
                 continue;
             }
 
-            return $matches['type'][$index];
+            return trim($matches['type'][$index]);
         }
 
-        return $matches['type'][0];
+        return trim($matches['type'][0]);
     }
 
     public static function docBlockReturnType(ReflectionFunctionAbstract $reflection): ?string
@@ -205,6 +205,6 @@ final class Reflection
     {
         $docComment = preg_replace('#^\s*/\*\*([^/]+)/\s*$#', '$1', $reflection->getDocComment() ?: '');
 
-        return preg_replace('/\s*\*\s*(\S*)/', '$1', $docComment); // @phpstan-ignore-line
+        return trim(preg_replace('/\s*\*\s*(\S*)/', "\n\$1", $docComment)); // @phpstan-ignore-line
     }
 }

--- a/src/Utility/Reflection/Reflection.php
+++ b/src/Utility/Reflection/Reflection.php
@@ -124,10 +124,6 @@ final class Reflection
             return null;
         }
 
-        if (count($matches['tool']) === 1) {
-            return $matches['type'][0];
-        }
-
         foreach ($matches['tool'] as $index => $tool) {
             if ($tool === self::TOOL_NONE) {
                 continue;

--- a/src/Utility/Reflection/Reflection.php
+++ b/src/Utility/Reflection/Reflection.php
@@ -110,28 +110,28 @@ final class Reflection
     {
         if ($reflection instanceof ReflectionProperty) {
             $docComment = self::sanitizeDocComment($reflection);
-            $regex = "@var\s+([\w\s?|&<>'\",-:\\\\\[\]{}]+)";
+            $regex = "@(psalm-|phpstan-)?var\s+(?<type>[\w\s?|&<>'\",-:\\\\\[\]{}]+)";
         } else {
             $docComment = self::sanitizeDocComment($reflection->getDeclaringFunction());
-            $regex = "@param\s+([\w\s?|&<>'\",-:\\\\\[\]{}]+)\s+\\$$reflection->name(\W+|$)";
+            $regex = "@(psalm-|phpstan-)?param\s+(?<type>[\w\s?|&<>'\",-:\\\\\[\]{}]+)\s+\\$$reflection->name(\W+|$)";
         }
 
         if (! preg_match("/$regex/", $docComment, $matches)) {
             return null;
         }
 
-        return $matches[1];
+        return $matches['type'];
     }
 
     public static function docBlockReturnType(ReflectionFunctionAbstract $reflection): ?string
     {
         $docComment = self::sanitizeDocComment($reflection);
 
-        if (! preg_match("/@return\s+([\w\s?|&<>'\",-:\\\\\[\]{}]+)(\W*|$)/", $docComment, $matches)) {
+        if (! preg_match("/@(psalm-|phpstan-)?return\s+(?<type>[\w\s?|&<>'\",-:\\\\\[\]{}]+)(\W*|$)/", $docComment, $matches)) {
             return null;
         }
 
-        return trim($matches[1]);
+        return trim($matches['type']);
     }
 
     /**

--- a/src/Utility/Reflection/Reflection.php
+++ b/src/Utility/Reflection/Reflection.php
@@ -117,7 +117,7 @@ final class Reflection
             $expression = sprintf('@%s?var\s+%s', self::TOOL_EXPRESSION, self::TYPE_EXPRESSION);
         } else {
             $docComment = self::sanitizeDocComment($reflection->getDeclaringFunction());
-            $expression = sprintf('@%s?param\s+%s\s+\$%s', self::TOOL_EXPRESSION, self::TYPE_EXPRESSION, $reflection->name);
+            $expression = sprintf('@%s?param\s+%s\s+\$\b%s\b', self::TOOL_EXPRESSION, self::TYPE_EXPRESSION, $reflection->name);
         }
 
         if (! preg_match_all("/$expression/", $docComment, $matches)) {

--- a/tests/Unit/Utility/Reflection/ReflectionTest.php
+++ b/tests/Unit/Utility/Reflection/ReflectionTest.php
@@ -223,7 +223,7 @@ final class ReflectionTest extends TestCase
             'string',
         ];
 
-        yield 'psalm @var' => [
+        yield 'psalm @var standalone' => [
             new ReflectionProperty(new class () {
                 /**
                  * @psalm-var string
@@ -233,7 +233,29 @@ final class ReflectionTest extends TestCase
             'string',
         ];
 
-        yield 'phpstan @var' => [
+        yield 'psalm @var leading' => [
+            new ReflectionProperty(new class () {
+                /**
+                 * @psalm-var non-empty-string
+                 * @var string
+                 */
+                public $foo;
+            }, 'foo'),
+            'non-empty-string',
+        ];
+
+        yield 'psalm @var trailing' => [
+            new ReflectionProperty(new class () {
+                /**
+                 * @var string
+                 * @psalm-var non-empty-string
+                 */
+                public $foo;
+            }, 'foo'),
+            'non-empty-string',
+        ];
+
+        yield 'phpstan @var standalone' => [
             new ReflectionProperty(new class () {
                 /**
                  * @phpstan-var string
@@ -241,6 +263,28 @@ final class ReflectionTest extends TestCase
                 public $foo;
             }, 'foo'),
             'string',
+        ];
+
+        yield 'phpstan @var leading' => [
+            new ReflectionProperty(new class () {
+                /**
+                 * @phpstan-var non-empty-string
+                 * @var string
+                 */
+                public $foo;
+            }, 'foo'),
+            'non-empty-string',
+        ];
+
+        yield 'phpstan @var trailing' => [
+            new ReflectionProperty(new class () {
+                /**
+                 * @var string
+                 * @phpstan-var non-empty-string
+                 */
+                public $foo;
+            }, 'foo'),
+            'non-empty-string',
         ];
 
         yield 'phpdoc @param' => [
@@ -253,7 +297,7 @@ final class ReflectionTest extends TestCase
             'string',
         ];
 
-        yield 'psalm @param' => [
+        yield 'psalm @param standalone' => [
             new ReflectionParameter(
                 /** @psalm-param string $string */
                 static function ($string): void {
@@ -263,7 +307,33 @@ final class ReflectionTest extends TestCase
             'string',
         ];
 
-        yield 'phpstan @param' => [
+        yield 'psalm @param leading' => [
+            new ReflectionParameter(
+                /**
+                 * @psalm-param non-empty-string $string
+                 * @param string $string
+                 */
+                static function ($string): void {
+                },
+                'string',
+            ),
+            'non-empty-string',
+        ];
+
+        yield 'psalm @param trailing' => [
+            new ReflectionParameter(
+                /**
+                 * @param string $string
+                 * @psalm-param non-empty-string $string
+                 */
+                static function ($string): void {
+                },
+                'string',
+            ),
+            'non-empty-string',
+        ];
+
+        yield 'phpstan @param standalone' => [
             new ReflectionParameter(
                 /** @phpstan-param string $string */
                 static function ($string): void {
@@ -271,6 +341,32 @@ final class ReflectionTest extends TestCase
                 'string',
             ),
             'string',
+        ];
+
+        yield 'phpstan @param leading' => [
+            new ReflectionParameter(
+                /**
+                 * @phpstan-param non-empty-string $string
+                 * @param string $string
+                 */
+                static function ($string): void {
+                },
+                'string',
+            ),
+            'non-empty-string',
+        ];
+
+        yield 'phpstan @param trailing' => [
+            new ReflectionParameter(
+                /**
+                 * @param string $string
+                 * @phpstan-param non-empty-string $string
+                 */
+                static function ($string): void {
+                },
+                'string',
+            ),
+            'non-empty-string',
         ];
     }
 }

--- a/tests/Unit/Utility/Reflection/ReflectionTest.php
+++ b/tests/Unit/Utility/Reflection/ReflectionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Unit\Utility\Reflection;
 
+use Closure;
 use CuyZ\Valinor\Tests\Fake\FakeReflector;
 use CuyZ\Valinor\Tests\Fixture\Object\ObjectWithPropertyWithNativeIntersectionType;
 use CuyZ\Valinor\Tests\Fixture\Object\ObjectWithPropertyWithNativeUnionType;
@@ -152,7 +153,7 @@ final class ReflectionTest extends TestCase
         callable $dockblockTypedCallable,
         string $expectedType
     ): void {
-        $type = Reflection::docBlockReturnType(new ReflectionFunction($dockblockTypedCallable));
+        $type = Reflection::docBlockReturnType(new ReflectionFunction(Closure::fromCallable($dockblockTypedCallable)));
 
         self::assertSame($expectedType, $type);
     }
@@ -168,6 +169,7 @@ final class ReflectionTest extends TestCase
     }
 
     /**
+     * @param ReflectionParameter|ReflectionProperty $property
      * @param non-empty-string $expectedType
      * @dataProvider objects_with_docblock_typed_properties
      */
@@ -178,6 +180,9 @@ final class ReflectionTest extends TestCase
         self::assertEquals($expectedType, Reflection::docBlockType($property));
     }
 
+    /**
+     * @return iterable<non-empty-string,array{0:callable,1:non-empty-string}>
+     */
     public function callables_with_docblock_typed_return_type(): iterable
     {
         yield 'phpdoc' => [
@@ -265,6 +270,9 @@ final class ReflectionTest extends TestCase
         ];
     }
 
+    /**
+     * @return iterable<non-empty-string,array{0:ReflectionProperty|ReflectionParameter,1:non-empty-string}>
+     */
     public function objects_with_docblock_typed_properties(): iterable
     {
         yield 'phpdoc @var' => [

--- a/tests/Unit/Utility/Reflection/ReflectionTest.php
+++ b/tests/Unit/Utility/Reflection/ReflectionTest.php
@@ -190,6 +190,16 @@ final class ReflectionTest extends TestCase
             'int',
         ];
 
+        yield 'phpdoc literal string' => [
+            /**
+             * @return 'foo'
+             */
+            static function () {
+                return 'foo';
+            },
+            '\'foo\'',
+        ];
+
         yield 'psalm' => [
             /**
              * @psalm-return int
@@ -200,6 +210,28 @@ final class ReflectionTest extends TestCase
             'int',
         ];
 
+        yield 'psalm trailing' => [
+            /**
+             * @return int
+             * @psalm-return positive-int
+             */
+            static function () {
+                return 42;
+            },
+            'positive-int',
+        ];
+
+        yield 'psalm leading' => [
+            /**
+             * @psalm-return positive-int
+             * @return int
+             */
+            static function () {
+                return 42;
+            },
+            'positive-int',
+        ];
+
         yield 'phpstan' => [
             /**
              * @phpstan-return int
@@ -208,6 +240,28 @@ final class ReflectionTest extends TestCase
                 return 42;
             },
             'int',
+        ];
+
+        yield 'phpstan trailing' => [
+            /**
+             * @return int
+             * @phpstan-return positive-int
+             */
+            static function () {
+                return 42;
+            },
+            'positive-int',
+        ];
+
+        yield 'phpstan leading' => [
+            /**
+             * @phpstan-return positive-int
+             * @return int
+             */
+            static function () {
+                return 42;
+            },
+            'positive-int',
         ];
     }
 

--- a/tests/Unit/Utility/Reflection/ReflectionTest.php
+++ b/tests/Unit/Utility/Reflection/ReflectionTest.php
@@ -186,32 +186,20 @@ final class ReflectionTest extends TestCase
     public function callables_with_docblock_typed_return_type(): iterable
     {
         yield 'phpdoc' => [
-            /**
-             * @return int
-             */
-            static function () {
-                return 42;
-            },
+            /** @return int */
+            fn () => 42,
             'int',
         ];
 
         yield 'phpdoc literal string' => [
-            /**
-             * @return 'foo'
-             */
-            static function () {
-                return 'foo';
-            },
+            /** @return 'foo' */
+            fn () => 'foo',
             '\'foo\'',
         ];
 
         yield 'psalm' => [
-            /**
-             * @psalm-return int
-             */
-            static function () {
-                return 42;
-            },
+            /** @psalm-return int */
+            fn () => 42,
             'int',
         ];
 
@@ -220,9 +208,7 @@ final class ReflectionTest extends TestCase
              * @return int
              * @psalm-return positive-int
              */
-            static function () {
-                return 42;
-            },
+            fn () => 42,
             'positive-int',
         ];
 
@@ -231,19 +217,13 @@ final class ReflectionTest extends TestCase
              * @psalm-return positive-int
              * @return int
              */
-            static function () {
-                return 42;
-            },
+            fn () => 42,
             'positive-int',
         ];
 
         yield 'phpstan' => [
-            /**
-             * @phpstan-return int
-             */
-            static function () {
-                return 42;
-            },
+            /** @phpstan-return int */
+            fn () => 42,
             'int',
         ];
 
@@ -252,9 +232,7 @@ final class ReflectionTest extends TestCase
              * @return int
              * @phpstan-return positive-int
              */
-            static function () {
-                return 42;
-            },
+            fn () => 42,
             'positive-int',
         ];
 
@@ -263,9 +241,7 @@ final class ReflectionTest extends TestCase
              * @phpstan-return positive-int
              * @return int
              */
-            static function () {
-                return 42;
-            },
+            fn () => 42,
             'positive-int',
         ];
     }
@@ -277,9 +253,7 @@ final class ReflectionTest extends TestCase
     {
         yield 'phpdoc @var' => [
             new ReflectionProperty(new class () {
-                /**
-                 * @var string
-                 */
+                /** @var string */
                 public $foo;
             }, 'foo'),
             'string',
@@ -287,9 +261,7 @@ final class ReflectionTest extends TestCase
 
         yield 'psalm @var standalone' => [
             new ReflectionProperty(new class () {
-                /**
-                 * @psalm-var string
-                 */
+                /** @psalm-var string */
                 public $foo;
             }, 'foo'),
             'string',
@@ -319,9 +291,7 @@ final class ReflectionTest extends TestCase
 
         yield 'phpstan @var standalone' => [
             new ReflectionProperty(new class () {
-                /**
-                 * @phpstan-var string
-                 */
+                /** @phpstan-var string */
                 public $foo;
             }, 'foo'),
             'string',

--- a/tests/Unit/Utility/Reflection/ReflectionTest.php
+++ b/tests/Unit/Utility/Reflection/ReflectionTest.php
@@ -191,6 +191,15 @@ final class ReflectionTest extends TestCase
             'int',
         ];
 
+        yield 'phpdoc followed by new line' => [
+            /**
+             * @return int
+             *
+             */
+            fn () => 42,
+            'int',
+        ];
+
         yield 'phpdoc literal string' => [
             /** @return 'foo' */
             fn () => 'foo',
@@ -254,6 +263,17 @@ final class ReflectionTest extends TestCase
         yield 'phpdoc @var' => [
             new ReflectionProperty(new class () {
                 /** @var string */
+                public $foo;
+            }, 'foo'),
+            'string',
+        ];
+
+        yield 'phpdoc @var followed by new line' => [
+            new ReflectionProperty(new class () {
+                /**
+                 * @var string
+                 *
+                 */
                 public $foo;
             }, 'foo'),
             'string',


### PR DESCRIPTION
As requested in #118, this PR provides support for these prefixes.