### PR TITLE
feat: improve cache warmup

### DIFF
--- a/src/Library/Container.php
+++ b/src/Library/Container.php
@@ -117,13 +117,7 @@ final class Container
 
                 $builder = new InterfaceNodeBuilder(
                     $builder,
-                    new ObjectImplementations(
-                        new FunctionsContainer(
-                            $this->get(FunctionDefinitionRepository::class),
-                            $settings->interfaceMapping
-                        ),
-                        $this->get(TypeParser::class),
-                    ),
+                    $this->get(ObjectImplementations::class),
                     $this->get(ClassDefinitionRepository::class),
                     $this->get(ObjectBuilderFactory::class),
                     $settings->flexible
@@ -144,6 +138,14 @@ final class Container
 
                 return new ErrorCatcherNodeBuilder($builder);
             },
+
+            ObjectImplementations::class => fn () => new ObjectImplementations(
+                new FunctionsContainer(
+                    $this->get(FunctionDefinitionRepository::class),
+                    $settings->interfaceMapping
+                ),
+                $this->get(TypeParser::class),
+            ),
 
             ObjectBuilderFactory::class => function () use ($settings) {
                 $constructors = new FunctionsContainer(
@@ -213,7 +215,9 @@ final class Container
 
             RecursiveCacheWarmupService::class => fn () => new RecursiveCacheWarmupService(
                 $this->get(TypeParser::class),
+                $this->get(ObjectImplementations::class),
                 $this->get(ClassDefinitionRepository::class),
+                $this->get(ObjectBuilderFactory::class)
             ),
 
             CacheInterface::class => function () use ($settings) {

--- a/src/Type/Types/ClassStringType.php
+++ b/src/Type/Types/ClassStringType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Types;
 
+use CuyZ\Valinor\Type\CompositeType;
 use CuyZ\Valinor\Type\ObjectType;
 use CuyZ\Valinor\Type\StringType;
 use CuyZ\Valinor\Type\Type;
@@ -18,7 +19,7 @@ use function is_string;
 use function method_exists;
 
 /** @api */
-final class ClassStringType implements StringType
+final class ClassStringType implements StringType, CompositeType
 {
     /** @var ObjectType|UnionType|null */
     private ?Type $subType;
@@ -128,6 +129,19 @@ final class ClassStringType implements StringType
     public function subType(): ?Type
     {
         return $this->subType;
+    }
+
+    public function traverse(): iterable
+    {
+        if (! $this->subType) {
+            return [];
+        }
+
+        yield $this->subType;
+
+        if ($this->subType instanceof CompositeType) {
+            yield from $this->subType->traverse();
+        }
     }
 
     public function __toString(): string

--- a/tests/Unit/Type/Types/ClassStringTypeTest.php
+++ b/tests/Unit/Type/Types/ClassStringTypeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Unit\Type\Types;
 
+use CuyZ\Valinor\Tests\Fake\Type\FakeObjectCompositeType;
 use CuyZ\Valinor\Tests\Fake\Type\FakeObjectType;
 use CuyZ\Valinor\Tests\Fake\Type\FakeType;
 use CuyZ\Valinor\Tests\Fixture\Object\StringableObject;
@@ -258,5 +259,22 @@ final class ClassStringTypeTest extends TestCase
         $unionType = new UnionType(new FakeType(), new FakeType());
 
         self::assertFalse($classStringType->matches($unionType));
+    }
+
+    public function test_traverse_type_yields_types_recursively(): void
+    {
+        $subTypeA = new FakeType();
+        $subTypeB = new FakeType();
+        $objectTypeA = new FakeObjectCompositeType(stdClass::class, ['Template' => $subTypeA]);
+        $objectTypeB = new FakeObjectCompositeType(stdClass::class, ['Template' => $subTypeB]);
+        $unionType = new UnionType($objectTypeA, $objectTypeB);
+
+        $type = new ClassStringType($unionType);
+
+        self::assertContains($unionType, $type->traverse());
+        self::assertContains($subTypeA, $type->traverse());
+        self::assertContains($subTypeB, $type->traverse());
+        self::assertContains($objectTypeA, $type->traverse());
+        self::assertContains($objectTypeB, $type->traverse());
     }
 }


### PR DESCRIPTION
The Warmup will now recursively handle interface and their class
implementations. It is also done in a more clever way: instead of
warming up all properties and constructors, it takes only what is
needed.