### PR TITLE
feat: introduce new helper class to list messages

### DIFF
--- a/docs/pages/message-customization.md
+++ b/docs/pages/message-customization.md
@@ -23,8 +23,9 @@ try {
         ->mapper()
         ->map(SomeClass::class, [/* … */]);
 } catch (\CuyZ\Valinor\Mapper\MappingError $error) {
-    $node = $error->node();
-    $messages = new \CuyZ\Valinor\Mapper\Tree\Message\MessagesFlattener($node);
+    $messages = \CuyZ\Valinor\Mapper\Tree\Message\Messages::flattenFromNode(
+        $error->node()
+    );
 
     foreach ($messages as $message) {
         if ($message->code() === 'some_code') {
@@ -76,8 +77,12 @@ See [ICU documentation] for more information on available syntax.
 
 ## Deeper message customization / translation
 
-For deeper message changes, formatters can be used — for instance to translate
-content.
+For deeper message changes, formatters can be used to customize body and 
+parameters.
+
+!!! note
+
+    Formatters can be added to messages
 
 ### Translation
 

--- a/docs/pages/validation.md
+++ b/docs/pages/validation.md
@@ -16,6 +16,9 @@ recursive object allows retrieving all needed information through the whole
 mapping tree: path, values, types and messages, including the issues that caused
 the exception.
 
+Node messages can be customized and iterated through with the usage of the class 
+`\CuyZ\Valinor\Mapper\Tree\Message\Messages`.
+
 ```php
 try {
    (new \CuyZ\Valinor\MapperBuilder())
@@ -23,9 +26,21 @@ try {
         ->map(SomeClass::class, [/* … */ ]);
 } catch (\CuyZ\Valinor\Mapper\MappingError $error) {
     // Get flatten list of all messages through the whole nodes tree
-    $node = $error->node();
-    $messages = new \CuyZ\Valinor\Mapper\Tree\Message\MessagesFlattener($node);
-    
+    $messages = \CuyZ\Valinor\Mapper\Tree\Message\Messages::flattenFromNode(
+        $error->node()
+    );
+
+    // Formatters can be added and will be applied on all messages
+    $messages = $messages->formatWith(
+        new \CuyZ\Valinor\Mapper\Tree\Message\Formatter\MessageMapFormatter([
+            // …
+        ]),
+        (new \CuyZ\Valinor\Mapper\Tree\Message\Formatter\TranslationMessageFormatter())
+            ->withTranslations([
+                // …
+            ])
+    );
+
     // If only errors are wanted, they can be filtered
     $errorMessages = $messages->errors();
 

--- a/src/Mapper/MappingError.php
+++ b/src/Mapper/MappingError.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper;
 
-use CuyZ\Valinor\Mapper\Tree\Message\MessagesFlattener;
+use CuyZ\Valinor\Mapper\Tree\Message\Messages;
 use CuyZ\Valinor\Mapper\Tree\Node;
 use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
@@ -20,7 +20,7 @@ final class MappingError extends RuntimeException
 
         $source = ValueDumper::dump($node->sourceValue());
 
-        $errors = (new MessagesFlattener($node))->errors();
+        $errors = Messages::flattenFromNode($node)->errors();
         $errorsCount = count($errors);
 
         $body = "Could not map type `{$node->type()}` with value $source. A total of $errorsCount errors were encountered.";

--- a/src/Mapper/Tree/Message/Formatter/CallbackMessageFormatter.php
+++ b/src/Mapper/Tree/Message/Formatter/CallbackMessageFormatter.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Tree\Message\Formatter;
+
+use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
+
+/**
+ * Can be used to easily customize a message with the given callback.
+ *
+ * Example:
+ *
+ * ```php
+ * // Customize the body of messages that have a certain code.
+ * $formatter = new CallbackMessageFormatter(
+ *     fn (NodeMessage $message) => match ($message->code()) {
+ *         'some_code_a',
+ *         'some_code_b',
+ *         'some_code_c' => $message->withBody('some new message body'),
+ *         default => $message
+ *     }
+ * );
+ *
+ * $message = $formatter->format($message);
+ * ```
+ *
+ * @api
+ */
+final class CallbackMessageFormatter implements MessageFormatter
+{
+    /** @var callable(NodeMessage): NodeMessage */
+    private $callback;
+
+    /**
+     * @param callable(NodeMessage): NodeMessage $callback
+     */
+    public function __construct(callable $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    public function format(NodeMessage $message): NodeMessage
+    {
+        return ($this->callback)($message);
+    }
+}

--- a/src/Mapper/Tree/Message/Messages.php
+++ b/src/Mapper/Tree/Message/Messages.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Tree\Message;
+
+use Countable;
+use CuyZ\Valinor\Mapper\Tree\Message\Formatter\MessageFormatter;
+use CuyZ\Valinor\Mapper\Tree\Node;
+use CuyZ\Valinor\Mapper\Tree\NodeTraverser;
+use Iterator;
+use IteratorAggregate;
+
+use function array_filter;
+use function count;
+
+/**
+ * Contains instances of messages. Can be used to flatten all messages of a node
+ * when a mapping error occurs.
+ *
+ * Message formatters can be added and will be applied on all messages.
+ *
+ * ```php
+ * try {
+ *     return (new \CuyZ\Valinor\MapperBuilder())
+ *         ->mapper()
+ *         ->map(SomeClass::class, [/* … * /]);
+ * } catch (\CuyZ\Valinor\Mapper\MappingError $error) {
+ *     // Get a flatten list of all messages through the whole nodes tree
+ *     $messages = \CuyZ\Valinor\Mapper\Tree\Message\Messages::flattenFromNode(
+ *         $error->node()
+ *     );
+ *
+ *     // Formatters can be added and will be applied on all messages
+ *     $messages = $messages->formatWith(
+ *         new \CuyZ\Valinor\Mapper\Tree\Message\Formatter\MessageMapFormatter([
+ *             // …
+ *         ]),
+ *         (new \CuyZ\Valinor\Mapper\Tree\Message\Formatter\TranslationMessageFormatter())
+ *             ->withTranslations([
+ *                 // …
+ *             ])
+ *     );
+ *
+ *     // If only errors are wanted, they can be filtered
+ *     $errors = $messages->errors();
+ *
+ *     foreach ($errors as $errorMessage) {
+ *         // …
+ *     }
+ * }
+ * ```
+ *
+ * @api
+ *
+ * @implements IteratorAggregate<int, NodeMessage>
+ */
+final class Messages implements IteratorAggregate, Countable
+{
+    /** @var list<NodeMessage> */
+    private array $messages;
+
+    /** @var array<MessageFormatter> */
+    private array $formatters = [];
+
+    /**
+     * @no-named-arguments
+     */
+    public function __construct(NodeMessage ...$messages)
+    {
+        $this->messages = $messages;
+    }
+
+    public static function flattenFromNode(Node $node): self
+    {
+        $nodeMessages = (new NodeTraverser(
+            fn (Node $node) => $node->messages()
+        ))->traverse($node);
+
+        $messages = [];
+
+        foreach ($nodeMessages as $messagesGroup) {
+            $messages = [...$messages, ...$messagesGroup];
+        }
+
+        return new self(...$messages);
+    }
+
+    public function errors(): self
+    {
+        $clone = clone $this;
+        $clone->messages = array_filter($clone->messages, fn (NodeMessage $message) => $message->isError());
+
+        return $clone;
+    }
+
+    public function formatWith(MessageFormatter ...$formatters): self
+    {
+        $clone = clone $this;
+        $clone->formatters = [...$clone->formatters, ...$formatters];
+
+        return $clone;
+    }
+
+    /**
+     * @return list<NodeMessage>
+     */
+    public function toArray(): array
+    {
+        return [...$this];
+    }
+
+    public function count(): int
+    {
+        return count($this->messages);
+    }
+
+    /**
+     * @return Iterator<int, NodeMessage>
+     */
+    public function getIterator(): Iterator
+    {
+        foreach ($this->messages as $message) {
+            foreach ($this->formatters as $formatter) {
+                $message = $formatter->format($message);
+            }
+
+            yield $message;
+        }
+    }
+}

--- a/src/Mapper/Tree/Message/MessagesFlattener.php
+++ b/src/Mapper/Tree/Message/MessagesFlattener.php
@@ -14,6 +14,9 @@ use function array_filter;
 use function count;
 
 /**
+ * @deprecated Use this method instead:
+ *     {@see \CuyZ\Valinor\Mapper\Tree\Message\Messages::flattenFromNode()}
+ *
  * Will recursively flatten messages of a node and all its children.
  *
  * This helper can for instance be used when errors occurred during a mapping to

--- a/tests/Fake/Mapper/Tree/Message/FakeNodeMessage.php
+++ b/tests/Fake/Mapper/Tree/Message/FakeNodeMessage.php
@@ -20,6 +20,11 @@ final class FakeNodeMessage
         return self::build($message);
     }
 
+    public static function withBody(string $body): NodeMessage
+    {
+        return self::build(new FakeMessage($body));
+    }
+
     private static function build(Message $message): NodeMessage
     {
         return new NodeMessage(

--- a/tests/Fake/Mapper/Tree/Message/Formatter/FakeMessageFormatter.php
+++ b/tests/Fake/Mapper/Tree/Message/Formatter/FakeMessageFormatter.php
@@ -9,17 +9,36 @@ use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
 
 final class FakeMessageFormatter implements MessageFormatter
 {
+    private string $prefix;
+
     private string $body;
 
-    public function __construct(string $body = null)
+    public static function withPrefix(string $prefix = 'formatted:'): self
     {
-        if ($body) {
-            $this->body = $body;
-        }
+        $instance = new self();
+        $instance->prefix = $prefix;
+
+        return $instance;
+    }
+
+    public static function withBody(string $body): self
+    {
+        $instance = new self();
+        $instance->body = $body;
+
+        return $instance;
     }
 
     public function format(NodeMessage $message): NodeMessage
     {
-        return $message->withBody($this->body ?? "formatted: {$message->body()}");
+        if (isset($this->prefix)) {
+            $body = "$this->prefix {$message->body()}";
+        } elseif (isset($this->body)) {
+            $body = $this->body;
+        } else {
+            $body = $message->body();
+        }
+
+        return $message->withBody($body);
     }
 }

--- a/tests/Unit/Mapper/Tree/Message/Formatter/AggregateMessageFormatterTest.php
+++ b/tests/Unit/Mapper/Tree/Message/Formatter/AggregateMessageFormatterTest.php
@@ -14,12 +14,12 @@ final class AggregateMessageFormatterTest extends TestCase
     public function test_formatters_are_called_in_correct_order(): void
     {
         $formatter = new AggregateMessageFormatter(
-            new FakeMessageFormatter('message A'),
-            new FakeMessageFormatter('message B'),
+            FakeMessageFormatter::withPrefix('prefix A:'),
+            FakeMessageFormatter::withPrefix('prefix B:'),
         );
 
         $message = $formatter->format(FakeNodeMessage::any());
 
-        self::assertSame('message B', (string)$message);
+        self::assertSame('prefix B: prefix A: some message', (string)$message);
     }
 }

--- a/tests/Unit/Mapper/Tree/Message/Formatter/CallbackMessageFormatterTest.php
+++ b/tests/Unit/Mapper/Tree/Message/Formatter/CallbackMessageFormatterTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Unit\Mapper\Tree\Message\Formatter;
+
+use CuyZ\Valinor\Mapper\Tree\Message\Formatter\CallbackMessageFormatter;
+use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
+use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeNodeMessage;
+use PHPUnit\Framework\TestCase;
+
+final class CallbackMessageFormatterTest extends TestCase
+{
+    public function test_callbacks_is_called_and_modifies_message(): void
+    {
+        $message = (FakeNodeMessage::withBody('some message with {some_parameter}'))
+            ->withParameter('some_parameter', 'some_value');
+
+        $formatter = new CallbackMessageFormatter(
+            fn (NodeMessage $message) => $message->withBody('some new message with {some_parameter}')
+        );
+
+        self::assertSame('some new message with some_value', $formatter->format($message)->toString());
+    }
+}

--- a/tests/Unit/Mapper/Tree/Message/Formatter/PlaceHolderMessageFormatterTest.php
+++ b/tests/Unit/Mapper/Tree/Message/Formatter/PlaceHolderMessageFormatterTest.php
@@ -16,7 +16,7 @@ final class PlaceHolderMessageFormatterTest extends TestCase
     public function test_format_message_replaces_placeholders_with_default_values(): void
     {
         $message = FakeNodeMessage::withMessage(new FakeMessage('some message'));
-        $message = (new FakeMessageFormatter('%1$s / %2$s / %3$s / %4$s / %5$s'))->format($message);
+        $message = (FakeMessageFormatter::withBody('%1$s / %2$s / %3$s / %4$s / %5$s'))->format($message);
         $message = (new PlaceHolderMessageFormatter())->format($message);
 
         self::assertSame("some_code / some message / `string` / nodeName / some.node.path", (string)$message);
@@ -25,7 +25,7 @@ final class PlaceHolderMessageFormatterTest extends TestCase
     public function test_format_message_replaces_correct_source_value_if_throwable(): void
     {
         $message = FakeNodeMessage::withMessage(new FakeErrorMessage('some error message'));
-        $message = (new FakeMessageFormatter('original: %2$s'))->format($message);
+        $message = (FakeMessageFormatter::withBody('original: %2$s'))->format($message);
         $message = (new PlaceHolderMessageFormatter())->format($message);
 
         self::assertSame('original: some error message', (string)$message);

--- a/tests/Unit/Mapper/Tree/Message/MessagesTest.php
+++ b/tests/Unit/Mapper/Tree/Message/MessagesTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Unit\Mapper\Tree\Message;
+
+use CuyZ\Valinor\Mapper\Tree\Message\Messages;
+use CuyZ\Valinor\Mapper\Tree\Node;
+use CuyZ\Valinor\Tests\Fake\Mapper\Tree\FakeNode;
+use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeErrorMessage;
+use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeMessage;
+use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeNodeMessage;
+use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\Formatter\FakeMessageFormatter;
+use PHPUnit\Framework\TestCase;
+
+use function count;
+
+final class MessagesTest extends TestCase
+{
+    public function test_iterator_yield_correct_messages(): void
+    {
+        $messageA = FakeNodeMessage::any();
+        $messageB = FakeNodeMessage::any();
+
+        $messages = new Messages($messageA, $messageB);
+
+        self::assertSame([$messageA, $messageB], [...$messages]);
+    }
+
+    public function test_to_array_yield_correct_messages(): void
+    {
+        $messageA = FakeNodeMessage::any();
+        $messageB = FakeNodeMessage::any();
+
+        $messages = new Messages($messageA, $messageB);
+
+        self::assertSame([$messageA, $messageB], $messages->toArray());
+    }
+
+    public function test_count_messages_return_correct_number(): void
+    {
+        $messages = new Messages(FakeNodeMessage::any(), FakeNodeMessage::any());
+
+        self::assertSame(2, count($messages));
+    }
+
+    public function test_filter_errors_returns_only_errors(): void
+    {
+        $messages = new Messages(
+            FakeNodeMessage::withMessage(new FakeMessage()),
+            $errorMessage = FakeNodeMessage::withMessage(new FakeErrorMessage()),
+            FakeNodeMessage::withMessage(new FakeMessage()),
+        );
+
+        $errors = $messages->errors();
+
+        self::assertNotSame($messages, $errors);
+        self::assertSame([$errorMessage], $errors->toArray());
+    }
+
+    public function test_formatter_are_used_on_messages(): void
+    {
+        $messages = new Messages(FakeNodeMessage::withBody('some message'));
+
+        $formatterA = FakeMessageFormatter::withPrefix('prefixA /');
+        $formatterB = FakeMessageFormatter::withPrefix('prefixB /');
+        $formatterC = FakeMessageFormatter::withPrefix('prefixC /');
+
+        $formattedMessages = $messages
+            ->formatWith($formatterA, $formatterB)
+            ->formatWith($formatterC);
+
+        self::assertNotSame($messages, $formattedMessages);
+        self::assertSame('prefixC / prefixB / prefixA / some message', $formattedMessages->toArray()[0]->body());
+    }
+
+    public function test_flatten_from_node_recursively_fetches_all_messages(): void
+    {
+        $node = new Node(
+            true,
+            'nodeName',
+            'some.node.path',
+            'string',
+            true,
+            'some source value',
+            'some value',
+            [
+                new FakeMessage('message A'),
+                new FakeErrorMessage('message B'),
+            ],
+            [
+                'foo' => FakeNode::withMessage(new FakeMessage('message C')),
+                'bar' => FakeNode::withMessage(new FakeErrorMessage('message D')),
+            ]
+        );
+
+        $messages = Messages::flattenFromNode($node)->toArray();
+
+        self::assertSame('message A', $messages[0]->toString());
+        self::assertSame('message B', $messages[1]->toString());
+        self::assertSame('message C', $messages[2]->toString());
+        self::assertSame('message D', $messages[3]->toString());
+    }
+}


### PR DESCRIPTION
The class `\CuyZ\Valinor\Mapper\Tree\Message\MessagesFlattener` is now deprecated in favor of `\CuyZ\Valinor\Mapper\Tree\Message\Messages`.

The behaviour of this new class is the same as the previous one, except for a new method to add formatters, and a new static factory to recursively flatten messages of a node.

```php
try {
    return (new \CuyZ\Valinor\MapperBuilder())
        ->mapper()
        ->map(SomeClass::class, [/* … * /]);
} catch (\CuyZ\Valinor\Mapper\MappingError $error) {
    // Get a flatten list of all messages through the whole nodes tree
    $messages = \CuyZ\Valinor\Mapper\Tree\Message\Messages::flattenFromNode(
        $error->node()
    );

    // Formatters can be added and will be applied on all messages
    $messages = $messages->formatWith(
        new \CuyZ\Valinor\Mapper\Tree\Message\Formatter\MessageMapFormatter([
            // …
        ]),
        (new \CuyZ\Valinor\Mapper\Tree\Message\Formatter\TranslationMessageFormatter())
            ->withTranslations([
                // …
            ])
    );

    // If only errors are wanted, they can be filtered
    $errors = $messages->errors();

    foreach ($errors as $errorMessage) {
        // …
    }
}
```