### PR TITLE
Feature: setting to disable cache source validation

### DIFF
--- a/src/Definition/Repository/Cache/Compiler/ClassDefinitionCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/ClassDefinitionCompiler.php
@@ -28,13 +28,16 @@ final class ClassDefinitionCompiler implements CacheCompiler, CacheValidationCom
 
     private PropertyDefinitionCompiler $propertyCompiler;
 
-    public function __construct()
+    private bool $validateCacheSource;
+
+    public function __construct(bool $validateCacheSource)
     {
         $this->typeCompiler = new TypeCompiler();
         $this->attributesCompiler = new AttributesCompiler();
 
         $this->methodCompiler = new MethodDefinitionCompiler($this->typeCompiler, $this->attributesCompiler);
         $this->propertyCompiler = new PropertyDefinitionCompiler($this->typeCompiler, $this->attributesCompiler);
+        $this->validateCacheSource = $validateCacheSource;
     }
 
     public function compile($value): string
@@ -71,6 +74,10 @@ final class ClassDefinitionCompiler implements CacheCompiler, CacheValidationCom
     public function compileValidation($value): string
     {
         assert($value instanceof ClassDefinition);
+
+        if ($this->validateCacheSource === false) {
+            return 'true';
+        }
 
         $filename = (Reflection::class($value->name()))->getFileName();
 

--- a/src/Library/Container.php
+++ b/src/Library/Container.php
@@ -173,7 +173,7 @@ final class Container
                 );
 
                 /** @var CacheInterface<ClassDefinition> $cache */
-                $cache = new CompiledPhpFileCache($settings->cacheDir, new ClassDefinitionCompiler());
+                $cache = new CompiledPhpFileCache($settings->cacheDir, new ClassDefinitionCompiler($settings->validateCacheSource));
                 $cache = $this->wrapCache($cache);
 
                 return new CacheClassDefinitionRepository($repository, $cache);

--- a/src/Library/Settings.php
+++ b/src/Library/Settings.php
@@ -32,6 +32,8 @@ final class Settings
 
     public bool $enableLegacyDoctrineAnnotations = PHP_VERSION_ID < 8_00_00;
 
+    public bool $validateCacheSource = true;
+
     public function __construct()
     {
         $this->cacheDir = sys_get_temp_dir();

--- a/src/MapperBuilder.php
+++ b/src/MapperBuilder.php
@@ -199,6 +199,14 @@ final class MapperBuilder
         return $clone;
     }
 
+    public function withDisabledCacheSourceValidation(): self
+    {
+        $clone = clone $this;
+        $clone->settings->validateCacheSource = false;
+
+        return $clone;
+    }
+
     /**
      * @deprecated It is not advised to use DoctrineAnnotation when using
      *             PHP >= 8, you should use built-in PHP attributes instead.

--- a/tests/Functional/Definition/Repository/Cache/Compiler/ClassDefinitionCompilerTest.php
+++ b/tests/Functional/Definition/Repository/Cache/Compiler/ClassDefinitionCompilerTest.php
@@ -32,7 +32,7 @@ final class ClassDefinitionCompilerTest extends TestCase
 
         $this->files = vfsStream::setup();
 
-        $this->compiler = new ClassDefinitionCompiler();
+        $this->compiler = new ClassDefinitionCompiler(true);
     }
 
     public function test_class_definition_is_compiled_correctly(): void

--- a/tests/Unit/Definition/Repository/Cache/Compiler/ClassDefinitionCompilerTest.php
+++ b/tests/Unit/Definition/Repository/Cache/Compiler/ClassDefinitionCompilerTest.php
@@ -6,7 +6,9 @@ namespace CuyZ\Valinor\Tests\Unit\Definition\Repository\Cache\Compiler;
 
 use AssertionError;
 use CuyZ\Valinor\Definition\Repository\Cache\Compiler\ClassDefinitionCompiler;
+use CuyZ\Valinor\Tests\Fake\Definition\FakeClassDefinition;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use stdClass;
 
 final class ClassDefinitionCompilerTest extends TestCase
@@ -17,7 +19,7 @@ final class ClassDefinitionCompilerTest extends TestCase
     {
         parent::setUp();
 
-        $this->compiler = new ClassDefinitionCompiler();
+        $this->compiler = new ClassDefinitionCompiler(true);
     }
 
     public function test_compile_wrong_type_fails_assertion(): void
@@ -32,5 +34,12 @@ final class ClassDefinitionCompilerTest extends TestCase
         $this->expectException(AssertionError::class);
 
         $this->compiler->compileValidation(new stdClass());
+    }
+
+    public function test_compile_validation_always_returns_true_when_source_validation_is_disabled(): void
+    {
+        $compiler = new ClassDefinitionCompiler(false);
+        $classDefinition = FakeClassDefinition::fromReflection(new ReflectionClass(new class () {}));
+        self::assertSame('true', $compiler->compileValidation($classDefinition));
     }
 }

--- a/tests/Unit/MapperBuilderTest.php
+++ b/tests/Unit/MapperBuilderTest.php
@@ -32,6 +32,7 @@ final class MapperBuilderTest extends TestCase
         $builderE = $builderA->alter(static fn (string $value): string => 'foo');
         $builderF = $builderA->withCacheDir(sys_get_temp_dir());
         $builderG = $builderA->enableLegacyDoctrineAnnotations();
+        $builderH = $builderA->withDisabledCacheSourceValidation();
 
         self::assertNotSame($builderA, $builderB);
         self::assertNotSame($builderA, $builderC);
@@ -39,6 +40,7 @@ final class MapperBuilderTest extends TestCase
         self::assertNotSame($builderA, $builderE);
         self::assertNotSame($builderA, $builderF);
         self::assertNotSame($builderA, $builderG);
+        self::assertNotSame($builderA, $builderH);
     }
 
     public function test_mapper_instance_is_the_same(): void


### PR DESCRIPTION
In #116, a new feature `MapperBuilder#warmup` will be introduced, which allows projects to pre-generate cached class definitions within their CI pipeline.

In some projects, this might lead to the problem, that the pipeline is being executed on a different server and thus probably in a different location (path).

The current cache implementation provides an ability to verify if the cache is still "up2date". This is done by comparing the current `filemtime` of the cache-source file in combination with the timepoint of that moment, when the cache file was created/generated.

I'd like to propose a setting to disable that cache validation as (at least in our case) the source-code does not change when its deployed to production. Having some kind of `filemtime` check in non-production systems make absolutely sense and thus this validation should be enabled by default (as it was before).

Happy to get some feedback here.