### PR TITLE
Add additional `export-ignore` files to `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 *.php text eol=lf
 
 /.github/ export-ignore
+/docs/ export-ignore
 /stubs/ export-ignore
 /tests/ export-ignore
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.php-cs-fixer.dist.php export-ignore
+/composer.lock export-ignore
 /infection.json.dist export-ignore
 /phpstan.neon.dist export-ignore
 /psalm.xml export-ignore


### PR DESCRIPTION
The lock file is not useful for downstream consumers and requires more than 200kB of data to be unnecessarily transmitted.

---------------

Also: Is the `/docs/` directory useful within the `vendor/` directory or can that one also be ignored?