### PR TITLE
feat: introduce attribute `DynamicConstructor`

### DIFF
--- a/src/Mapper/Object/DynamicConstructor.php
+++ b/src/Mapper/Object/DynamicConstructor.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Object;
+
+use Attribute;
+use CuyZ\Valinor\MapperBuilder;
+
+/**
+ * This attribute allows the registration of dynamic constructors used when
+ * mapping implementations of interfaces or abstract classes.
+ *
+ * A constructor given to {@see MapperBuilder::registerConstructor()} with this
+ * attribute will be called with the first parameter filled with the name of the
+ * class the mapper needs to build.
+ *
+ * Note that the first parameter of the constructor has to be a string otherwise
+ * an exception will be thrown on mapping.
+ *
+ * ```php
+ * interface SomeInterfaceWithStaticConstructor
+ * {
+ *     public static function from(string $value): self;
+ * }
+ *
+ * final class SomeClassWithInheritedStaticConstructor implements SomeInterfaceWithStaticConstructor
+ * {
+ *     private function __construct(private SomeValueObject $value) {}
+ *
+ *     public static function from(string $value): self
+ *     {
+ *         return new self(new SomeValueObject($value));
+ *     }
+ * }
+ *
+ * (new \CuyZ\Valinor\MapperBuilder())
+ *     ->registerConstructor(
+ *         #[\CuyZ\Valinor\Attribute\DynamicConstructor]
+ *         function (string $className, string $value): SomeInterfaceWithStaticConstructor {
+ *             return $className::from($value);
+ *         }
+ *     )
+ *     ->mapper()
+ *     ->map(SomeClassWithInheritedStaticConstructor::class, 'foo');
+ * ```
+ *
+ * @api
+ */
+#[Attribute(Attribute::TARGET_FUNCTION | Attribute::TARGET_METHOD)]
+final class DynamicConstructor
+{
+}

--- a/src/Mapper/Object/Exception/InvalidConstructorClassTypeParameter.php
+++ b/src/Mapper/Object/Exception/InvalidConstructorClassTypeParameter.php
@@ -6,16 +6,16 @@ namespace CuyZ\Valinor\Mapper\Object\Exception;
 
 use CuyZ\Valinor\Definition\FunctionDefinition;
 use CuyZ\Valinor\Type\Type;
-use RuntimeException;
+use LogicException;
 
 /** @internal */
-final class InvalidClassConstructorType extends RuntimeException
+final class InvalidConstructorClassTypeParameter extends LogicException
 {
     public function __construct(FunctionDefinition $function, Type $type)
     {
         parent::__construct(
-            "Invalid type `{$type->toString()}` handled by constructor `{$function->signature()}`. It must be a valid class name.",
-            1659446121
+            "Invalid type `{$type->toString()}` for the first parameter of the constructor `{$function->signature()}`, it should be of type `class-string`.",
+            1661517000
         );
     }
 }

--- a/src/Mapper/Object/Exception/InvalidConstructorReturnType.php
+++ b/src/Mapper/Object/Exception/InvalidConstructorReturnType.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Object\Exception;
+
+use CuyZ\Valinor\Definition\FunctionDefinition;
+use LogicException;
+
+/** @internal */
+final class InvalidConstructorReturnType extends LogicException
+{
+    public function __construct(FunctionDefinition $function)
+    {
+        parent::__construct(
+            "Invalid return type `{$function->returnType()->toString()}` for constructor `{$function->signature()}`, it must be a valid class name.",
+            1659446121
+        );
+    }
+}

--- a/src/Mapper/Object/Exception/MissingConstructorClassTypeParameter.php
+++ b/src/Mapper/Object/Exception/MissingConstructorClassTypeParameter.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Object\Exception;
+
+use CuyZ\Valinor\Definition\FunctionDefinition;
+use LogicException;
+
+/** @internal */
+final class MissingConstructorClassTypeParameter extends LogicException
+{
+    public function __construct(FunctionDefinition $function)
+    {
+        parent::__construct(
+            "Missing first parameter of type `class-string` for the constructor `{$function->signature()}`.",
+            1661516853
+        );
+    }
+}

--- a/src/Mapper/Object/Factory/DateTimeObjectBuilderFactory.php
+++ b/src/Mapper/Object/Factory/DateTimeObjectBuilderFactory.php
@@ -9,7 +9,7 @@ use CuyZ\Valinor\Definition\FunctionsContainer;
 use CuyZ\Valinor\Mapper\Object\DateTimeObjectBuilder;
 use CuyZ\Valinor\Mapper\Object\FunctionObjectBuilder;
 use CuyZ\Valinor\Mapper\Object\ObjectBuilder;
-use CuyZ\Valinor\Type\Type;
+use CuyZ\Valinor\Type\Types\ClassType;
 use DateTimeInterface;
 
 use function count;
@@ -39,15 +39,16 @@ final class DateTimeObjectBuilderFactory implements ObjectBuilderFactory
             return $this->delegate->for($class);
         }
 
-        return $this->builders($class->type(), $className);
+        return $this->builders($class->type());
     }
 
     /**
-     * @param class-string<DateTimeInterface> $className
      * @return list<ObjectBuilder>
      */
