### PR TITLE
fix: handle constructors that are static anonymous functions

### DIFF
--- a/src/Definition/FunctionDefinition.php
+++ b/src/Definition/FunctionDefinition.php
@@ -22,6 +22,8 @@ final class FunctionDefinition
 
     private bool $isStatic;
 
+    private bool $isClosure;
+
     private Parameters $parameters;
 
     private Type $returnType;
@@ -36,6 +38,7 @@ final class FunctionDefinition
         ?string $fileName,
         ?string $class,
         bool $isStatic,
+        bool $isClosure,
         Parameters $parameters,
         Type $returnType
     ) {
@@ -45,6 +48,7 @@ final class FunctionDefinition
         $this->fileName = $fileName;
         $this->class = $class;
         $this->isStatic = $isStatic;
+        $this->isClosure = $isClosure;
         $this->parameters = $parameters;
         $this->returnType = $returnType;
     }
@@ -80,6 +84,11 @@ final class FunctionDefinition
     public function isStatic(): bool
     {
         return $this->isStatic;
+    }
+
+    public function isClosure(): bool
+    {
+        return $this->isClosure;
     }
 
     /**

--- a/src/Definition/Repository/Cache/Compiler/FunctionDefinitionCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/FunctionDefinitionCompiler.php
@@ -40,6 +40,7 @@ final class FunctionDefinitionCompiler implements CacheCompiler
         $fileName = var_export($value->fileName(), true);
         $class = var_export($value->class(), true);
         $isStatic = var_export($value->isStatic(), true);
+        $isClosure = var_export($value->isClosure(), true);
         $parameters = implode(', ', $parameters);
         $returnType = $this->typeCompiler->compile($value->returnType());
 
@@ -51,6 +52,7 @@ final class FunctionDefinitionCompiler implements CacheCompiler
                 $fileName,
                 $class,
                 $isStatic,
+                $isClosure,
                 new \CuyZ\Valinor\Definition\Parameters($parameters),
                 $returnType
             )

--- a/src/Definition/Repository/Reflection/ReflectionFunctionDefinitionRepository.php
+++ b/src/Definition/Repository/Reflection/ReflectionFunctionDefinitionRepository.php
@@ -12,6 +12,7 @@ use CuyZ\Valinor\Type\Parser\Factory\Specifications\AliasSpecification;
 use CuyZ\Valinor\Type\Parser\Factory\Specifications\ClassContextSpecification;
 use CuyZ\Valinor\Type\Parser\Factory\Specifications\HandleClassGenericSpecification;
 use CuyZ\Valinor\Type\Parser\Factory\TypeParserFactory;
+use CuyZ\Valinor\Utility\Polyfill;
 use CuyZ\Valinor\Utility\Reflection\Reflection;
 use ReflectionFunction;
 use ReflectionParameter;
@@ -44,17 +45,20 @@ final class ReflectionFunctionDefinitionRepository implements FunctionDefinition
             $reflection->getParameters()
         );
 
+        $name = $reflection->getName();
         $class = $reflection->getClosureScopeClass();
         $returnType = $typeResolver->resolveType($reflection);
+        $isClosure = $name === '{closure}' || Polyfill::str_ends_with($name, '\\{closure}');
 
         return new FunctionDefinition(
-            $reflection->getName(),
+            $name,
             Reflection::signature($reflection),
             $this->attributesRepository->for($reflection),
             $reflection->getFileName() ?: null,
             // @PHP 8.0 nullsafe operator
             $class ? $class->name : null,
             $reflection->getClosureThis() === null,
+            $isClosure,
             new Parameters(...$parameters),
             $returnType
         );

--- a/src/Mapper/Object/Factory/ConstructorObjectBuilderFactory.php
+++ b/src/Mapper/Object/Factory/ConstructorObjectBuilderFactory.php
@@ -22,7 +22,6 @@ use CuyZ\Valinor\Type\Types\ClassStringType;
 use CuyZ\Valinor\Type\Types\ClassType;
 use CuyZ\Valinor\Type\Types\InterfaceType;
 use CuyZ\Valinor\Type\Types\NativeStringType;
-use CuyZ\Valinor\Utility\Polyfill;
 
 use function array_key_exists;
 use function count;
@@ -83,10 +82,8 @@ final class ConstructorObjectBuilderFactory implements ObjectBuilderFactory
 
             $definition = $function->definition();
             $functionClass = $definition->class();
-            $isClosure = $definition->name() === '{closure}'
-                || Polyfill::str_ends_with($definition->name(), '\\{closure}');
 
-            if ($functionClass && $definition->isStatic() && ! $isClosure) {
+            if ($functionClass && $definition->isStatic() && ! $definition->isClosure()) {
                 $builders[] = new MethodObjectBuilder($className, $definition->name(), $definition->parameters());
             } else {
                 $builders[] = new FunctionObjectBuilder($function, $classType);

--- a/src/Mapper/Object/Factory/ConstructorObjectBuilderFactory.php
+++ b/src/Mapper/Object/Factory/ConstructorObjectBuilderFactory.php
@@ -22,6 +22,7 @@ use CuyZ\Valinor\Type\Types\ClassStringType;
 use CuyZ\Valinor\Type\Types\ClassType;
 use CuyZ\Valinor\Type\Types\InterfaceType;
 use CuyZ\Valinor\Type\Types\NativeStringType;
+use CuyZ\Valinor\Utility\Polyfill;
 
 use function array_key_exists;
 use function count;
@@ -82,8 +83,10 @@ final class ConstructorObjectBuilderFactory implements ObjectBuilderFactory
 
             $definition = $function->definition();
             $functionClass = $definition->class();
+            $isClosure = $definition->name() === '{closure}'
+                || Polyfill::str_ends_with($definition->name(), '\\{closure}');
 
-            if ($functionClass && $definition->isStatic()) {
+            if ($functionClass && $definition->isStatic() && ! $isClosure) {
                 $builders[] = new MethodObjectBuilder($className, $definition->name(), $definition->parameters());
             } else {
                 $builders[] = new FunctionObjectBuilder($function, $classType);

--- a/tests/Fake/Definition/FakeFunctionDefinition.php
+++ b/tests/Fake/Definition/FakeFunctionDefinition.php
@@ -22,6 +22,7 @@ final class FakeFunctionDefinition
             $fileName ?? 'foo/bar',
             stdClass::class,
             true,
+            true,
             new Parameters(
                 new ParameterDefinition(
                     'bar',

--- a/tests/Functional/Definition/Repository/Cache/Compiler/FunctionDefinitionCompilerTest.php
+++ b/tests/Functional/Definition/Repository/Cache/Compiler/FunctionDefinitionCompilerTest.php
@@ -35,6 +35,7 @@ final class FunctionDefinitionCompilerTest extends TestCase
             'foo/bar',
             stdClass::class,
             true,
+            true,
             new Parameters(
                 new ParameterDefinition(
                     'bar',
@@ -57,6 +58,7 @@ final class FunctionDefinitionCompilerTest extends TestCase
         self::assertSame('foo:42-1337', $compiledFunction->signature());
         self::assertSame('foo/bar', $compiledFunction->fileName());
         self::assertSame(true, $compiledFunction->isStatic());
+        self::assertSame(true, $compiledFunction->isClosure());
         self::assertSame(stdClass::class, $compiledFunction->class());
         self::assertTrue($compiledFunction->parameters()->has('bar'));
         self::assertInstanceOf(NativeStringType::class, $compiledFunction->returnType());


### PR DESCRIPTION
The `MethodObjectBuilder` was incorrectly used when a registered constructor is a static anonymous functions — it was handled like a static method closure `Class::method(...)` and would yield errors like this:

    Error: Call to undefined method stdClass::CuyZ\Valinor\Tests\Integration\Mapping\{closure}()

PHP Reflection does not provide any way of telling static functions and closures of static methods apart, other than checking for the name `{closure}`. We check that `{closure}` is actually the last part of the fully-qualified name, instead of just checking that the string ends with `{closure}`.