### PR TITLE
Fix psr/simple-cache deprecations

### DIFF
--- a/src/Cache/ChainCache.php
+++ b/src/Cache/ChainCache.php
@@ -30,6 +30,8 @@ final class ChainCache implements CacheInterface
     }
 
     /**
+     * @PHP8.0 add `mixed` return type and remove PHPDoc
+     *
      * @return EntryType|null
      */
     public function get($key, $default = null)

--- a/src/Cache/ChainCache.php
+++ b/src/Cache/ChainCache.php
@@ -29,6 +29,9 @@ final class ChainCache implements CacheInterface
         $this->count = count($caches);
     }
 
+    /**
+     * @return EntryType|null
+     */
     public function get($key, $default = null)
     {
         foreach ($this->delegates as $i => $delegate) {

--- a/src/Cache/Compiled/CompiledPhpFileCache.php
+++ b/src/Cache/Compiled/CompiledPhpFileCache.php
@@ -62,6 +62,9 @@ final class CompiledPhpFileCache implements CacheInterface
         return $this->getFile($filename)->isValid();
     }
 
+    /**
+     * @return EntryType|null
+     */
     public function get($key, $default = null)
     {
         if (! $this->has($key)) {

--- a/src/Cache/Compiled/CompiledPhpFileCache.php
+++ b/src/Cache/Compiled/CompiledPhpFileCache.php
@@ -63,6 +63,8 @@ final class CompiledPhpFileCache implements CacheInterface
     }
 
     /**
+     * @PHP8.0 add `mixed` return type and remove PHPDoc
+     *
      * @return EntryType|null
      */
     public function get($key, $default = null)

--- a/src/Cache/FileSystemCache.php
+++ b/src/Cache/FileSystemCache.php
@@ -51,6 +51,9 @@ final class FileSystemCache implements CacheInterface
         return false;
     }
 
+    /**
+     * @return EntryType|null
+     */
     public function get($key, $default = null)
     {
         foreach ($this->delegates as $delegate) {

--- a/src/Cache/FileSystemCache.php
+++ b/src/Cache/FileSystemCache.php
@@ -52,6 +52,8 @@ final class FileSystemCache implements CacheInterface
     }
 
     /**
+     * @PHP8.0 add `mixed` return type and remove PHPDoc
+     *
      * @return EntryType|null
      */
     public function get($key, $default = null)

--- a/src/Cache/FileWatchingCache.php
+++ b/src/Cache/FileWatchingCache.php
@@ -58,6 +58,8 @@ final class FileWatchingCache implements CacheInterface
     }
 
     /**
+     * @PHP8.0 add `mixed` return type and remove PHPDoc
+     *
      * @return EntryType|TimestampsArray|null
      */
     public function get($key, $default = null)

--- a/src/Cache/FileWatchingCache.php
+++ b/src/Cache/FileWatchingCache.php
@@ -57,6 +57,9 @@ final class FileWatchingCache implements CacheInterface
         return $this->delegate->has($key);
     }
 
+    /**
+     * @return EntryType|TimestampsArray|null
+     */
     public function get($key, $default = null)
     {
         return $this->delegate->get($key, $default);

--- a/src/Cache/KeySanitizerCache.php
+++ b/src/Cache/KeySanitizerCache.php
@@ -43,6 +43,9 @@ final class KeySanitizerCache implements CacheInterface
         $this->sanitize = static fn (string $key) => sha1("$key." . self::$version ??= PHP_VERSION . '/' . Package::version());
     }
 
+    /**
+     * @return EntryType|null
+     */
     public function get($key, $default = null)
     {
         return $this->delegate->get(($this->sanitize)($key), $default);

--- a/src/Cache/KeySanitizerCache.php
+++ b/src/Cache/KeySanitizerCache.php
@@ -44,6 +44,8 @@ final class KeySanitizerCache implements CacheInterface
     }
 
     /**
+     * @PHP8.0 add `mixed` return type and remove PHPDoc
+     *
      * @return EntryType|null
      */
     public function get($key, $default = null)

--- a/src/Cache/RuntimeCache.php
+++ b/src/Cache/RuntimeCache.php
@@ -24,6 +24,9 @@ final class RuntimeCache implements CacheInterface
     /** @var array<string, EntryType> */
     private array $entries = [];
 
+    /**
+     * @return EntryType|null
+     */
     public function get($key, $default = null)
     {
         return $this->entries[$key] ?? $default;

--- a/src/Cache/RuntimeCache.php
+++ b/src/Cache/RuntimeCache.php
@@ -25,6 +25,8 @@ final class RuntimeCache implements CacheInterface
     private array $entries = [];
 
     /**
+     * @PHP8.0 add `mixed` return type and remove PHPDoc
+     *
      * @return EntryType|null
      */
     public function get($key, $default = null)

--- a/tests/Fake/Cache/FakeCache.php
+++ b/tests/Fake/Cache/FakeCache.php
@@ -44,6 +44,9 @@ final class FakeCache implements CacheInterface
         return count($this->entries);
     }
 
+    /**
+     * @return mixed
+     */
     public function get($key, $default = null)
     {
         $this->timesEntryWasFetched[$key] ??= 0;

--- a/tests/Fake/Cache/FakeCache.php
+++ b/tests/Fake/Cache/FakeCache.php
@@ -45,6 +45,8 @@ final class FakeCache implements CacheInterface
     }
 
     /**
+     * @PHP8.0 add `mixed` return type and remove PHPDoc
+     *
      * @return mixed
      */
     public function get($key, $default = null)

--- a/tests/Fake/Cache/FakeFailingCache.php
+++ b/tests/Fake/Cache/FakeFailingCache.php
@@ -12,6 +12,8 @@ use Psr\SimpleCache\CacheInterface;
 final class FakeFailingCache implements CacheInterface
 {
     /**
+     * @PHP8.0 add `mixed` return type and remove PHPDoc
+     *
      * @return mixed
      */
     public function get($key, $default = null)

--- a/tests/Fake/Cache/FakeFailingCache.php
+++ b/tests/Fake/Cache/FakeFailingCache.php
@@ -11,6 +11,9 @@ use Psr\SimpleCache\CacheInterface;
  */
 final class FakeFailingCache implements CacheInterface
 {
+    /**
+     * @return mixed
+     */
     public function get($key, $default = null)
     {
         return null;


### PR DESCRIPTION
Fixes `User Deprecated: Method "Psr\SimpleCache\CacheInterface::get()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "CuyZ\Valinor\Cache\..." now to avoid errors or add an explicit @return annotation to suppress this message.` reported by `symfony/error-handler`.