### PR TITLE
misc: do not use `uniqid()`

### DIFF
--- a/src/Cache/Compiled/CompiledPhpFileCache.php
+++ b/src/Cache/Compiled/CompiledPhpFileCache.php
@@ -16,14 +16,15 @@ use Psr\SimpleCache\CacheInterface;
 use Traversable;
 
 use function assert;
+use function bin2hex;
 use function file_exists;
 use function file_put_contents;
 use function is_dir;
 use function mkdir;
+use function random_bytes;
 use function rename;
 use function sha1;
 use function time;
-use function uniqid;
 use function unlink;
 
 /**
@@ -93,7 +94,7 @@ final class CompiledPhpFileCache implements CacheInterface
         }
 
         /** @infection-ignore-all */
-        $tmpFilename = $tmpDir . DIRECTORY_SEPARATOR . uniqid('', true);
+        $tmpFilename = $tmpDir . DIRECTORY_SEPARATOR . bin2hex(random_bytes(16));
 
         try {
             if (! @file_put_contents($tmpFilename, $code)) {


### PR DESCRIPTION
The return value of `uniqid()` is not very random and easily guessable. While this likely does not introduce any issues in CompiledPhpFileCache, the fact that `uniqid()` is often mis-used in locations where actual randomness is a hard requirement, makes this a red flag.

Replace the use of `uniqid()` to generate a random filename by hexadecimal encoded `random_bytes(16)`, giving 128 Bits of randomness, making the value unguessable in practice and preventing the `CompiledPhpFileCache` from showing up when searching for `uniqid()`.