### PR TITLE
Ensure cached files do not already exist

### DIFF
--- a/src/Cache/Compiled/CompiledPhpFileCache.php
+++ b/src/Cache/Compiled/CompiledPhpFileCache.php
@@ -86,8 +86,10 @@ final class CompiledPhpFileCache implements CacheInterface
         $tmpFilename = $tmpDir . DIRECTORY_SEPARATOR . uniqid('', true);
         $filename = $this->path($key);
 
-        if (! @file_put_contents($tmpFilename, $code) || ! @rename($tmpFilename, $filename)) {
-            throw new CompiledPhpCacheFileNotWritten($filename);
+        if (!file_exists($filename)) {
+            if (!@file_put_contents($tmpFilename, $code) || !@rename($tmpFilename, $filename)) {
+                throw new CompiledPhpCacheFileNotWritten($filename);
+            }
         }
 
         return true;

--- a/src/Cache/Compiled/CompiledPhpFileCache.php
+++ b/src/Cache/Compiled/CompiledPhpFileCache.php
@@ -86,10 +86,16 @@ final class CompiledPhpFileCache implements CacheInterface
         $tmpFilename = $tmpDir . DIRECTORY_SEPARATOR . uniqid('', true);
         $filename = $this->path($key);
 
-        if (!file_exists($filename)) {
-            if (!@file_put_contents($tmpFilename, $code) || !@rename($tmpFilename, $filename)) {
+        try {
+            if (! @file_put_contents($tmpFilename, $code)) {
+                throw new CompiledPhpCacheFileNotWritten($tmpFilename);
+            }
+
+            if (! file_exists($filename) && ! @rename($tmpFilename, $filename)) {
                 throw new CompiledPhpCacheFileNotWritten($filename);
             }
+        } finally {
+            @unlink($tmpFilename);
         }
 
         return true;

--- a/tests/Unit/Cache/Compiled/CompiledPhpFileCacheTest.php
+++ b/tests/Unit/Cache/Compiled/CompiledPhpFileCacheTest.php
@@ -207,17 +207,46 @@ final class CompiledPhpFileCacheTest extends TestCase
         $this->cache->set('foo', 'foo');
     }
 
-    public function test_cache_file_not_writable_throws_exception(): void
+    public function test_temporary_cache_file_not_writable_throws_exception(): void
     {
         $this->expectException(CompiledPhpCacheFileNotWritten::class);
         $this->expectExceptionCode(1616445695);
-        $this->expectExceptionMessageMatches('/^File `[^`]+` could not be written\.$/');
+        $this->expectExceptionMessageMatches('/^File `[^`]+.valinor.tmp[^`]+` could not be written\.$/');
 
         (vfsStream::newDirectory('.valinor.tmp'))
             ->chmod(0444)
             ->at($this->files);
 
         $this->cache->set('foo', 'foo');
+    }
+
+    public function test_cache_file_not_writable_throws_exception(): void
+    {
+        $this->expectException(CompiledPhpCacheFileNotWritten::class);
+        $this->expectExceptionCode(1616445695);
+        $this->expectExceptionMessageMatches('/^File `[^`]+` could not be written\.$/');
+
+        (vfsStream::newDirectory('.valinor.tmp'))->at($this->files);
+
+        $this->files->chmod(0444);
+
+        $this->cache->set('foo', 'foo');
+    }
+
+    public function test_temporary_cache_file_is_always_deleted(): void
+    {
+        $tmpDirectory = vfsStream::newDirectory('.valinor.tmp');
+        $tmpDirectory->at($this->files);
+
+        $this->files->chmod(0444);
+
+        try {
+            $this->cache->set('foo', 'foo');
+        } catch (CompiledPhpCacheFileNotWritten $exception) {
+            // @PHP8.0 remove variable
+        }
+
+        self::assertEmpty($tmpDirectory->getChildren());
     }
 
     private function currentCacheFile(): vfsStreamFile


### PR DESCRIPTION
seems to be necessary with concurrent requests