### PR TITLE
feat: handle float value type 

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,9 @@ final class SomeClass
         /** @var array<SomeInterface|AnotherInterface> */
         private array $unionInsideArray,
         
+        /** @var 404.42|1337.42 */
+        private string $unionOfFloatValues,
+        
         /** @var 42|1337 */
         private string $unionOfIntegerValues,
         

--- a/README.md
+++ b/README.md
@@ -781,6 +781,12 @@ final class SomeClass
         
         /** @var array<SomeInterface|AnotherInterface> */
         private array $unionInsideArray,
+        
+        /** @var 42|1337 */
+        private string $unionOfIntegerValues,
+        
+        /** @var 'foo'|'bar' */
+        private string $unionOfStringValues,
     ) {}
 }
 ```

--- a/src/Definition/Repository/Cache/Compiler/TypeCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/TypeCompiler.php
@@ -12,7 +12,8 @@ use CuyZ\Valinor\Type\Types\ClassStringType;
 use CuyZ\Valinor\Type\Types\ClassType;
 use CuyZ\Valinor\Type\Types\ArrayType;
 use CuyZ\Valinor\Type\Types\EnumType;
-use CuyZ\Valinor\Type\Types\FloatType;
+use CuyZ\Valinor\Type\Types\NativeFloatType;
+use CuyZ\Valinor\Type\Types\FloatValueType;
 use CuyZ\Valinor\Type\Types\IntegerRangeType;
 use CuyZ\Valinor\Type\Types\IntegerValueType;
 use CuyZ\Valinor\Type\Types\InterfaceType;
@@ -50,7 +51,7 @@ final class TypeCompiler
         switch (true) {
             case $type instanceof NullType:
             case $type instanceof BooleanType:
-            case $type instanceof FloatType:
+            case $type instanceof NativeFloatType:
             case $type instanceof NativeIntegerType:
             case $type instanceof PositiveIntegerType:
             case $type instanceof NegativeIntegerType:
@@ -63,6 +64,7 @@ final class TypeCompiler
                 return "new $class({$type->min()}, {$type->max()})";
             case $type instanceof StringValueType:
             case $type instanceof IntegerValueType:
+            case $type instanceof FloatValueType:
                 $value = var_export($type->value(), true);
 
                 return "new $class($value)";

--- a/src/Type/FloatType.php
+++ b/src/Type/FloatType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Type;
+
+/** @api */
+interface FloatType extends ScalarType
+{
+    public function cast($value): float;
+}

--- a/src/Type/Parser/Lexer/NativeLexer.php
+++ b/src/Type/Parser/Lexer/NativeLexer.php
@@ -13,6 +13,7 @@ use CuyZ\Valinor\Type\Parser\Lexer\Token\ClosingSquareBracketToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\ColonToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\CommaToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\EnumNameToken;
+use CuyZ\Valinor\Type\Parser\Lexer\Token\FloatValueToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\IntegerToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\IntegerValueToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\IntersectionToken;
@@ -33,6 +34,7 @@ use UnitEnum;
 use function class_exists;
 use function filter_var;
 use function interface_exists;
+use function is_numeric;
 use function strtolower;
 use function substr;
 
@@ -95,6 +97,10 @@ final class NativeLexer implements TypeLexer
 
         if (filter_var($symbol, FILTER_VALIDATE_INT) !== false) {
             return new IntegerValueToken((int)$symbol);
+        }
+
+        if (is_numeric($symbol)) {
+            return new FloatValueToken((float)$symbol);
         }
 
         /** @infection-ignore-all */

--- a/src/Type/Parser/Lexer/Token/FloatValueToken.php
+++ b/src/Type/Parser/Lexer/Token/FloatValueToken.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Type\Parser\Lexer\Token;
+
+use CuyZ\Valinor\Type\Parser\Lexer\TokenStream;
+use CuyZ\Valinor\Type\Type;
+use CuyZ\Valinor\Type\Types\FloatValueType;
+
+/** @internal */
+final class FloatValueToken implements TraversingToken
+{
+    private float $value;
+
+    public function __construct(float $value)
+    {
+        $this->value = $value;
+    }
+
+    public function traverse(TokenStream $stream): Type
+    {
+        return new FloatValueType($this->value);
+    }
+}

--- a/src/Type/Parser/Lexer/Token/NativeToken.php
+++ b/src/Type/Parser/Lexer/Token/NativeToken.php
@@ -8,7 +8,7 @@ use CuyZ\Valinor\Type\Parser\Lexer\TokenStream;
 use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\ArrayKeyType;
 use CuyZ\Valinor\Type\Types\BooleanType;
-use CuyZ\Valinor\Type\Types\FloatType;
+use CuyZ\Valinor\Type\Types\NativeFloatType;
 use CuyZ\Valinor\Type\Types\MixedType;
 use CuyZ\Valinor\Type\Types\NativeStringType;
 use CuyZ\Valinor\Type\Types\NegativeIntegerType;
@@ -60,7 +60,7 @@ final class NativeToken implements TraversingToken
             case 'mixed':
                 return MixedType::get();
             case 'float':
-                return FloatType::get();
+                return NativeFloatType::get();
             case 'positive-int':
                 return PositiveIntegerType::get();
             case 'negative-int':

--- a/src/Type/Types/Exception/InvalidFloatValue.php
+++ b/src/Type/Types/Exception/InvalidFloatValue.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Type\Types\Exception;
+
+use RuntimeException;
+
+/** @api */
+final class InvalidFloatValue extends RuntimeException implements CastError
+{
+    public function __construct(float $value, float $expected)
+    {
+        parent::__construct(
+            "Value `$value` does not match expected value `$expected`.",
+            1652110115
+        );
+    }
+}

--- a/src/Type/Types/Exception/InvalidFloatValueType.php
+++ b/src/Type/Types/Exception/InvalidFloatValueType.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Type\Types\Exception;
+
+use CuyZ\Valinor\Utility\Polyfill;
+use RuntimeException;
+
+/** @api */
+final class InvalidFloatValueType extends RuntimeException implements CastError
+{
+    /**
+     * @param mixed $value
+     */
+    public function __construct($value, float $floatValue)
+    {
+        $baseType = Polyfill::get_debug_type($value);
+
+        parent::__construct(
+            "Value of type `$baseType` does not match float value `$floatValue`.",
+            1652110003
+        );
+    }
+}

--- a/src/Type/Types/FloatValueType.php
+++ b/src/Type/Types/FloatValueType.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Type\Types;
+
+use CuyZ\Valinor\Type\FixedType;
+use CuyZ\Valinor\Type\FloatType;
+use CuyZ\Valinor\Type\Type;
+use CuyZ\Valinor\Type\Types\Exception\InvalidFloatValue;
+use CuyZ\Valinor\Type\Types\Exception\InvalidFloatValueType;
+
+/** @api */
+final class FloatValueType implements FloatType, FixedType
+{
+    private float $value;
+
+    public function __construct(float $value)
+    {
+        $this->value = $value;
+    }
+
+    public function accepts($value): bool
+    {
+        return $value === $this->value;
+    }
+
+    public function matches(Type $other): bool
+    {
+        if ($other instanceof UnionType) {
+            return $other->isMatchedBy($this);
+        }
+
+        if ($other instanceof self) {
+            return $this->value === $other->value;
+        }
+
+        return $other instanceof NativeFloatType || $other instanceof MixedType;
+    }
+
+    public function canCast($value): bool
+    {
+        return is_numeric($value);
+    }
+
+    public function cast($value): float
+    {
+        if (! $this->canCast($value)) {
+            throw new InvalidFloatValueType($value, $this->value);
+        }
+
+        $value = (float)$value; // @phpstan-ignore-line
+
+        if (! $this->accepts($value)) {
+            throw new InvalidFloatValue($value, $this->value);
+        }
+
+        return $value;
+    }
+
+    public function value()
+    {
+        return $this->value;
+    }
+
+    public function __toString(): string
+    {
+        return (string)$this->value;
+    }
+}

--- a/src/Type/Types/NativeFloatType.php
+++ b/src/Type/Types/NativeFloatType.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Types;
 
-use CuyZ\Valinor\Type\ScalarType;
+use CuyZ\Valinor\Type\FloatType;
 use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\Exception\CannotCastValue;
 use CuyZ\Valinor\Utility\IsSingleton;
@@ -13,7 +13,7 @@ use function is_float;
 use function is_numeric;
 
 /** @api */
-final class FloatType implements ScalarType
+final class NativeFloatType implements FloatType
 {
     use IsSingleton;
 

--- a/tests/Functional/Definition/Repository/Cache/Compiler/TypeCompilerTest.php
+++ b/tests/Functional/Definition/Repository/Cache/Compiler/TypeCompilerTest.php
@@ -11,7 +11,8 @@ use CuyZ\Valinor\Type\Types\BooleanType;
 use CuyZ\Valinor\Type\Types\ClassStringType;
 use CuyZ\Valinor\Type\Types\ClassType;
 use CuyZ\Valinor\Type\Types\ArrayType;
-use CuyZ\Valinor\Type\Types\FloatType;
+use CuyZ\Valinor\Type\Types\NativeFloatType;
+use CuyZ\Valinor\Type\Types\FloatValueType;
 use CuyZ\Valinor\Type\Types\IntegerRangeType;
 use CuyZ\Valinor\Type\Types\IntegerValueType;
 use CuyZ\Valinor\Type\Types\InterfaceType;
@@ -73,10 +74,14 @@ final class TypeCompilerTest extends TestCase
     {
         yield [NullType::get()];
         yield [BooleanType::get()];
-        yield [FloatType::get()];
+        yield [NativeFloatType::get()];
+        yield [new FloatValueType(1337.42)];
+        yield [new FloatValueType(-1337.42)];
         yield [NativeIntegerType::get()];
         yield [PositiveIntegerType::get()];
         yield [NegativeIntegerType::get()];
+        yield [new IntegerValueType(1337)];
+        yield [new IntegerValueType(-1337)];
         yield [new IntegerRangeType(42, 1337)];
         yield [new IntegerRangeType(-1337, -42)];
         yield [new IntegerRangeType(PHP_INT_MIN, PHP_INT_MAX)];
@@ -87,28 +92,28 @@ final class TypeCompilerTest extends TestCase
         yield [new InterfaceType(DateTimeInterface::class, ['Template' => NativeStringType::get()])];
         yield [new ClassType(stdClass::class, ['Template' => NativeStringType::get()])];
         yield [new IntersectionType(new InterfaceType(DateTimeInterface::class), new ClassType(DateTime::class))];
-        yield [new UnionType(NativeStringType::get(), NativeIntegerType::get(), FloatType::get())];
+        yield [new UnionType(NativeStringType::get(), NativeIntegerType::get(), NativeFloatType::get())];
         yield [ArrayType::native()];
-        yield [new ArrayType(ArrayKeyType::default(), FloatType::get())];
+        yield [new ArrayType(ArrayKeyType::default(), NativeFloatType::get())];
         yield [new ArrayType(ArrayKeyType::integer(), NativeIntegerType::get())];
         yield [new ArrayType(ArrayKeyType::string(), NativeStringType::get())];
         yield [NonEmptyArrayType::native()];
-        yield [new NonEmptyArrayType(ArrayKeyType::default(), FloatType::get())];
+        yield [new NonEmptyArrayType(ArrayKeyType::default(), NativeFloatType::get())];
         yield [new NonEmptyArrayType(ArrayKeyType::integer(), NativeIntegerType::get())];
         yield [new NonEmptyArrayType(ArrayKeyType::string(), NativeStringType::get())];
         yield [ListType::native()];
-        yield [new ListType(FloatType::get())];
+        yield [new ListType(NativeFloatType::get())];
         yield [new ListType(NativeIntegerType::get())];
         yield [new ListType(NativeStringType::get())];
         yield [NonEmptyListType::native()];
-        yield [new NonEmptyListType(FloatType::get())];
+        yield [new NonEmptyListType(NativeFloatType::get())];
         yield [new NonEmptyListType(NativeIntegerType::get())];
         yield [new NonEmptyListType(NativeStringType::get())];
         yield [new ShapedArrayType(
             new ShapedArrayElement(new StringValueType('foo'), NativeStringType::get()),
             new ShapedArrayElement(new IntegerValueType(1337), NativeIntegerType::get(), true)
         )];
-        yield [new IterableType(ArrayKeyType::default(), FloatType::get())];
+        yield [new IterableType(ArrayKeyType::default(), NativeFloatType::get())];
         yield [new IterableType(ArrayKeyType::integer(), NativeIntegerType::get())];
         yield [new IterableType(ArrayKeyType::string(), NativeStringType::get())];
         yield [new ClassStringType()];

--- a/tests/Functional/Type/Parser/Lexer/NativeLexerTest.php
+++ b/tests/Functional/Type/Parser/Lexer/NativeLexerTest.php
@@ -40,7 +40,8 @@ use CuyZ\Valinor\Type\Types\ArrayType;
 use CuyZ\Valinor\Type\Types\BooleanType;
 use CuyZ\Valinor\Type\Types\ClassStringType;
 use CuyZ\Valinor\Type\Types\ClassType;
-use CuyZ\Valinor\Type\Types\FloatType;
+use CuyZ\Valinor\Type\Types\NativeFloatType;
+use CuyZ\Valinor\Type\Types\FloatValueType;
 use CuyZ\Valinor\Type\Types\IntegerRangeType;
 use CuyZ\Valinor\Type\Types\IntegerValueType;
 use CuyZ\Valinor\Type\Types\InterfaceType;
@@ -123,17 +124,37 @@ final class NativeLexerTest extends TestCase
             'Float type' => [
                 'raw' => 'float',
                 'transformed' => 'float',
-                'type' => FloatType::class,
+                'type' => NativeFloatType::class,
             ],
             'Float type - uppercase' => [
                 'raw' => 'FLOAT',
                 'transformed' => 'float',
-                'type' => FloatType::class,
+                'type' => NativeFloatType::class,
             ],
             'Float type followed by description' => [
                 'raw' => 'float lorem ipsum',
                 'transformed' => 'float',
-                'type' => FloatType::class,
+                'type' => NativeFloatType::class,
+            ],
+            'Positive float value' => [
+                'raw' => '1337.42',
+                'transformed' => '1337.42',
+                'type' => FloatValueType::class,
+            ],
+            'Positive float value followed by description' => [
+                'raw' => '1337.42 lorem ipsum',
+                'transformed' => '1337.42',
+                'type' => FloatValueType::class,
+            ],
+            'Negative float value' => [
+                'raw' => '-1337.42',
+                'transformed' => '-1337.42',
+                'type' => FloatValueType::class,
+            ],
+            'Negative float value followed by description' => [
+                'raw' => '-1337.42 lorem ipsum',
+                'transformed' => '-1337.42',
+                'type' => FloatValueType::class,
             ],
             'Integer type' => [
                 'raw' => 'int',
@@ -659,7 +680,7 @@ final class NativeLexerTest extends TestCase
         $types = $unionType->types();
 
         self::assertInstanceOf(IntegerType::class, $types[0]);
-        self::assertInstanceOf(FloatType::class, $types[1]);
+        self::assertInstanceOf(NativeFloatType::class, $types[1]);
         self::assertInstanceOf(StringType::class, $types[2]);
     }
 

--- a/tests/Integration/IntegrationTest.php
+++ b/tests/Integration/IntegrationTest.php
@@ -21,9 +21,9 @@ abstract class IntegrationTest extends TestCase
     {
         parent::setUp();
 
-        vfsStream::setup();
+        vfsStream::setup('cache-dir');
 
-        $this->mapperBuilder = new MapperBuilder();
+        $this->mapperBuilder = (new MapperBuilder())->withCacheDir(vfsStream::url('cache-dir'));
     }
 
     /**

--- a/tests/Integration/Mapping/Object/ScalarValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ScalarValuesMappingTest.php
@@ -20,6 +20,8 @@ final class ScalarValuesMappingTest extends IntegrationTest
         $source = [
             'boolean' => true,
             'float' => 42.404,
+            'positiveFloatValue' => 42.404,
+            'negativeFloatValue' => -42.404,
             'integer' => 1337,
             'positiveInteger' => 1337,
             'negativeInteger' => -1337,
@@ -46,6 +48,8 @@ final class ScalarValuesMappingTest extends IntegrationTest
 
             self::assertSame(true, $result->boolean);
             self::assertSame(42.404, $result->float);
+            self::assertSame(42.404, $result->positiveFloatValue); // @phpstan-ignore-line
+            self::assertSame(-42.404, $result->negativeFloatValue); // @phpstan-ignore-line
             self::assertSame(1337, $result->integer);
             self::assertSame(1337, $result->positiveInteger);
             self::assertSame(-1337, $result->negativeInteger);
@@ -99,6 +103,12 @@ class ScalarValues
 
     public float $float = -1.0;
 
+    /** @var 42.404 */
+    public float $positiveFloatValue;
+
+    /** @var -42.404 */
+    public float $negativeFloatValue;
+
     public int $integer = -1;
 
     /** @var positive-int */
@@ -146,6 +156,8 @@ class ScalarValues
 class ScalarValuesWithConstructor extends ScalarValues
 {
     /**
+     * @param 42.404 $positiveFloatValue
+     * @param -42.404 $negativeFloatValue
      * @param positive-int $positiveInteger
      * @param negative-int $negativeInteger
      * @param int<-1337, 1337> $integerRangeWithPositiveValue
@@ -163,6 +175,8 @@ class ScalarValuesWithConstructor extends ScalarValues
     public function __construct(
         bool $boolean,
         float $float,
+        float $positiveFloatValue,
+        float $negativeFloatValue,
         int $integer,
         int $positiveInteger,
         int $negativeInteger,
@@ -181,6 +195,8 @@ class ScalarValuesWithConstructor extends ScalarValues
     ) {
         $this->boolean = $boolean;
         $this->float = $float;
+        $this->positiveFloatValue = $positiveFloatValue;
+        $this->negativeFloatValue = $negativeFloatValue;
         $this->integer = $integer;
         $this->positiveInteger = $positiveInteger;
         $this->negativeInteger = $negativeInteger;

--- a/tests/Integration/Mapping/Object/ScalarValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ScalarValuesMappingTest.php
@@ -26,7 +26,8 @@ final class ScalarValuesMappingTest extends IntegrationTest
             'integerRangeWithPositiveValue' => 1337,
             'integerRangeWithNegativeValue' => -1337,
             'integerRangeWithMinAndMax' => 42,
-            'integerValue' => 42,
+            'positiveIntegerValue' => 42,
+            'negativeIntegerValue' => -42,
             'string' => 'foo',
             'nonEmptyString' => 'bar',
             'stringValueWithSingleQuote' => 'baz',
@@ -51,7 +52,8 @@ final class ScalarValuesMappingTest extends IntegrationTest
             self::assertSame(1337, $result->integerRangeWithPositiveValue);
             self::assertSame(-1337, $result->integerRangeWithNegativeValue);
             self::assertSame(42, $result->integerRangeWithMinAndMax);
-            self::assertSame(42, $result->integerValue); // @phpstan-ignore-line
+            self::assertSame(42, $result->positiveIntegerValue); // @phpstan-ignore-line
+            self::assertSame(-42, $result->negativeIntegerValue); // @phpstan-ignore-line
             self::assertSame('foo', $result->string);
             self::assertSame('bar', $result->nonEmptyString);
             self::assertSame('baz', $result->stringValueWithSingleQuote); // @phpstan-ignore-line
@@ -115,7 +117,10 @@ class ScalarValues
     public int $integerRangeWithMinAndMax = -1;
 
     /** @var 42 */
-    public int $integerValue;
+    public int $positiveIntegerValue;
+
+    /** @var -42 */
+    public int $negativeIntegerValue;
 
     public string $string = 'Schwifty!';
 
@@ -146,7 +151,8 @@ class ScalarValuesWithConstructor extends ScalarValues
      * @param int<-1337, 1337> $integerRangeWithPositiveValue
      * @param int<-1337, 1337> $integerRangeWithNegativeValue
      * @param int<min, max> $integerRangeWithMinAndMax
-     * @param 42 $integerValue
+     * @param 42 $positiveIntegerValue
+     * @param -42 $negativeIntegerValue
      * @param non-empty-string $nonEmptyString
      * @param 'baz' $stringValueWithSingleQuote
      * @param "fiz" $stringValueWithDoubleQuote
@@ -163,7 +169,8 @@ class ScalarValuesWithConstructor extends ScalarValues
         int $integerRangeWithPositiveValue,
         int $integerRangeWithNegativeValue,
         int $integerRangeWithMinAndMax,
-        int $integerValue,
+        int $positiveIntegerValue,
+        int $negativeIntegerValue,
         string $string,
         string $nonEmptyString,
         string $stringValueWithSingleQuote,
@@ -180,7 +187,8 @@ class ScalarValuesWithConstructor extends ScalarValues
         $this->integerRangeWithPositiveValue = $integerRangeWithPositiveValue;
         $this->integerRangeWithNegativeValue = $integerRangeWithNegativeValue;
         $this->integerRangeWithMinAndMax = $integerRangeWithMinAndMax;
-        $this->integerValue = $integerValue;
+        $this->positiveIntegerValue = $positiveIntegerValue;
+        $this->negativeIntegerValue = $negativeIntegerValue;
         $this->string = $string;
         $this->nonEmptyString = $nonEmptyString;
         $this->stringValueWithSingleQuote = $stringValueWithSingleQuote;

--- a/tests/Integration/Mapping/Object/UnionValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/UnionValuesMappingTest.php
@@ -20,7 +20,8 @@ final class UnionValuesMappingTest extends IntegrationTest
             'scalarWithString' => 'foo',
             'nullableWithString' => 'bar',
             'nullableWithNull' => null,
-            'integerValue' => 1337,
+            'positiveIntegerValue' => 1337,
+            'negativeIntegerValue' => -1337,
             'stringValueWithSingleQuote' => 'bar',
             'stringValueWithDoubleQuote' => 'fiz',
         ];
@@ -47,7 +48,8 @@ final class UnionValuesMappingTest extends IntegrationTest
             self::assertSame(null, $result->nullableWithNull);
 
             if ($result instanceof UnionValues) {
-                self::assertSame(1337, $result->integerValue);
+                self::assertSame(1337, $result->positiveIntegerValue);
+                self::assertSame(-1337, $result->negativeIntegerValue);
                 self::assertSame('bar', $result->stringValueWithSingleQuote);
                 self::assertSame('fiz', $result->stringValueWithDoubleQuote);
             }
@@ -76,7 +78,10 @@ class UnionValues
     public $nullableWithNull = 'Schwifty!';
 
     /** @var 42|1337 */
-    public int $integerValue = 42;
+    public int $positiveIntegerValue = 42;
+
+    /** @var -42|-1337 */
+    public int $negativeIntegerValue = -42;
 
     /** @var 'foo'|'bar' */
     public string $stringValueWithSingleQuote;
@@ -94,7 +99,8 @@ class UnionValuesWithConstructor extends UnionValues
      * @param bool|float|int|string $scalarWithString
      * @param string|null|float $nullableWithString
      * @param string|null|float $nullableWithNull
-     * @param 42|1337 $integerValue
+     * @param 42|1337 $positiveIntegerValue
+     * @param -42|-1337 $negativeIntegerValue
      * @param 'foo'|'bar' $stringValueWithSingleQuote
      * @param "baz"|"fiz" $stringValueWithDoubleQuote
      */
@@ -105,7 +111,8 @@ class UnionValuesWithConstructor extends UnionValues
         $scalarWithString = 'Schwifty!',
         $nullableWithString = 'Schwifty!',
         $nullableWithNull = 'Schwifty!',
-        int $integerValue = 42,
+        int $positiveIntegerValue = 42,
+        int $negativeIntegerValue = -42,
         string $stringValueWithSingleQuote = 'foo',
         string $stringValueWithDoubleQuote = 'baz'
     ) {
@@ -115,7 +122,8 @@ class UnionValuesWithConstructor extends UnionValues
         $this->scalarWithString = $scalarWithString;
         $this->nullableWithString = $nullableWithString;
         $this->nullableWithNull = $nullableWithNull;
-        $this->integerValue = $integerValue;
+        $this->positiveIntegerValue = $positiveIntegerValue;
+        $this->negativeIntegerValue = $negativeIntegerValue;
         $this->stringValueWithSingleQuote = $stringValueWithSingleQuote;
         $this->stringValueWithDoubleQuote = $stringValueWithDoubleQuote;
     }

--- a/tests/Integration/Mapping/Object/UnionValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/UnionValuesMappingTest.php
@@ -20,6 +20,8 @@ final class UnionValuesMappingTest extends IntegrationTest
             'scalarWithString' => 'foo',
             'nullableWithString' => 'bar',
             'nullableWithNull' => null,
+            'positiveFloatValue' => 1337.42,
+            'negativeFloatValue' => -1337.42,
             'positiveIntegerValue' => 1337,
             'negativeIntegerValue' => -1337,
             'stringValueWithSingleQuote' => 'bar',
@@ -48,6 +50,8 @@ final class UnionValuesMappingTest extends IntegrationTest
             self::assertSame(null, $result->nullableWithNull);
 
             if ($result instanceof UnionValues) {
+                self::assertSame(1337.42, $result->positiveFloatValue);
+                self::assertSame(-1337.42, $result->negativeFloatValue);
                 self::assertSame(1337, $result->positiveIntegerValue);
                 self::assertSame(-1337, $result->negativeIntegerValue);
                 self::assertSame('bar', $result->stringValueWithSingleQuote);
@@ -77,6 +81,12 @@ class UnionValues
     /** @var string|null|float */
     public $nullableWithNull = 'Schwifty!';
 
+    /** @var 404.42|1337.42 */
+    public float $positiveFloatValue = 404.42;
+
+    /** @var -404.42|-1337.42 */
+    public float $negativeFloatValue = -404.42;
+
     /** @var 42|1337 */
     public int $positiveIntegerValue = 42;
 
@@ -99,6 +109,8 @@ class UnionValuesWithConstructor extends UnionValues
      * @param bool|float|int|string $scalarWithString
      * @param string|null|float $nullableWithString
      * @param string|null|float $nullableWithNull
+     * @param 404.42|1337.42 $positiveFloatValue
+     * @param -404.42|-1337.42 $negativeFloatValue
      * @param 42|1337 $positiveIntegerValue
      * @param -42|-1337 $negativeIntegerValue
      * @param 'foo'|'bar' $stringValueWithSingleQuote
@@ -111,6 +123,8 @@ class UnionValuesWithConstructor extends UnionValues
         $scalarWithString = 'Schwifty!',
         $nullableWithString = 'Schwifty!',
         $nullableWithNull = 'Schwifty!',
+        float $positiveFloatValue = 404.42,
+        float $negativeFloatValue = -404.42,
         int $positiveIntegerValue = 42,
         int $negativeIntegerValue = -42,
         string $stringValueWithSingleQuote = 'foo',
@@ -122,6 +136,8 @@ class UnionValuesWithConstructor extends UnionValues
         $this->scalarWithString = $scalarWithString;
         $this->nullableWithString = $nullableWithString;
         $this->nullableWithNull = $nullableWithNull;
+        $this->positiveFloatValue = $positiveFloatValue;
+        $this->negativeFloatValue = $negativeFloatValue;
         $this->positiveIntegerValue = $positiveIntegerValue;
         $this->negativeIntegerValue = $negativeIntegerValue;
         $this->stringValueWithSingleQuote = $stringValueWithSingleQuote;

--- a/tests/Unit/Type/Resolver/Union/UnionScalarNarrowerTest.php
+++ b/tests/Unit/Type/Resolver/Union/UnionScalarNarrowerTest.php
@@ -11,7 +11,7 @@ use CuyZ\Valinor\Type\Resolver\Union\UnionScalarNarrower;
 use CuyZ\Valinor\Type\StringType;
 use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\BooleanType;
-use CuyZ\Valinor\Type\Types\FloatType;
+use CuyZ\Valinor\Type\Types\NativeFloatType;
 use CuyZ\Valinor\Type\Types\NativeIntegerType;
 use CuyZ\Valinor\Type\Types\NativeStringType;
 use CuyZ\Valinor\Type\Types\UndefinedObjectType;
@@ -47,7 +47,7 @@ final class UnionScalarNarrowerTest extends TestCase
     {
         $scalarUnion = new UnionType(
             NativeIntegerType::get(),
-            FloatType::get(),
+            NativeFloatType::get(),
             NativeStringType::get(),
             BooleanType::get(),
         );
@@ -61,12 +61,12 @@ final class UnionScalarNarrowerTest extends TestCase
             'int|float|string|bool with float value' => [
                 'Union type' => $scalarUnion,
                 'Source' => 1337.42,
-                'Expected type' => FloatType::class,
+                'Expected type' => NativeFloatType::class,
             ],
             'int|float with stringed-float value' => [
-                'Union type' => new UnionType(NativeIntegerType::get(), FloatType::get()),
+                'Union type' => new UnionType(NativeIntegerType::get(), NativeFloatType::get()),
                 'Source' => '1337.42',
-                'Expected type' => FloatType::class,
+                'Expected type' => NativeFloatType::class,
             ],
             'int|float|string|bool with string value' => [
                 'Union type' => $scalarUnion,
@@ -88,7 +88,7 @@ final class UnionScalarNarrowerTest extends TestCase
 
     public function test_integer_type_is_narrowed_over_float_when_an_integer_value_is_given(): void
     {
-        $unionType = new UnionType(FloatType::get(), NativeIntegerType::get());
+        $unionType = new UnionType(NativeFloatType::get(), NativeIntegerType::get());
 
         $type = $this->unionScalarNarrower->narrow($unionType, 42);
 
@@ -97,7 +97,7 @@ final class UnionScalarNarrowerTest extends TestCase
 
     public function test_several_possible_types_throws_exception(): void
     {
-        $unionType = new UnionType(BooleanType::get(), NativeIntegerType::get(), FloatType::get());
+        $unionType = new UnionType(BooleanType::get(), NativeIntegerType::get(), NativeFloatType::get());
 
         $this->expectException(CannotResolveTypeFromUnion::class);
         $this->expectExceptionCode(1607027306);

--- a/tests/Unit/Type/Types/FloatValueTypeTest.php
+++ b/tests/Unit/Type/Types/FloatValueTypeTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Unit\Type\Types;
+
+use CuyZ\Valinor\Tests\Fake\Type\FakeType;
+use CuyZ\Valinor\Type\Types\Exception\InvalidFloatValue;
+use CuyZ\Valinor\Type\Types\Exception\InvalidFloatValueType;
+use CuyZ\Valinor\Type\Types\NativeFloatType;
+use CuyZ\Valinor\Type\Types\FloatValueType;
+use CuyZ\Valinor\Type\Types\MixedType;
+use CuyZ\Valinor\Type\Types\UnionType;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class FloatValueTypeTest extends TestCase
+{
+    private FloatValueType $floatValueType;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->floatValueType = new FloatValueType(1337.42);
+    }
+
+    public function test_value_can_be_retrieved(): void
+    {
+        self::assertSame(1337.42, $this->floatValueType->value());
+    }
+
+    public function test_accepts_correct_values(): void
+    {
+        self::assertTrue($this->floatValueType->accepts(1337.42));
+    }
+
+    public function test_does_not_accept_incorrect_values(): void
+    {
+        self::assertFalse($this->floatValueType->accepts(null));
+        self::assertFalse($this->floatValueType->accepts('Schwifty!'));
+        self::assertFalse($this->floatValueType->accepts(404));
+        self::assertFalse($this->floatValueType->accepts(404.42));
+        self::assertFalse($this->floatValueType->accepts(['foo' => 'bar']));
+        self::assertFalse($this->floatValueType->accepts(false));
+        self::assertFalse($this->floatValueType->accepts(new stdClass()));
+    }
+
+    public function test_can_cast_float_value(): void
+    {
+        self::assertTrue($this->floatValueType->canCast(404));
+        self::assertTrue($this->floatValueType->canCast(42.1337));
+        self::assertTrue($this->floatValueType->canCast('42.1337'));
+    }
+
+    public function test_cannot_cast_other_types(): void
+    {
+        self::assertFalse($this->floatValueType->canCast(null));
+        self::assertFalse($this->floatValueType->canCast(['foo' => 'bar']));
+        self::assertFalse($this->floatValueType->canCast('Schwifty!'));
+        self::assertFalse($this->floatValueType->canCast(false));
+        self::assertFalse($this->floatValueType->canCast(new stdClass()));
+    }
+
+    public function test_cast_value_returns_correct_result(): void
+    {
+        self::assertSame(1337.42, $this->floatValueType->cast('1337.42'));
+        self::assertSame(1337.42, $this->floatValueType->cast(1337.42));
+    }
+
+    public function test_cast_invalid_value_throws_exception(): void
+    {
+        $this->expectException(InvalidFloatValueType::class);
+        $this->expectExceptionCode(1652110003);
+        $this->expectExceptionMessage('Value of type `string` does not match float value `1337.42`.');
+
+        $this->floatValueType->cast('foo');
+    }
+
+    public function test_cast_another_float_value_throws_exception(): void
+    {
+        $this->expectException(InvalidFloatValue::class);
+        $this->expectExceptionCode(1652110115);
+        $this->expectExceptionMessage('Value `404.42` does not match expected value `1337.42`.');
+
+        $this->floatValueType->cast('404.42');
+    }
+
+    public function test_string_value_is_correct(): void
+    {
+        self::assertSame('1337.42', (string)$this->floatValueType);
+    }
+
+    public function test_matches_native_float_type(): void
+    {
+        self::assertTrue($this->floatValueType->matches(new NativeFloatType()));
+    }
+
+    public function test_matches_other_float_type_with_same_value(): void
+    {
+        self::assertTrue($this->floatValueType->matches(new FloatValueType(1337.42)));
+    }
+
+    public function test_does_not_match_other_type(): void
+    {
+        self::assertFalse($this->floatValueType->matches(new FakeType()));
+    }
+
+    public function test_matches_mixed_type(): void
+    {
+        self::assertTrue($this->floatValueType->matches(new MixedType()));
+    }
+
+    public function test_matches_union_type_containing_native_float_type(): void
+    {
+        $unionType = new UnionType(
+            new FakeType(),
+            new NativeFloatType(),
+            new FakeType(),
+        );
+
+        self::assertTrue($this->floatValueType->matches($unionType));
+    }
+
+    public function test_matches_union_type_containing_float_type_with_same_value(): void
+    {
+        $unionType = new UnionType(
+            new FakeType(),
+            new FloatValueType(1337.42),
+            new FakeType(),
+        );
+
+        self::assertTrue($this->floatValueType->matches($unionType));
+    }
+
+    public function test_does_not_match_union_type_not_containing_float_type(): void
+    {
+        $unionType = new UnionType(new FakeType(), new FakeType());
+
+        self::assertFalse($this->floatValueType->matches($unionType));
+    }
+}

--- a/tests/Unit/Type/Types/IntegerValueTypeTest.php
+++ b/tests/Unit/Type/Types/IntegerValueTypeTest.php
@@ -27,6 +27,11 @@ final class IntegerValueTypeTest extends TestCase
         $this->type = new IntegerValueType(1337);
     }
 
+    public function test_value_can_be_retrieved(): void
+    {
+        self::assertSame(1337, $this->type->value());
+    }
+
     public function test_accepts_correct_values(): void
     {
         self::assertTrue($this->type->accepts(1337));
@@ -104,7 +109,7 @@ final class IntegerValueTypeTest extends TestCase
         $this->expectExceptionCode(1631090798);
         $this->expectExceptionMessage('Value `42` does not match integer value `1337`.');
 
-        $this->type->cast(42);
+        $this->type->cast('42');
     }
 
     public function test_string_value_is_correct(): void

--- a/tests/Unit/Type/Types/NativeFloatTypeTest.php
+++ b/tests/Unit/Type/Types/NativeFloatTypeTest.php
@@ -7,23 +7,23 @@ namespace CuyZ\Valinor\Tests\Unit\Type\Types;
 use CuyZ\Valinor\Tests\Fake\Type\FakeType;
 use CuyZ\Valinor\Tests\Traits\TestIsSingleton;
 use CuyZ\Valinor\Type\Types\Exception\CannotCastValue;
-use CuyZ\Valinor\Type\Types\FloatType;
+use CuyZ\Valinor\Type\Types\NativeFloatType;
 use CuyZ\Valinor\Type\Types\MixedType;
 use CuyZ\Valinor\Type\Types\UnionType;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-final class FloatTypeTest extends TestCase
+final class NativeFloatTypeTest extends TestCase
 {
     use TestIsSingleton;
 
-    private FloatType $floatType;
+    private NativeFloatType $floatType;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->floatType = new FloatType();
+        $this->floatType = new NativeFloatType();
     }
 
     public function test_accepts_correct_values(): void
@@ -101,8 +101,8 @@ final class FloatTypeTest extends TestCase
 
     public function test_matches_valid_types(): void
     {
-        $floatTypeA = new FloatType();
-        $floatTypeB = new FloatType();
+        $floatTypeA = new NativeFloatType();
+        $floatTypeB = new NativeFloatType();
 
         self::assertTrue($floatTypeA->matches($floatTypeB));
     }
@@ -121,7 +121,7 @@ final class FloatTypeTest extends TestCase
     {
         $unionType = new UnionType(
             new FakeType(),
-            new FloatType(),
+            new NativeFloatType(),
             new FakeType(),
         );
 

--- a/tests/Unit/Type/Types/ShapedArrayTypeTest.php
+++ b/tests/Unit/Type/Types/ShapedArrayTypeTest.php
@@ -9,7 +9,7 @@ use CuyZ\Valinor\Tests\Fake\Type\FakeType;
 use CuyZ\Valinor\Type\Parser\Exception\Iterable\ShapedArrayElementDuplicatedKey;
 use CuyZ\Valinor\Type\Types\ArrayKeyType;
 use CuyZ\Valinor\Type\Types\ArrayType;
-use CuyZ\Valinor\Type\Types\FloatType;
+use CuyZ\Valinor\Type\Types\NativeFloatType;
 use CuyZ\Valinor\Type\Types\IntegerValueType;
 use CuyZ\Valinor\Type\Types\MixedType;
 use CuyZ\Valinor\Type\Types\NativeIntegerType;
@@ -105,7 +105,7 @@ final class ShapedArrayTypeTest extends TestCase
     public function test_does_not_match_invalid_array_shaped_type(): void
     {
         $otherA = new ShapedArrayType(
-            new ShapedArrayElement(new StringValueType('foo'), new FloatType()),
+            new ShapedArrayElement(new StringValueType('foo'), new NativeFloatType()),
         );
 
         $otherB = new ShapedArrayType(

--- a/tests/Unit/Type/Types/StringValueTypeTest.php
+++ b/tests/Unit/Type/Types/StringValueTypeTest.php
@@ -25,6 +25,11 @@ final class StringValueTypeTest extends TestCase
         $this->type = new StringValueType('Schwifty!');
     }
 
+    public function test_value_can_be_retrieved(): void
+    {
+        self::assertSame('Schwifty!', $this->type->value());
+    }
+
     public function test_accepts_correct_values(): void
     {
         $type = new StringValueType('Schwifty!');


### PR DESCRIPTION
Allows the usage of float values, as follows:

```php
class Foo
{
    /** @var 404.42|1337.42 */
    public readonly float $value;
}
```