### PR TITLE
feat: add support for `strict-array` type

### DIFF
--- a/src/Type/Parser/Lexer/NativeLexer.php
+++ b/src/Type/Parser/Lexer/NativeLexer.php
@@ -74,6 +74,7 @@ final class NativeLexer implements TypeLexer
             case 'integer':
                 return IntegerToken::get();
             case 'array':
+            case 'strict-array':
                 return ArrayToken::array();
             case 'non-empty-array':
                 return ArrayToken::nonEmptyArray();

--- a/tests/Functional/Type/Parser/Lexer/NativeLexerTest.php
+++ b/tests/Functional/Type/Parser/Lexer/NativeLexerTest.php
@@ -628,7 +628,6 @@ final class NativeLexerTest extends TestCase
             'type' => ShapedArrayType::class,
         ];
 
-
         yield 'Strict shaped array' => [
             'raw' => 'strict-array{foo: string}',
             'transformed' => 'array{foo: string}',

--- a/tests/Functional/Type/Parser/Lexer/NativeLexerTest.php
+++ b/tests/Functional/Type/Parser/Lexer/NativeLexerTest.php
@@ -628,6 +628,13 @@ final class NativeLexerTest extends TestCase
             'type' => ShapedArrayType::class,
         ];
 
+
+        yield 'Strict shaped array' => [
+            'raw' => 'strict-array{foo: string}',
+            'transformed' => 'array{foo: string}',
+            'type' => ShapedArrayType::class,
+        ];
+
         yield 'Shaped array with single quote key' => [
             'raw' => "array{'foo': string}",
             'transformed' => "array{'foo': string}",


### PR DESCRIPTION
This PR adds basic support for strict array tokens, just so I can keep the new section in the Psalm docs mentioning Valinor as a way to validate strict arrays :)

Phpstan should also support strict array syntax once https://github.com/phpstan/phpdoc-parser/pull/161 is merged.