### PR TITLE
Fixing example of typed array mapping

### DIFF
--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -43,11 +43,13 @@ A schema representing the needed structure must be provided, using classes.
 ```php
 final class Thread
 {
+    /**
+     * @param Answer[] $answers
+     */
     public function __construct(
         public readonly int $id,
         public readonly string $content,
         public readonly DateTimeInterface $date,
-        /** @var Answer[] */
         public readonly array $answers, 
     ) {}
 }


### PR DESCRIPTION
Hi!

The given example with `@var` doesn't map answers items to `Answer` class. They remain plain arrays. 
Instead of this I tried with `@param` and it did work well.


TBH I didn't dig too much in code. Maybe this example was written before something changed in Valinors core.