### PR TITLE
support @var annotion for property promotion parameter

### DIFF
--- a/src/Utility/Reflection/Reflection.php
+++ b/src/Utility/Reflection/Reflection.php
@@ -120,6 +120,7 @@ final class Reflection
 
         if (method_exists($reflection, 'isPromoted') && $reflection->isPromoted()) {
             $type = self::parseDocBlock(
+                // @phpstan-ignore-next-line / parameter is promoted so class exists for sure
                 self::sanitizeDocComment($reflection->getDeclaringClass()->getProperty($reflection->name)),
                 sprintf('@%s?var\s+%s', self::TOOL_EXPRESSION, self::TYPE_EXPRESSION)
             );

--- a/src/Utility/Reflection/Reflection.php
+++ b/src/Utility/Reflection/Reflection.php
@@ -118,7 +118,7 @@ final class Reflection
             );
         }
 
-        if (method_exists($reflection, 'isPromoted') && $reflection->isPromoted()) {
+        if (PHP_VERSION_ID >= 8_00_00 && $reflection->isPromoted()) {
             $type = self::parseDocBlock(
                 // @phpstan-ignore-next-line / parameter is promoted so class exists for sure
                 self::sanitizeDocComment($reflection->getDeclaringClass()->getProperty($reflection->name)),

--- a/tests/Fixture/Object/ObjectWithPropertyPromotion.php
+++ b/tests/Fixture/Object/ObjectWithPropertyPromotion.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Fixture\Object;
+
+// @PHP8.0 move to anonymous class
+final class ObjectWithPropertyPromotion
+{
+    public function __construct(
+        /** @var non-empty-string */
+        public string $someProperty
+    ){
+    }
+}

--- a/tests/Fixture/Object/ObjectWithPropertyPromotion.php
+++ b/tests/Fixture/Object/ObjectWithPropertyPromotion.php
@@ -10,6 +10,6 @@ final class ObjectWithPropertyPromotion
     public function __construct(
         /** @var non-empty-string */
         public string $someProperty
-    ){
+    ) {
     }
 }

--- a/tests/Unit/Utility/Reflection/ReflectionTest.php
+++ b/tests/Unit/Utility/Reflection/ReflectionTest.php
@@ -6,12 +6,14 @@ namespace CuyZ\Valinor\Tests\Unit\Utility\Reflection;
 
 use Closure;
 use CuyZ\Valinor\Tests\Fake\FakeReflector;
+use CuyZ\Valinor\Tests\Fixture\Object\ObjectWithPropertyPromotion;
 use CuyZ\Valinor\Tests\Fixture\Object\ObjectWithPropertyWithNativeIntersectionType;
 use CuyZ\Valinor\Tests\Fixture\Object\ObjectWithPropertyWithNativeUnionType;
 use CuyZ\Valinor\Utility\Reflection\Reflection;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionFunction;
+use ReflectionMethod;
 use ReflectionParameter;
 use ReflectionProperty;
 use ReflectionType;
@@ -178,6 +180,17 @@ final class ReflectionTest extends TestCase
         string $expectedType
     ): void {
         self::assertEquals($expectedType, Reflection::docBlockType($property));
+    }
+
+    /**
+     * @requires PHP >= 8
+     */
+    public function test_docblock_var_type_is_fetched_correctly_with_property_promotion(): void {
+
+        $class = ObjectWithPropertyPromotion::class;
+        $type = Reflection::docBlockType((new ReflectionMethod($class, '__construct'))->getParameters()[0]);
+
+        self::assertEquals('non-empty-string', $type);
     }
 
     /**

--- a/tests/Unit/Utility/Reflection/ReflectionTest.php
+++ b/tests/Unit/Utility/Reflection/ReflectionTest.php
@@ -185,8 +185,8 @@ final class ReflectionTest extends TestCase
     /**
      * @requires PHP >= 8
      */
-    public function test_docblock_var_type_is_fetched_correctly_with_property_promotion(): void {
-
+    public function test_docblock_var_type_is_fetched_correctly_with_property_promotion(): void
+    {
         $class = ObjectWithPropertyPromotion::class;
         $type = Reflection::docBlockType((new ReflectionMethod($class, '__construct'))->getParameters()[0]);
 


### PR DESCRIPTION
Hello, I encountered a problem while trying out the interesting library. I use a lot of dtos with property promotions, my typing was not recognized there and eg. `non-empty-string` was ignored (missing mapping error message).

```php
final class PublishMessage
{
    public function __construct(
        /** @var non-empty-string */
        public readonly string $text
    ) {
    }
}
```

I dug deeper and saw what the problem was. I noticed that in the case of property promotion, the @var annotation is ignored when the constructor is used.

I am of the opinion that with promoted properties the parameters should be treated exactly as properties and thus @var annotation are allowed. So do other tools like phpstan/psalm etc.

I created a first fix, which I would be happy to improve with your feedback.