### PR TITLE
DateTimeObjectBuilder: support dates without time

### DIFF
--- a/src/Mapper/Object/DateTimeObjectBuilder.php
+++ b/src/Mapper/Object/DateTimeObjectBuilder.php
@@ -27,6 +27,7 @@ final class DateTimeObjectBuilder implements ObjectBuilder
 {
     public const DATE_MYSQL = 'Y-m-d H:i:s';
     public const DATE_PGSQL = 'Y-m-d H:i:s.u';
+    public const DATE_WITHOUT_TIME = '!Y-m-d';
 
     /** @var class-string<DateTime|DateTimeImmutable> */
     private string $className;
@@ -95,7 +96,7 @@ final class DateTimeObjectBuilder implements ObjectBuilder
         $formats = [
             self::DATE_MYSQL, self::DATE_PGSQL, DATE_ATOM, DATE_RFC850, DATE_COOKIE,
             DATE_RFC822, DATE_RFC1036, DATE_RFC1123, DATE_RFC2822, DATE_RFC3339,
-            DATE_RFC3339_EXTENDED, DATE_RFC7231, DATE_RSS, DATE_W3C,
+            DATE_RFC3339_EXTENDED, DATE_RFC7231, DATE_RSS, DATE_W3C, self::DATE_WITHOUT_TIME
         ];
 
         foreach ($formats as $format) {

--- a/tests/Integration/Mapping/Object/DateTimeMappingTest.php
+++ b/tests/Integration/Mapping/Object/DateTimeMappingTest.php
@@ -36,6 +36,8 @@ final class DateTimeMappingTest extends IntegrationTest
         $mysqlDate = (new DateTime('@' . $this->buildRandomTimestamp()))->format('Y-m-d H:i:s');
         $pgsqlDate = (new DateTime('@' . $this->buildRandomTimestamp()))->format('Y-m-d H:i:s.u');
 
+        $sqlDateNotTime = '2022-04-30';
+
         try {
             $result = (new MapperBuilder())->mapper()->map(AllDateTimeValues::class, [
                 'dateTimeInterface' => $dateTimeInterface,
@@ -47,6 +49,7 @@ final class DateTimeMappingTest extends IntegrationTest
                 'dateTimeFromArray' => $dateTimeFromArray,
                 'mysqlDate' => $mysqlDate,
                 'pgsqlDate' => $pgsqlDate,
+                'sqlDateNotTime' => $sqlDateNotTime,
 
             ]);
         } catch (MappingError $error) {
@@ -63,6 +66,7 @@ final class DateTimeMappingTest extends IntegrationTest
         self::assertEquals(DateTimeImmutable::createFromFormat($dateTimeFromArray['format'], $dateTimeFromArray['datetime']), $result->dateTimeFromArray);
         self::assertEquals(DateTimeImmutable::createFromFormat(DateTimeObjectBuilder::DATE_MYSQL, $mysqlDate), $result->mysqlDate);
         self::assertEquals(DateTimeImmutable::createFromFormat(DateTimeObjectBuilder::DATE_PGSQL, $pgsqlDate), $result->pgsqlDate);
+        self::assertSame($sqlDateNotTime . ' 00:00:00', $result->sqlDateNotTime->format(DateTimeObjectBuilder::DATE_MYSQL));
     }
 
     public function test_invalid_datetime_throws_exception(): void
@@ -151,4 +155,6 @@ final class AllDateTimeValues
     public DateTimeInterface $mysqlDate;
 
     public DateTimeInterface $pgsqlDate;
+
+    public DateTimeImmutable $sqlDateNotTime;
 }


### PR DESCRIPTION
Hi, here I propose the support for dates without time on `DateTimeObjectBuilder`.