### PR TITLE
misc: add fixed value for root node path

### DIFF
--- a/src/Mapper/Tree/Shell.php
+++ b/src/Mapper/Tree/Shell.php
@@ -134,6 +134,10 @@ final class Shell
 
     public function path(): string
     {
+        if (! isset($this->parent)) {
+            return '*root*';
+        }
+
         $node = $this;
         $path = [];
 

--- a/tests/Unit/Mapper/Tree/Builder/TreeNodeTest.php
+++ b/tests/Unit/Mapper/Tree/Builder/TreeNodeTest.php
@@ -29,7 +29,7 @@ final class TreeNodeTest extends TestCase
 
         self::assertTrue($node->isRoot());
         self::assertSame('', $node->name());
-        self::assertSame('', $node->path());
+        self::assertSame('*root*', $node->path());
         self::assertSame($type->toString(), $node->type());
         self::assertTrue($node->sourceFilled());
         self::assertSame('some source value', $node->sourceValue());

--- a/tests/Unit/Mapper/Tree/ShellTest.php
+++ b/tests/Unit/Mapper/Tree/ShellTest.php
@@ -28,6 +28,13 @@ final class ShellTest extends TestCase
         self::assertSame($value, $shell->value());
     }
 
+    public function test_root_path_is_fixed(): void
+    {
+        $shell = Shell::root(new FakeType(), 'foo');
+
+        self::assertSame('*root*', $shell->path());
+    }
+
     public function test_change_type_changes_type(): void
     {
         $typeA = FakeType::matching($typeB = new FakeType());
@@ -66,7 +73,7 @@ final class ShellTest extends TestCase
 
         $this->expectException(NewShellTypeDoesNotMatch::class);
         $this->expectExceptionCode(1628845224);
-        $this->expectExceptionMessage("Trying to change the type of the shell at path ``: `{$typeB->toString()}` is not a valid subtype of `{$typeA->toString()}`.");
+        $this->expectExceptionMessage("Trying to change the type of the shell at path `*root*`: `{$typeB->toString()}` is not a valid subtype of `{$typeA->toString()}`.");
 
         (Shell::root($typeA, []))->withType($typeB);
     }


### PR DESCRIPTION
The path is no longer an empty string, the string `*root*` is now
returned.