### PR TITLE
Extract promoted property/param attribute based on the attribute target flags

### DIFF
--- a/tests/Fixture/Attribute/PropertyTargetAttribute.php
+++ b/tests/Fixture/Attribute/PropertyTargetAttribute.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace CuyZ\Valinor\Tests\Fixture\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class PropertyTargetAttribute
+{
+}

--- a/tests/Fixture/Object/ObjectWithAttributes.php
+++ b/tests/Fixture/Object/ObjectWithAttributes.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Tests\Fixture\Object;
 
 use CuyZ\Valinor\Tests\Fixture\Attribute\AttributeWithArguments;
 use CuyZ\Valinor\Tests\Fixture\Attribute\BasicAttribute;
+use CuyZ\Valinor\Tests\Fixture\Attribute\PropertyTargetAttribute;
 
 #[BasicAttribute]
 #[AttributeWithArguments('foo', 'bar')]
@@ -15,6 +16,10 @@ final class ObjectWithAttributes
     #[BasicAttribute]
     #[AttributeWithArguments('foo', 'bar')]
     public bool $property;
+
+    public function __construct(#[PropertyTargetAttribute] public bool $promotedProperty)
+    {
+    }
 
     #[BasicAttribute]
     #[AttributeWithArguments('foo', 'bar')]

--- a/tests/Functional/Definition/Repository/Cache/Compiler/AttributesCompilerTest.php
+++ b/tests/Functional/Definition/Repository/Cache/Compiler/AttributesCompilerTest.php
@@ -14,12 +14,14 @@ use CuyZ\Valinor\Tests\Fixture\Annotation\BasicAnnotation;
 use CuyZ\Valinor\Tests\Fixture\Attribute\AttributeWithArguments;
 use CuyZ\Valinor\Tests\Fixture\Attribute\BasicAttribute;
 use CuyZ\Valinor\Tests\Fixture\Attribute\NestedAttribute;
+use CuyZ\Valinor\Tests\Fixture\Attribute\PropertyTargetAttribute;
 use CuyZ\Valinor\Tests\Fixture\Object\ObjectWithAttributes;
 use CuyZ\Valinor\Tests\Fixture\Object\ObjectWithNestedAttributes;
 use Error;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionMethod;
+use ReflectionParameter;
 use ReflectionProperty;
 use stdClass;
 
@@ -320,6 +322,30 @@ final class AttributesCompilerTest extends TestCase
         self::assertTrue($attributes->has(BasicAttribute::class));
         self::assertTrue($attributes->has(AttributeWithArguments::class));
         self::assertTrue($attributes->has(NestedAttribute::class));
+    }
+
+    /**
+     * @requires PHP >= 8
+     */
+    public function test_compiles_native_php_attributes_for_promoted_property_with_property_target_attribute(): void
+    {
+        $reflection = new ReflectionProperty(ObjectWithAttributes::class, 'promotedProperty');
+        $attributes = $this->compile(new NativeAttributes($reflection));
+
+        self::assertCount(1, $attributes);
+        self::assertTrue($attributes->has(PropertyTargetAttribute::class));
+    }
+
+    /**
+     * @requires PHP >= 8
+     */
+    public function test_compiles_an_empty_attributes_instance_for_promoted_parameter_with_property_target_attribute(): void
+    {
+        $reflection = new ReflectionParameter([ObjectWithAttributes::class, '__construct'], 'promotedProperty');
+        $attributes = $this->compile(new NativeAttributes($reflection));
+
+        self::assertCount(0, $attributes);
+        self::assertInstanceOf(EmptyAttributes::class, $attributes);
     }
 
     private function compile(Attributes $attributes): Attributes


### PR DESCRIPTION
First of all, I wanted to thank everyone who has contributed to this amazing library! Good job guys!

I created this PR after dealing with some issues while trying to use `symfony/validator` with Valinor:

```php
use App\Request\ParamConverter\RequestQueryInterface;
use Symfony\Component\Validator\Constraints\Range;

class TestQuery implements RequestQueryInterface
{
    public function __construct(
        #[Range(min: 10)]
        public readonly int $page,
    ) {
    }
}
```

After calling `map()` method I received this exception:

```
Attribute "Symfony\Component\Validator\Constraints\Range" cannot target parameter (allowed targets: method, property)
```

So basically, all Symfony's constraint attributes are declared with these flags:
```php
#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
```

And based on [PHP RFC: Constructor Property Promotion #Attributes](https://wiki.php.net/rfc/constructor_promotion#attributes) promoted properties with attributes will apply to both **property** AND **parameter** reflections, which I hope it'll get improved in the upcoming PHP versions. So in order to fix this issue, I though it should be useful to prepare quick workaround by excluding attributes with errors while trying to create them via `$attribute->newInstance()` call.