-    private function builders(Type $type, string $className): array
+    private function builders(ClassType $type): array
     {
+        /** @var class-string<DateTimeInterface> $className */
+        $className = $type->className();
         $key = $type->toString();
 
         if (! isset($this->builders[$key])) {
@@ -66,7 +67,7 @@ final class DateTimeObjectBuilderFactory implements ObjectBuilderFactory
                     $overridesDefault = true;
                 }
 
-                $this->builders[$key][] = new FunctionObjectBuilder($function);
+                $this->builders[$key][] = new FunctionObjectBuilder($function, $type);
             }
 
             if (! $overridesDefault) {

--- a/src/Mapper/Object/FunctionObjectBuilder.php
+++ b/src/Mapper/Object/FunctionObjectBuilder.php
@@ -5,29 +5,59 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Object;
 
 use CuyZ\Valinor\Definition\FunctionObject;
+use CuyZ\Valinor\Definition\ParameterDefinition;
 use CuyZ\Valinor\Mapper\Tree\Message\UserlandError;
+use CuyZ\Valinor\Type\Types\ClassType;
 use Exception;
+
+use function array_map;
+use function array_shift;
 
 /** @internal */
 final class FunctionObjectBuilder implements ObjectBuilder
 {
     private FunctionObject $function;
 
+    private string $className;
+
     private Arguments $arguments;
 
-    public function __construct(FunctionObject $function)
+    private bool $isDynamicConstructor;
+
+    public function __construct(FunctionObject $function, ClassType $type)
     {
+        $definition = $function->definition();
+
+        $arguments = array_map(
+            fn (ParameterDefinition $parameter) => Argument::fromParameter($parameter),
+            array_values(iterator_to_array($definition->parameters())) // @PHP8.1 array unpacking
+        );
+
+        $this->isDynamicConstructor = $definition->attributes()->has(DynamicConstructor::class);
+
+        if ($this->isDynamicConstructor) {
+            array_shift($arguments);
+        }
+
         $this->function = $function;
+        $this->className = $type->className();
+        $this->arguments = new Arguments(...$arguments);
     }
 
     public function describeArguments(): Arguments
     {
-        return $this->arguments ??= Arguments::fromParameters($this->function->definition()->parameters());
+        return $this->arguments;
     }
 
     public function build(array $arguments): object
     {
-        $arguments = new MethodArguments($this->function->definition()->parameters(), $arguments);
+        $parameters = $this->function->definition()->parameters();
+
+        if ($this->isDynamicConstructor) {
+            $arguments[$parameters->at(0)->name()] = $this->className;
+        }
+
+        $arguments = new MethodArguments($parameters, $arguments);
 
         try {
             return ($this->function->callback())(...$arguments);

--- a/tests/Unit/Mapper/Object/FunctionObjectBuilderTest.php
+++ b/tests/Unit/Mapper/Object/FunctionObjectBuilderTest.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Tests\Unit\Mapper\Object;
 use CuyZ\Valinor\Definition\FunctionObject;
 use CuyZ\Valinor\Mapper\Object\FunctionObjectBuilder;
 use CuyZ\Valinor\Tests\Fake\Definition\FakeFunctionDefinition;
+use CuyZ\Valinor\Type\Types\ClassType;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -14,7 +15,10 @@ final class FunctionObjectBuilderTest extends TestCase
 {
     public function test_arguments_instance_stays_the_same(): void
     {
-        $objectBuilder = new FunctionObjectBuilder(new FunctionObject(FakeFunctionDefinition::new(), fn () => new stdClass()));
+        $objectBuilder = new FunctionObjectBuilder(
+            new FunctionObject(FakeFunctionDefinition::new(), fn () => new stdClass()),
+            new ClassType(stdClass::class)
+        );
 
         $argumentsA = $objectBuilder->describeArguments();
         $argumentsB = $objectBuilder->describeArguments();


### PR DESCRIPTION
In some situations the type handled by a constructor is only known at
runtime, in which case the constructor needs to know what class must be
used to instantiate the object.

For instance, an interface may declare a static constructor that is then
implemented by several child classes. One solution would be to register
the constructor for each child class, which leads to a lot of
boilerplate code and would require a new registration each time a new
child is created. Another way is to use the attribute
`\CuyZ\Valinor\Mapper\Object\DynamicConstructor`.

When a constructor uses this attribute, its first parameter must be a
string and will be filled with the name of the actual class that the
mapper needs to build when the constructor is called. Other arguments
may be added and will be mapped normally, depending on the source given
to the mapper.

```php
interface InterfaceWithStaticConstructor
{
    public static function from(string $value): self;
}

final class ClassWithInheritedStaticConstructor implements InterfaceWithStaticConstructor
{
    private function __construct(private SomeValueObject $value) {}

    public static function from(string $value): self
    {
        return new self(new SomeValueObject($value));
    }
}

(new \CuyZ\Valinor\MapperBuilder())
    ->registerConstructor(
        #[\CuyZ\Valinor\Attribute\DynamicConstructor]
        function (string $className, string $value): InterfaceWithStaticConstructor {
            return $className::from($value);
        }
    )
    ->mapper()
    ->map(ClassWithInheritedStaticConstructor::class, 'foo');
```