### PR TITLE
MappingError: expose the first error in Exception message

### DIFF
--- a/src/Mapper/MappingError.php
+++ b/src/Mapper/MappingError.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Mapper;
 
 use CuyZ\Valinor\Mapper\Tree\Message\MessagesFlattener;
 use CuyZ\Valinor\Mapper\Tree\Node;
+use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @api */
@@ -17,16 +18,21 @@ final class MappingError extends RuntimeException
     {
         $this->node = $node;
 
-        $firstMessage = '';
-        foreach (new MessagesFlattener($node) as $message) {
-            $firstMessage = $message->withBody(" First error is:\nPath: {node_path}\nGiven value: {original_value}\nError: {original_message}")->__toString();
-            break;
+        $source = ValueDumper::dump($node->sourceValue());
+
+        $errors = (new MessagesFlattener($node))->errors();
+        $errorsCount = count($errors);
+
+        $body = "Could not map type `{$node->type()}` with value $source. A total of $errorsCount errors were encountered.";
+
+        if ($errorsCount === 1) {
+            $body = $errors->getIterator()->current()
+                ->withParameter('root_type', $node->type())
+                ->withBody("Could not map type `{root_type}`. An error occurred at path {node_path}: {original_message}")
+                ->toString();
         }
 
-        parent::__construct(
-            "Could not map type `{$node->type()}` with the given source.{$firstMessage}",
-            1617193185
-        );
+        parent::__construct($body, 1617193185);
     }
 
     public function node(): Node

--- a/src/Mapper/MappingError.php
+++ b/src/Mapper/MappingError.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper;
 
+use CuyZ\Valinor\Mapper\Tree\Message\MessagesFlattener;
 use CuyZ\Valinor\Mapper\Tree\Node;
 use RuntimeException;
 
@@ -16,8 +17,14 @@ final class MappingError extends RuntimeException
     {
         $this->node = $node;
 
+        $firstMessage = '';
+        foreach (new MessagesFlattener($node) as $message) {
+            $firstMessage = $message->withBody(" First error is:\nPath: {node_path}\nGiven value: {original_value}\nError: {original_message}")->__toString();
+            break;
+        }
+
         parent::__construct(
-            "Could not map type `{$node->type()}` with the given source.",
+            "Could not map type `{$node->type()}` with the given source.{$firstMessage}",
             1617193185
         );
     }

--- a/src/Mapper/Tree/Message/MessagesFlattener.php
+++ b/src/Mapper/Tree/Message/MessagesFlattener.php
@@ -7,8 +7,8 @@ namespace CuyZ\Valinor\Mapper\Tree\Message;
 use Countable;
 use CuyZ\Valinor\Mapper\Tree\Node;
 use CuyZ\Valinor\Mapper\Tree\NodeTraverser;
+use Iterator;
 use IteratorAggregate;
-use Traversable;
 
 use function array_filter;
 use function count;
@@ -66,9 +66,9 @@ final class MessagesFlattener implements IteratorAggregate, Countable
     }
 
     /**
-     * @return Traversable<NodeMessage>
+     * @return Iterator<NodeMessage>
      */
-    public function getIterator(): Traversable
+    public function getIterator(): Iterator
     {
         yield from $this->messages;
     }

--- a/tests/Integration/Mapping/MappingErrorTest.php
+++ b/tests/Integration/Mapping/MappingErrorTest.php
@@ -10,22 +10,42 @@ use CuyZ\Valinor\Tests\Integration\IntegrationTest;
 
 final class MappingErrorTest extends IntegrationTest
 {
-    public function test_first_error_is_reported_in_exception_message(): void
+    public function test_mapping_error_code_is_correct(): void
     {
         try {
-            (new MapperBuilder())
-                ->mapper()
-                ->map(
-                    'array{foo: string, bar: int}',
-                    ['foo' => [], 'bar' => []]
-                );
+            (new MapperBuilder())->mapper()->map('string', ['foo']);
+
             self::fail();
         } catch (MappingError $exception) {
-            self::assertStringContainsString('Path: foo', $exception->getMessage());
-            self::assertStringContainsString('Given value: array (empty)', $exception->getMessage());
-            self::assertStringContainsString('`string`', $exception->getMessage());
+            self::assertSame(1617193185, $exception->getCode());
+        }
+    }
 
-            self::assertStringNotContainsString('Path: bar', $exception->getMessage());
+    public function test_single_error_details_are_reported_in_exception_message(): void
+    {
+        try {
+            (new MapperBuilder())->mapper()->map('string', ['foo']);
+
+            self::fail();
+        } catch (MappingError $exception) {
+            self::assertSame("Could not map type `string`. An error occurred at path *root*: Value array{0: 'foo'} does not match type `string`.", $exception->getMessage());
+        }
+    }
+
+    public function test_several_errors_count_are_reported_in_exception_message(): void
+    {
+        try {
+            (new MapperBuilder())->mapper()->map(
+                'array{foo: string, bar: int}',
+                ['foo' => 42, 'bar' => 'some string']
+            );
+
+            self::fail();
+        } catch (MappingError $exception) {
+            self::assertSame(
+                "Could not map type `array{foo: string, bar: int}` with value array{foo: 42, bar: 'some string'}. A total of 2 errors were encountered.",
+                $exception->getMessage()
+            );
         }
     }
 }

--- a/tests/Integration/Mapping/MappingErrorTest.php
+++ b/tests/Integration/Mapping/MappingErrorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Mapping;
+
+use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\MapperBuilder;
+use CuyZ\Valinor\Tests\Integration\IntegrationTest;
+
+final class MappingErrorTest extends IntegrationTest
+{
+    public function test_first_error_is_reported_in_exception_message(): void
+    {
+        try {
+            (new MapperBuilder())
+                ->mapper()
+                ->map(
+                    'array{foo: string, bar: int}',
+                    ['foo' => [], 'bar' => []]
+                );
+            self::fail();
+        } catch (MappingError $exception) {
+            self::assertStringContainsString('Path: foo', $exception->getMessage());
+            self::assertStringContainsString('Given value: array (empty)', $exception->getMessage());
+            self::assertStringContainsString('`string`', $exception->getMessage());
+
+            self::assertStringNotContainsString('Path: bar', $exception->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Hi, the [message customization](https://github.com/CuyZ/Valinor#message-customization) is great, but a first feedback without it would be very useful to speed up debugging.

Before and after this PR:

```diff
-CuyZ\Valinor\Mapper\MappingError: Could not map type `array{foo: string, bar: int}` with the given source.
+CuyZ\Valinor\Mapper\MappingError: Could not map type `array{foo: string, bar: int}` with the given source. First error is:
+Path: foo
+Given value: array (empty)
+Error: Cannot be empty and must be filled with a value matching type `string`.
```