### PR TITLE
Switch to using getAtomicTypes

### DIFF
--- a/qa/Psalm/Plugin/TreeMapperPsalmPlugin.php
+++ b/qa/Psalm/Plugin/TreeMapperPsalmPlugin.php
@@ -35,7 +35,7 @@ final class TreeMapperPsalmPlugin implements MethodReturnTypeProviderInterface
 
         $types = [];
 
-        foreach ($type->getChildNodes() as $node) {
+        foreach ($type->getAtomicTypes() as $node) {
             $inferred = self::type($node);
 
             if ($inferred === null) {


### PR DESCRIPTION
`getAtomicTypes` should be used to iterate over the types of a Union, removing the call to `getChildNodes` since it's out of place and may be deprecated in psalm v5.