### PR TITLE
Introduce configurable date formats for `DateTimeObjectBuilder`

### DIFF
--- a/src/Library/Container.php
+++ b/src/Library/Container.php
@@ -153,7 +153,11 @@ final class Container
 
                 $factory = new ReflectionObjectBuilderFactory();
                 $factory = new ConstructorObjectBuilderFactory($factory, $settings->nativeConstructors, $constructors);
-                $factory = new DateTimeObjectBuilderFactory($factory, $constructors);
+                $factory = new DateTimeObjectBuilderFactory(
+                    $factory,
+                    $constructors,
+                    $settings->dateTimeFormats
+                );
                 $factory = new AttributeObjectBuilderFactory($factory);
                 $factory =  new CollisionObjectBuilderFactory($factory);
 

--- a/src/Library/Settings.php
+++ b/src/Library/Settings.php
@@ -35,6 +35,11 @@ final class Settings
 
     public bool $enableLegacyDoctrineAnnotations = PHP_VERSION_ID < 8_00_00;
 
+    /**
+     * @var non-empty-list<non-empty-string>|null
+     */
+    public ?array $dateTimeFormats = null;
+
     public function __construct()
     {
         $this->interfaceMapping[DateTimeInterface::class] = static fn () => DateTimeImmutable::class;

--- a/src/Mapper/Object/DateTimeObjectBuilder.php
+++ b/src/Mapper/Object/DateTimeObjectBuilder.php
@@ -29,17 +29,28 @@ final class DateTimeObjectBuilder implements ObjectBuilder
     public const DATE_PGSQL = 'Y-m-d H:i:s.u';
     public const DATE_WITHOUT_TIME = '!Y-m-d';
 
+    private const DEFAULT_DATE_TIME_FORMATS = [
+        self::DATE_MYSQL, self::DATE_PGSQL, DATE_ATOM, DATE_RFC850, DATE_COOKIE,
+        DATE_RFC822, DATE_RFC1036, DATE_RFC1123, DATE_RFC2822, DATE_RFC3339,
+        DATE_RFC3339_EXTENDED, DATE_RFC7231, DATE_RSS, DATE_W3C, self::DATE_WITHOUT_TIME
+    ];
+
     /** @var class-string<DateTime|DateTimeImmutable> */
     private string $className;
 
     private Arguments $arguments;
 
+    /** @var non-empty-list<non-empty-string> */
+    private array $formats;
+
     /**
      * @param class-string<DateTime|DateTimeImmutable> $className
+     * @param non-empty-list<non-empty-string>|null $formats
      */
-    public function __construct(string $className)
+    public function __construct(string $className, ?array $formats = null)
     {
         $this->className = $className;
+        $this->formats = $formats ?? self::DEFAULT_DATE_TIME_FORMATS;
     }
 
     public function describeArguments(): Arguments
@@ -98,13 +109,7 @@ final class DateTimeObjectBuilder implements ObjectBuilder
 
     private function tryAllFormats(string $value): ?DateTimeInterface
     {
-        $formats = [
-            self::DATE_MYSQL, self::DATE_PGSQL, DATE_ATOM, DATE_RFC850, DATE_COOKIE,
-            DATE_RFC822, DATE_RFC1036, DATE_RFC1123, DATE_RFC2822, DATE_RFC3339,
-            DATE_RFC3339_EXTENDED, DATE_RFC7231, DATE_RSS, DATE_W3C, self::DATE_WITHOUT_TIME
-        ];
-
-        foreach ($formats as $format) {
+        foreach ($this->formats as $format) {
             $date = $this->tryFormat($value, $format);
 
             if ($date instanceof DateTimeInterface) {

--- a/src/Mapper/Object/Factory/DateTimeObjectBuilderFactory.php
+++ b/src/Mapper/Object/Factory/DateTimeObjectBuilderFactory.php
@@ -25,6 +25,9 @@ final class DateTimeObjectBuilderFactory implements ObjectBuilderFactory
     /** @var array<string, ObjectBuilder[]> */
     private array $builders = [];
 
+    /** @var non-empty-list<non-empty-string>|null */
+    private ?array $dateTimeFormats;
+
     /**
      * @param non-empty-list<non-empty-string>|null $dateTimeFormats
      */

--- a/src/Mapper/Object/Factory/DateTimeObjectBuilderFactory.php
+++ b/src/Mapper/Object/Factory/DateTimeObjectBuilderFactory.php
@@ -25,10 +25,17 @@ final class DateTimeObjectBuilderFactory implements ObjectBuilderFactory
     /** @var array<string, ObjectBuilder[]> */
     private array $builders = [];
 
-    public function __construct(ObjectBuilderFactory $delegate, FunctionsContainer $functions)
-    {
+    /**
+     * @param non-empty-list<non-empty-string>|null $dateTimeFormats
+     */
+    public function __construct(
+        ObjectBuilderFactory $delegate,
+        FunctionsContainer $functions,
+        ?array $dateTimeFormats = null
+    ) {
         $this->delegate = $delegate;
         $this->functions = $functions;
+        $this->dateTimeFormats = $dateTimeFormats;
     }
 
     public function for(ClassDefinition $class): iterable
@@ -68,7 +75,7 @@ final class DateTimeObjectBuilderFactory implements ObjectBuilderFactory
             }
 
             if (! $overridesDefault) {
-                $this->builders[$key][] = new DateTimeObjectBuilder($className);
+                $this->builders[$key][] = new DateTimeObjectBuilder($className, $this->dateTimeFormats);
             }
         }
 

--- a/src/MapperBuilder.php
+++ b/src/MapperBuilder.php
@@ -344,6 +344,17 @@ final class MapperBuilder
         return $this->container()->treeMapper();
     }
 
+    /**
+     * @param non-empty-list<non-empty-string> $formats
+     */
+    public function withDateTimeFormats(array $formats): self
+    {
+        $clone = clone $this;
+        $clone->settings->dateTimeFormats = $formats;
+
+        return $clone;
+    }
+
     public function __clone()
     {
         $this->settings = clone $this->settings;

--- a/tests/Integration/Mapping/Object/DateTimeMappingTest.php
+++ b/tests/Integration/Mapping/Object/DateTimeMappingTest.php
@@ -127,7 +127,6 @@ final class DateTimeMappingTest extends IntegrationTest
             'value' => '2022-08-01T00:00:00+00:00',
         ]);
 
-        self::assertInstanceOf(DateTimeImmutableValue::class, $result);
         self::assertSame('2022-08-01T00:00:00+00:00', $result->value->format(DateTimeInterface::RFC3339));
 
         try {

--- a/tests/Integration/Mapping/Object/DateTimeMappingTest.php
+++ b/tests/Integration/Mapping/Object/DateTimeMappingTest.php
@@ -138,7 +138,7 @@ final class DateTimeMappingTest extends IntegrationTest
         } catch (MappingError $exception) {
             $error = $exception->node()->children()['value']->messages()[0];
 
-            self::assertStringContainsString('Impossible to convert `2022-08-01` to `DateTimeImmutable`', (string) $error);
+            self::assertStringContainsString('Value \'2022-08-01\' does not match a valid date format.', (string) $error);
         }
     }
 

--- a/tests/Unit/MapperBuilderTest.php
+++ b/tests/Unit/MapperBuilderTest.php
@@ -35,6 +35,7 @@ final class MapperBuilderTest extends TestCase
         $builderG = $builderA->filterExceptions(fn () => new FakeErrorMessage());
         $builderH = $builderA->withCacheDir(sys_get_temp_dir());
         $builderI = $builderA->enableLegacyDoctrineAnnotations();
+        $builderJ = $builderA->withDateTimeFormats([DateTimeInterface::RFC2822]);
 
         self::assertNotSame($builderA, $builderB);
         self::assertNotSame($builderA, $builderC);
@@ -44,6 +45,7 @@ final class MapperBuilderTest extends TestCase
         self::assertNotSame($builderA, $builderG);
         self::assertNotSame($builderA, $builderH);
         self::assertNotSame($builderA, $builderI);
+        self::assertNotSame($builderA, $builderJ);
     }
 
     public function test_mapper_instance_is_the_same(): void


### PR DESCRIPTION
Hey there,

since mapping of external API responses should be as performant as possible, I'd really love to configure the formats the `DateTimeObjectBuilder` should actually try to apply.

In our API specs, we do always have either RFC-3339 or `Y-m-d` (only date). Depending on other APIs, maybe other formats are being preferred. To avoid multiple `DateTimeImmutable::createFromFormat` executions with unnecessary formats which are not configured either, I was thinking about adding a way to actually configure these formats globally.

This is actually implemented in a BC compatible way, so unless there are specific formats configured, the "default" formats (as before) are being used.

I have no idea where the best place to actually document this feature would be. I'd say in the README but since there are not all features document, I was unable to find a slot where I could just append this new setting.

Happy to get some feedback.
Until then, thanks for all the work here - this is one of those libraries which had the most impact in my development experience.