### PR TITLE
feat: split mapper flexible mode in three distinct modes

### DIFF
--- a/docs/pages/mapping/type-strictness.md
+++ b/docs/pages/mapping/type-strictness.md
@@ -65,15 +65,15 @@ $flexibleMapper->map(
 // => ['foo' => 'foo', 'bar' => []]
 ```
 
-## Enabling superfluous keys
+## Allowing superfluous keys
 
-With this setting enabled, superfluous keys in source arrays will be ignored, 
+With this setting enabled, superfluous keys in source arrays will be allowed, 
 preventing errors when a value is not bound to any object property/parameter or
 shaped array element.
 
 ```php
 (new \CuyZ\Valinor\MapperBuilder())
-    ->enableSuperfluousKeys()
+    ->allowSuperfluousKeys()
     ->mapper()
     ->map(
         'array{foo: string, bar: int}',
@@ -85,14 +85,14 @@ shaped array element.
     );
 ```
 
-## Enabling permissive types
+## Allowing permissive types
 
 This setting allows permissive types `mixed` and `object` to be used during 
 mapping.
 
 ```php
 (new \CuyZ\Valinor\MapperBuilder())
-    ->enablePermissiveTypes()
+    ->allowPermissiveTypes()
     ->mapper()
     ->map(
         'array{foo: string, bar: mixed}',

--- a/src/Library/Container.php
+++ b/src/Library/Container.php
@@ -96,7 +96,7 @@ final class Container
                     ArrayType::class => $arrayNodeBuilder,
                     NonEmptyArrayType::class => $arrayNodeBuilder,
                     IterableType::class => $arrayNodeBuilder,
-                    ShapedArrayType::class => new ShapedArrayNodeBuilder($settings->enableSuperfluousKeys),
+                    ShapedArrayType::class => new ShapedArrayNodeBuilder($settings->allowSuperfluousKeys),
                     ScalarType::class => new ScalarNodeBuilder($settings->enableFlexibleCasting),
                 ]);
 
@@ -107,7 +107,7 @@ final class Container
                     $this->get(ClassDefinitionRepository::class),
                     $this->get(ObjectBuilderFactory::class),
                     $settings->enableFlexibleCasting,
-                    $settings->enableSuperfluousKeys
+                    $settings->allowSuperfluousKeys
                 );
 
                 $builder = new InterfaceNodeBuilder(
@@ -127,7 +127,7 @@ final class Container
                         $settings->valueModifier
                     )
                 );
-                $builder = new StrictNodeBuilder($builder, $settings->enablePermissiveTypes, $settings->enableFlexibleCasting);
+                $builder = new StrictNodeBuilder($builder, $settings->allowPermissiveTypes, $settings->enableFlexibleCasting);
                 $builder = new ShellVisitorNodeBuilder($builder, $this->get(ShellVisitor::class));
 
                 return new ErrorCatcherNodeBuilder($builder, $settings->exceptionFilter);
@@ -153,7 +153,7 @@ final class Container
                 $factory = new AttributeObjectBuilderFactory($factory);
                 $factory = new CollisionObjectBuilderFactory($factory);
 
-                if (! $settings->enablePermissiveTypes) {
+                if (! $settings->allowPermissiveTypes) {
                     $factory = new StrictTypesObjectBuilderFactory($factory);
                 }
 

--- a/src/Library/Container.php
+++ b/src/Library/Container.php
@@ -87,8 +87,8 @@ final class Container
             ShellVisitor::class => fn () => new AttributeShellVisitor(),
 
             NodeBuilder::class => function () use ($settings) {
-                $listNodeBuilder = new ListNodeBuilder($settings->flexible);
-                $arrayNodeBuilder = new ArrayNodeBuilder($settings->flexible);
+                $listNodeBuilder = new ListNodeBuilder($settings->enableFlexibleCasting);
+                $arrayNodeBuilder = new ArrayNodeBuilder($settings->enableFlexibleCasting);
 
                 $builder = new CasterNodeBuilder([
                     ListType::class => $listNodeBuilder,
@@ -96,17 +96,18 @@ final class Container
                     ArrayType::class => $arrayNodeBuilder,
                     NonEmptyArrayType::class => $arrayNodeBuilder,
                     IterableType::class => $arrayNodeBuilder,
-                    ShapedArrayType::class => new ShapedArrayNodeBuilder($settings->flexible),
-                    ScalarType::class => new ScalarNodeBuilder($settings->flexible),
+                    ShapedArrayType::class => new ShapedArrayNodeBuilder($settings->enableSuperfluousKeys),
+                    ScalarType::class => new ScalarNodeBuilder($settings->enableFlexibleCasting),
                 ]);
 
-                $builder = new UnionNodeBuilder($builder, $settings->flexible);
+                $builder = new UnionNodeBuilder($builder, $settings->enableFlexibleCasting);
 
                 $builder = new ClassNodeBuilder(
                     $builder,
                     $this->get(ClassDefinitionRepository::class),
                     $this->get(ObjectBuilderFactory::class),
-                    $settings->flexible
+                    $settings->enableFlexibleCasting,
+                    $settings->enableSuperfluousKeys
                 );
 
                 $builder = new InterfaceNodeBuilder(
@@ -114,7 +115,7 @@ final class Container
                     $this->get(ObjectImplementations::class),
                     $this->get(ClassDefinitionRepository::class),
                     $this->get(ObjectBuilderFactory::class),
-                    $settings->flexible
+                    $settings->enableFlexibleCasting
                 );
 
                 $builder = new CasterProxyNodeBuilder($builder);
@@ -126,7 +127,7 @@ final class Container
                         $settings->valueModifier
                     )
                 );
-                $builder = new StrictNodeBuilder($builder, $settings->flexible);
+                $builder = new StrictNodeBuilder($builder, $settings->enablePermissiveTypes, $settings->enableFlexibleCasting);
                 $builder = new ShellVisitorNodeBuilder($builder, $this->get(ShellVisitor::class));
 
                 return new ErrorCatcherNodeBuilder($builder, $settings->exceptionFilter);
@@ -152,7 +153,7 @@ final class Container
                 $factory = new AttributeObjectBuilderFactory($factory);
                 $factory = new CollisionObjectBuilderFactory($factory);
 
-                if (! $settings->flexible) {
+                if (! $settings->enablePermissiveTypes) {
                     $factory = new StrictTypesObjectBuilderFactory($factory);
                 }
 

--- a/src/Library/Settings.php
+++ b/src/Library/Settings.php
@@ -30,9 +30,9 @@ final class Settings
 
     public bool $enableFlexibleCasting = false;
 
-    public bool $enableSuperfluousKeys = false;
+    public bool $allowSuperfluousKeys = false;
 
-    public bool $enablePermissiveTypes = false;
+    public bool $allowPermissiveTypes = false;
 
     /** @var callable(Throwable): ErrorMessage */
     public $exceptionFilter;

--- a/src/Library/Settings.php
+++ b/src/Library/Settings.php
@@ -28,7 +28,11 @@ final class Settings
     /** @var CacheInterface<mixed> */
     public CacheInterface $cache;
 
-    public bool $flexible = false;
+    public bool $enableFlexibleCasting = false;
+
+    public bool $enableSuperfluousKeys = false;
+
+    public bool $enablePermissiveTypes = false;
 
     /** @var callable(Throwable): ErrorMessage */
     public $exceptionFilter;

--- a/src/Mapper/Object/FilledArguments.php
+++ b/src/Mapper/Object/FilledArguments.php
@@ -28,18 +28,15 @@ final class FilledArguments implements IteratorAggregate
 
     private Arguments $arguments;
 
-    private bool $flexible;
-
-    private function __construct(Arguments $arguments, Shell $shell, bool $flexible)
+    private function __construct(Arguments $arguments, Shell $shell)
     {
         $this->arguments = $arguments;
-        $this->flexible = $flexible;
         $this->hasValue = $shell->hasValue();
     }
 
-    public static function forInterface(Arguments $arguments, Shell $shell, bool $flexible): self
+    public static function forInterface(Arguments $arguments, Shell $shell): self
     {
-        $self = new self($arguments, $shell, $flexible);
+        $self = new self($arguments, $shell);
 
         if ($self->hasValue) {
             if (count($arguments) > 0) {
@@ -50,9 +47,9 @@ final class FilledArguments implements IteratorAggregate
         return $self;
     }
 
-    public static function forClass(Arguments $arguments, Shell $shell, bool $flexible): self
+    public static function forClass(Arguments $arguments, Shell $shell): self
     {
-        $self = new self($arguments, $shell, $flexible);
+        $self = new self($arguments, $shell);
 
         if ($self->hasValue) {
             $self->value = $self->transform($shell->value());
@@ -107,10 +104,6 @@ final class FilledArguments implements IteratorAggregate
             if (! $isArray || ! array_key_exists($name, $source)) {
                 return [$name => $source];
             }
-        }
-
-        if ($argumentsCount === 0 && $this->flexible && ! $isArray) {
-            return [];
         }
 
         if (! $isArray) {

--- a/src/Mapper/Tree/Builder/ArrayNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ArrayNodeBuilder.php
@@ -18,11 +18,11 @@ use function is_array;
 /** @internal */
 final class ArrayNodeBuilder implements NodeBuilder
 {
-    private bool $flexible;
+    private bool $enableFlexibleCasting;
 
-    public function __construct(bool $flexible)
+    public function __construct(bool $enableFlexibleCasting)
     {
-        $this->flexible = $flexible;
+        $this->enableFlexibleCasting = $enableFlexibleCasting;
     }
 
     public function build(Shell $shell, RootNodeBuilder $rootBuilder): TreeNode
@@ -32,7 +32,7 @@ final class ArrayNodeBuilder implements NodeBuilder
 
         assert($type instanceof ArrayType || $type instanceof NonEmptyArrayType || $type instanceof IterableType);
 
-        if (null === $value && $this->flexible) {
+        if ($this->enableFlexibleCasting && $value === null) {
             return TreeNode::branch($shell, [], []);
         }
 

--- a/src/Mapper/Tree/Builder/ClassNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ClassNodeBuilder.php
@@ -26,18 +26,22 @@ final class ClassNodeBuilder implements NodeBuilder
 
     private ObjectBuilderFactory $objectBuilderFactory;
 
-    private bool $flexible;
+    private bool $enableFlexibleCasting;
+
+    private bool $enableSuperfluousKeys;
 
     public function __construct(
         NodeBuilder $delegate,
         ClassDefinitionRepository $classDefinitionRepository,
         ObjectBuilderFactory $objectBuilderFactory,
-        bool $flexible
+        bool $enableFlexibleCasting,
+        bool $enableSuperfluousKeys
     ) {
         $this->delegate = $delegate;
         $this->classDefinitionRepository = $classDefinitionRepository;
         $this->objectBuilderFactory = $objectBuilderFactory;
-        $this->flexible = $flexible;
+        $this->enableFlexibleCasting = $enableFlexibleCasting;
+        $this->enableSuperfluousKeys = $enableSuperfluousKeys;
     }
 
     public function build(Shell $shell, RootNodeBuilder $rootBuilder): TreeNode
@@ -48,8 +52,12 @@ final class ClassNodeBuilder implements NodeBuilder
             return $this->delegate->build($shell, $rootBuilder);
         }
 
+        if ($this->enableFlexibleCasting && $shell->value() === null) {
+            $shell = $shell->withValue([]);
+        }
+
         $builder = $this->builder($shell, ...$classTypes);
-        $arguments = FilledArguments::forClass($builder->describeArguments(), $shell, $this->flexible);
+        $arguments = FilledArguments::forClass($builder->describeArguments(), $shell);
 
         $children = [];
 
@@ -71,8 +79,8 @@ final class ClassNodeBuilder implements NodeBuilder
 
         $node = TreeNode::branch($shell, $object, $children);
 
-        if (! $this->flexible) {
-            $node = $this->checkForUnexpectedKeys($arguments, $node);
+        if (! $this->enableSuperfluousKeys) {
+            $node = $this->checkForSuperfluousKeys($arguments, $node);
         }
 
         return $node;
@@ -125,7 +133,7 @@ final class ClassNodeBuilder implements NodeBuilder
         return $builder->build($arguments);
     }
 
-    private function checkForUnexpectedKeys(FilledArguments $arguments, TreeNode $node): TreeNode
+    private function checkForSuperfluousKeys(FilledArguments $arguments, TreeNode $node): TreeNode
     {
         $superfluousKeys = $arguments->superfluousKeys();
 

--- a/src/Mapper/Tree/Builder/ClassNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ClassNodeBuilder.php
@@ -28,20 +28,20 @@ final class ClassNodeBuilder implements NodeBuilder
 
     private bool $enableFlexibleCasting;
 
-    private bool $enableSuperfluousKeys;
+    private bool $allowSuperfluousKeys;
 
     public function __construct(
         NodeBuilder $delegate,
         ClassDefinitionRepository $classDefinitionRepository,
         ObjectBuilderFactory $objectBuilderFactory,
         bool $enableFlexibleCasting,
-        bool $enableSuperfluousKeys
+        bool $allowSuperfluousKeys
     ) {
         $this->delegate = $delegate;
         $this->classDefinitionRepository = $classDefinitionRepository;
         $this->objectBuilderFactory = $objectBuilderFactory;
         $this->enableFlexibleCasting = $enableFlexibleCasting;
-        $this->enableSuperfluousKeys = $enableSuperfluousKeys;
+        $this->allowSuperfluousKeys = $allowSuperfluousKeys;
     }
 
     public function build(Shell $shell, RootNodeBuilder $rootBuilder): TreeNode
@@ -79,7 +79,7 @@ final class ClassNodeBuilder implements NodeBuilder
 
         $node = TreeNode::branch($shell, $object, $children);
 
-        if (! $this->enableSuperfluousKeys) {
+        if (! $this->allowSuperfluousKeys) {
             $node = $this->checkForSuperfluousKeys($arguments, $node);
         }
 

--- a/src/Mapper/Tree/Builder/InterfaceNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/InterfaceNodeBuilder.php
@@ -27,20 +27,20 @@ final class InterfaceNodeBuilder implements NodeBuilder
 
     private ObjectBuilderFactory $objectBuilderFactory;
 
-    private bool $flexible;
+    private bool $enableFlexibleCasting;
 
     public function __construct(
         NodeBuilder $delegate,
         ObjectImplementations $implementations,
         ClassDefinitionRepository $classDefinitionRepository,
         ObjectBuilderFactory $objectBuilderFactory,
-        bool $flexible
+        bool $enableFlexibleCasting
     ) {
         $this->delegate = $delegate;
         $this->implementations = $implementations;
         $this->classDefinitionRepository = $classDefinitionRepository;
         $this->objectBuilderFactory = $objectBuilderFactory;
-        $this->flexible = $flexible;
+        $this->enableFlexibleCasting = $enableFlexibleCasting;
     }
 
     public function build(Shell $shell, RootNodeBuilder $rootBuilder): TreeNode
@@ -51,11 +51,15 @@ final class InterfaceNodeBuilder implements NodeBuilder
             return $this->delegate->build($shell, $rootBuilder);
         }
 
+        if ($this->enableFlexibleCasting && $shell->value() === null) {
+            $shell = $shell->withValue([]);
+        }
+
         $interfaceName = $type->className();
 
         $function = $this->implementations->function($interfaceName);
         $arguments = Arguments::fromParameters($function->parameters());
-        $arguments = FilledArguments::forInterface($arguments, $shell, $this->flexible);
+        $arguments = FilledArguments::forInterface($arguments, $shell);
 
         $children = $this->children($shell, $arguments, $rootBuilder);
         $values = [];

--- a/src/Mapper/Tree/Builder/ListNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ListNodeBuilder.php
@@ -17,11 +17,11 @@ use function is_array;
 /** @internal */
 final class ListNodeBuilder implements NodeBuilder
 {
-    private bool $flexible;
+    private bool $enableFlexibleCasting;
 
-    public function __construct(bool $flexible)
+    public function __construct(bool $enableFlexibleCasting)
     {
-        $this->flexible = $flexible;
+        $this->enableFlexibleCasting = $enableFlexibleCasting;
     }
 
     public function build(Shell $shell, RootNodeBuilder $rootBuilder): TreeNode
@@ -31,7 +31,7 @@ final class ListNodeBuilder implements NodeBuilder
 
         assert($type instanceof ListType || $type instanceof NonEmptyListType);
 
-        if (null === $value && $this->flexible) {
+        if ($this->enableFlexibleCasting && $value === null) {
             return TreeNode::branch($shell, [], []);
         }
 
@@ -58,7 +58,7 @@ final class ListNodeBuilder implements NodeBuilder
         $children = [];
 
         foreach ($values as $key => $value) {
-            if ($this->flexible || $key === $expected) {
+            if ($this->enableFlexibleCasting || $key === $expected) {
                 $child = $shell->child((string)$expected, $subType);
                 $children[$expected] = $rootBuilder->build($child->withValue($value));
             } else {

--- a/src/Mapper/Tree/Builder/ScalarNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ScalarNodeBuilder.php
@@ -13,11 +13,11 @@ use function assert;
 /** @internal */
 final class ScalarNodeBuilder implements NodeBuilder
 {
-    private bool $flexible;
+    private bool $enableFlexibleCasting;
 
-    public function __construct(bool $flexible)
+    public function __construct(bool $enableFlexibleCasting)
     {
-        $this->flexible = $flexible;
+        $this->enableFlexibleCasting = $enableFlexibleCasting;
     }
 
     public function build(Shell $shell, RootNodeBuilder $rootBuilder): TreeNode
@@ -30,7 +30,7 @@ final class ScalarNodeBuilder implements NodeBuilder
         // The flexible mode is always active for enum types, as it makes no
         // sense not to activate it in the strict mode: a scalar value is always
         // wanted as input.
-        if ((! $this->flexible && ! $type instanceof EnumType) || ! $type->canCast($value)) {
+        if ((! $this->enableFlexibleCasting && ! $type instanceof EnumType) || ! $type->canCast($value)) {
             throw $type->errorMessage();
         }
 

--- a/src/Mapper/Tree/Builder/ShapedArrayNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ShapedArrayNodeBuilder.php
@@ -18,11 +18,11 @@ use function is_array;
 /** @internal */
 final class ShapedArrayNodeBuilder implements NodeBuilder
 {
-    private bool $enableSuperfluousKeys;
+    private bool $allowSuperfluousKeys;
 
-    public function __construct(bool $enableSuperfluousKeys)
+    public function __construct(bool $allowSuperfluousKeys)
     {
-        $this->enableSuperfluousKeys = $enableSuperfluousKeys;
+        $this->allowSuperfluousKeys = $allowSuperfluousKeys;
     }
 
     public function build(Shell $shell, RootNodeBuilder $rootBuilder): TreeNode
@@ -69,7 +69,7 @@ final class ShapedArrayNodeBuilder implements NodeBuilder
             unset($value[$key]);
         }
 
-        if (! $this->enableSuperfluousKeys && count($value) > 0) {
+        if (! $this->allowSuperfluousKeys && count($value) > 0) {
             throw new UnexpectedShapedArrayKeys(array_keys($value), $elements);
         }
 

--- a/src/Mapper/Tree/Builder/ShapedArrayNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ShapedArrayNodeBuilder.php
@@ -18,11 +18,11 @@ use function is_array;
 /** @internal */
 final class ShapedArrayNodeBuilder implements NodeBuilder
 {
-    private bool $flexible;
+    private bool $enableSuperfluousKeys;
 
-    public function __construct(bool $flexible)
+    public function __construct(bool $enableSuperfluousKeys)
     {
-        $this->flexible = $flexible;
+        $this->enableSuperfluousKeys = $enableSuperfluousKeys;
     }
 
     public function build(Shell $shell, RootNodeBuilder $rootBuilder): TreeNode
@@ -69,7 +69,7 @@ final class ShapedArrayNodeBuilder implements NodeBuilder
             unset($value[$key]);
         }
 
-        if (! $this->flexible && count($value) > 0) {
+        if (! $this->enableSuperfluousKeys && count($value) > 0) {
             throw new UnexpectedShapedArrayKeys(array_keys($value), $elements);
         }
 

--- a/src/Mapper/Tree/Builder/StrictNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/StrictNodeBuilder.php
@@ -13,24 +13,27 @@ final class StrictNodeBuilder implements NodeBuilder
 {
     private NodeBuilder $delegate;
 
-    private bool $flexible;
+    private bool $enablePermissiveTypes;
 
-    public function __construct(NodeBuilder $delegate, bool $flexible)
+    private bool $enableFlexibleCasting;
+
+    public function __construct(NodeBuilder $delegate, bool $enablePermissiveTypes, bool $enableFlexibleCasting)
     {
         $this->delegate = $delegate;
-        $this->flexible = $flexible;
+        $this->enablePermissiveTypes = $enablePermissiveTypes;
+        $this->enableFlexibleCasting = $enableFlexibleCasting;
     }
 
     public function build(Shell $shell, RootNodeBuilder $rootBuilder): TreeNode
     {
         $type = $shell->type();
 
-        if (! $this->flexible) {
+        if (! $this->enablePermissiveTypes) {
             TypeHelper::checkPermissiveType($type);
         }
 
         if (! $shell->hasValue()) {
-            if ($this->flexible) {
+            if ($this->enableFlexibleCasting) {
                 return $this->delegate->build($shell->withValue(null), $rootBuilder);
             }
 

--- a/src/Mapper/Tree/Builder/StrictNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/StrictNodeBuilder.php
@@ -13,14 +13,14 @@ final class StrictNodeBuilder implements NodeBuilder
 {
     private NodeBuilder $delegate;
 
-    private bool $enablePermissiveTypes;
+    private bool $allowPermissiveTypes;
 
     private bool $enableFlexibleCasting;
 
-    public function __construct(NodeBuilder $delegate, bool $enablePermissiveTypes, bool $enableFlexibleCasting)
+    public function __construct(NodeBuilder $delegate, bool $allowPermissiveTypes, bool $enableFlexibleCasting)
     {
         $this->delegate = $delegate;
-        $this->enablePermissiveTypes = $enablePermissiveTypes;
+        $this->allowPermissiveTypes = $allowPermissiveTypes;
         $this->enableFlexibleCasting = $enableFlexibleCasting;
     }
 
@@ -28,7 +28,7 @@ final class StrictNodeBuilder implements NodeBuilder
     {
         $type = $shell->type();
 
-        if (! $this->enablePermissiveTypes) {
+        if (! $this->allowPermissiveTypes) {
             TypeHelper::checkPermissiveType($type);
         }
 

--- a/src/Mapper/Tree/Builder/UnionNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/UnionNodeBuilder.php
@@ -19,12 +19,12 @@ final class UnionNodeBuilder implements NodeBuilder
 {
     private NodeBuilder $delegate;
 
-    private bool $flexible;
+    private bool $enableFlexibleCasting;
 
-    public function __construct(NodeBuilder $delegate, bool $flexible)
+    public function __construct(NodeBuilder $delegate, bool $enableFlexibleCasting)
     {
         $this->delegate = $delegate;
-        $this->flexible = $flexible;
+        $this->enableFlexibleCasting = $enableFlexibleCasting;
     }
 
     public function build(Shell $shell, RootNodeBuilder $rootBuilder): TreeNode
@@ -60,7 +60,7 @@ final class UnionNodeBuilder implements NodeBuilder
                 continue;
             }
 
-            if (! $this->flexible && ! $subType instanceof EnumType) {
+            if (! $this->enableFlexibleCasting && ! $subType instanceof EnumType) {
                 continue;
             }
 

--- a/src/MapperBuilder.php
+++ b/src/MapperBuilder.php
@@ -250,15 +250,15 @@ final class MapperBuilder
     /**
      * @deprecated use the following method(s) depending on your needs:
      * @see \CuyZ\Valinor\MapperBuilder::enableFlexibleCasting()
-     * @see \CuyZ\Valinor\MapperBuilder::enableSuperfluousKeys()
-     * @see \CuyZ\Valinor\MapperBuilder::enablePermissiveTypes()
+     * @see \CuyZ\Valinor\MapperBuilder::allowSuperfluousKeys()
+     * @see \CuyZ\Valinor\MapperBuilder::allowPermissiveTypes()
      */
     public function flexible(): self
     {
         $clone = clone $this;
         $clone->settings->enableFlexibleCasting = true;
-        $clone->settings->enableSuperfluousKeys = true;
-        $clone->settings->enablePermissiveTypes = true;
+        $clone->settings->allowSuperfluousKeys = true;
+        $clone->settings->allowPermissiveTypes = true;
 
         return $clone;
     }
@@ -320,7 +320,7 @@ final class MapperBuilder
      *
      * ```php
      * (new \CuyZ\Valinor\MapperBuilder())
-     *     ->enableSuperfluousKeys()
+     *     ->allowSuperfluousKeys()
      *     ->mapper()
      *     ->map(
      *         'array{foo: string, bar: int}',
@@ -332,10 +332,10 @@ final class MapperBuilder
      *     );
      * ```
      */
-    public function enableSuperfluousKeys(): self
+    public function allowSuperfluousKeys(): self
     {
         $clone = clone $this;
-        $clone->settings->enableSuperfluousKeys = true;
+        $clone->settings->allowSuperfluousKeys = true;
 
         return $clone;
     }
@@ -345,7 +345,7 @@ final class MapperBuilder
      *
      * ```php
      * (new \CuyZ\Valinor\MapperBuilder())
-     *     ->enablePermissiveTypes()
+     *     ->allowPermissiveTypes()
      *     ->mapper()
      *     ->map(
      *         'array{foo: string, bar: mixed}',
@@ -356,10 +356,10 @@ final class MapperBuilder
      *     );
      * ```
      */
-    public function enablePermissiveTypes(): self
+    public function allowPermissiveTypes(): self
     {
         $clone = clone $this;
-        $clone->settings->enablePermissiveTypes = true;
+        $clone->settings->allowPermissiveTypes = true;
 
         return $clone;
     }

--- a/src/MapperBuilder.php
+++ b/src/MapperBuilder.php
@@ -248,25 +248,118 @@ final class MapperBuilder
     }
 
     /**
-     * Enables flexible mode for the mapper:
-     *
-     * - Scalar types will be cast whenever possible, for instance an integer
-     *   node will accept any valid numeric value like the string "42".
-     *
-     * - Superfluous keys in source arrays will be ignored, preventing errors
-     *   when a value is not bound to any object property/parameter or shaped
-     *   array element.
-     *
-     * - Permissive types `mixed` and `object` are allowed.
+     * @deprecated use the following method(s) depending on your needs:
+     * @see \CuyZ\Valinor\MapperBuilder::enableFlexibleCasting()
+     * @see \CuyZ\Valinor\MapperBuilder::enableSuperfluousKeys()
+     * @see \CuyZ\Valinor\MapperBuilder::enablePermissiveTypes()
      */
     public function flexible(): self
     {
-        if ($this->settings->flexible) {
-            return $this;
-        }
-
         $clone = clone $this;
-        $clone->settings->flexible = true;
+        $clone->settings->enableFlexibleCasting = true;
+        $clone->settings->enableSuperfluousKeys = true;
+        $clone->settings->enablePermissiveTypes = true;
+
+        return $clone;
+    }
+
+    /**
+     * Changes the behaviours explained below:
+     *
+     * ```php
+     * $flexibleMapper = (new \CuyZ\Valinor\MapperBuilder())
+     *     ->enableFlexibleCasting()
+     *     ->mapper();
+     *
+     * // ---
+     * // Scalar types will accept non-strict values; for instance an integer
+     * // type will accept any valid numeric value like the *string* "42".
+     *
+     * $flexibleMapper->map('int', '42');
+     * // => 42
+     *
+     * // ---
+     * // List type will accept non-incremental keys.
+     *
+     * $flexibleMapper->map('list<int>', ['foo' => 42, 'bar' => 1337]);
+     * // => [0 => 42, 1 => 1338]
+     *
+     * // ---
+     * // If a value is missing in a source for a node that accepts `null`, the
+     * // node will be filled with `null`.
+     *
+     * $flexibleMapper->map(
+     *     'array{foo: string, bar: null|string}',
+     *     ['foo' => 'foo'] // `bar` is missing
+     * );
+     * // => ['foo' => 'foo', 'bar' => null]
+     *
+     * // ---
+     * // Array and list types will convert `null` or missing values to an empty
+     * // array.
+     *
+     * $flexibleMapper->map(
+     *     'array{foo: string, bar: array<string>}',
+     *     ['foo' => 'foo'] // `bar` is missing
+     * );
+     * // => ['foo' => 'foo', 'bar' => []]
+     * ```
+     */
+    public function enableFlexibleCasting(): self
+    {
+        $clone = clone $this;
+        $clone->settings->enableFlexibleCasting = true;
+
+        return $clone;
+    }
+
+    /**
+     * Superfluous keys in source arrays will be ignored, preventing errors when
+     * a value is not bound to any object property/parameter or shaped array
+     * element.
+     *
+     * ```php
+     * (new \CuyZ\Valinor\MapperBuilder())
+     *     ->enableSuperfluousKeys()
+     *     ->mapper()
+     *     ->map(
+     *         'array{foo: string, bar: int}',
+     *         [
+     *             'foo' => 'foo',
+     *             'bar' => 42,
+     *             'baz' => 1337.404, // `baz` will be ignored
+     *         ]
+     *     );
+     * ```
+     */
+    public function enableSuperfluousKeys(): self
+    {
+        $clone = clone $this;
+        $clone->settings->enableSuperfluousKeys = true;
+
+        return $clone;
+    }
+
+    /**
+     * Allows permissive types `mixed` and `object` to be used during mapping.
+     *
+     * ```php
+     * (new \CuyZ\Valinor\MapperBuilder())
+     *     ->enablePermissiveTypes()
+     *     ->mapper()
+     *     ->map(
+     *         'array{foo: string, bar: mixed}',
+     *         [
+     *             'foo' => 'foo',
+     *             'bar' => 42, // Could be any value
+     *         ]
+     *     );
+     * ```
+     */
+    public function enablePermissiveTypes(): self
+    {
+        $clone = clone $this;
+        $clone->settings->enablePermissiveTypes = true;
 
         return $clone;
     }

--- a/tests/Integration/Mapping/Other/PermissiveTypesMappingTest.php
+++ b/tests/Integration/Mapping/Other/PermissiveTypesMappingTest.php
@@ -19,7 +19,7 @@ final class PermissiveTypesMappingTest extends IntegrationTest
     {
         parent::setUp();
 
-        $this->mapper = (new MapperBuilder())->enablePermissiveTypes()->mapper();
+        $this->mapper = (new MapperBuilder())->allowPermissiveTypes()->mapper();
     }
 
     public function test_can_map_to_mixed_type(): void

--- a/tests/Integration/Mapping/Other/PermissiveTypesMappingTest.php
+++ b/tests/Integration/Mapping/Other/PermissiveTypesMappingTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Mapping\Other;
+
+use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\Mapper\TreeMapper;
+use CuyZ\Valinor\MapperBuilder;
+use CuyZ\Valinor\Tests\Integration\IntegrationTest;
+use DateTime;
+use stdClass;
+
+final class PermissiveTypesMappingTest extends IntegrationTest
+{
+    private TreeMapper $mapper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mapper = (new MapperBuilder())->enablePermissiveTypes()->mapper();
+    }
+
+    public function test_can_map_to_mixed_type(): void
+    {
+        try {
+            $result = $this->mapper->map('mixed[]', [
+                'foo' => 'foo',
+                'bar' => 'bar',
+            ]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame(['foo' => 'foo', 'bar' => 'bar'], $result);
+    }
+
+    public function test_can_map_to_undefined_object_type(): void
+    {
+        $source = [new stdClass(), new DateTime()];
+
+        try {
+            $result = $this->mapper->map('object[]', $source);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame($source, $result);
+    }
+}

--- a/tests/Integration/Mapping/Other/StrictMappingTest.php
+++ b/tests/Integration/Mapping/Other/StrictMappingTest.php
@@ -7,7 +7,10 @@ namespace CuyZ\Valinor\Tests\Integration\Mapping\Other;
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Mapper\Object\Exception\PermissiveTypeNotAllowed;
 use CuyZ\Valinor\MapperBuilder;
+use CuyZ\Valinor\Tests\Fixture\Enum\BackedIntegerEnum;
+use CuyZ\Valinor\Tests\Fixture\Enum\BackedStringEnum;
 use CuyZ\Valinor\Tests\Fixture\Enum\ClassWithBackedStringEnum;
+use CuyZ\Valinor\Tests\Fixture\Enum\PureEnum;
 use CuyZ\Valinor\Tests\Integration\IntegrationTest;
 use CuyZ\Valinor\Utility\PermissiveTypeFound;
 use stdClass;
@@ -112,6 +115,186 @@ final class StrictMappingTest extends IntegrationTest
 
             self::assertSame('1655449641', $errorB->code());
             self::assertSame('Cannot be empty and must be filled with a value matching type `foo|bar|baz`.', (string)$errorB);
+        }
+    }
+
+    public function test_null_that_cannot_be_cast_throws_exception(): void
+    {
+        try {
+            (new MapperBuilder())->mapper()->map('int', null);
+        } catch (MappingError $exception) {
+            $error = $exception->node()->messages()[0];
+
+            self::assertSame('Value null is not a valid integer.', (string)$error);
+        }
+    }
+
+    public function test_invalid_float_throws_exception(): void
+    {
+        try {
+            (new MapperBuilder())->mapper()->map('float', 'foo');
+        } catch (MappingError $exception) {
+            $error = $exception->node()->messages()[0];
+
+            self::assertSame("Value 'foo' is not a valid float.", (string)$error);
+        }
+    }
+
+    public function test_invalid_float_value_throws_exception(): void
+    {
+        try {
+            (new MapperBuilder())->mapper()->map('42.404', 1337);
+        } catch (MappingError $exception) {
+            $error = $exception->node()->messages()[0];
+
+            self::assertSame('Value 1337 does not match float value 42.404.', (string)$error);
+        }
+    }
+
+    public function test_invalid_integer_throws_exception(): void
+    {
+        try {
+            (new MapperBuilder())->mapper()->map('int', 'foo');
+        } catch (MappingError $exception) {
+            $error = $exception->node()->messages()[0];
+
+            self::assertSame("Value 'foo' is not a valid integer.", (string)$error);
+        }
+    }
+
+    public function test_invalid_integer_value_throws_exception(): void
+    {
+        try {
+            (new MapperBuilder())->mapper()->map('42', 1337);
+        } catch (MappingError $exception) {
+            $error = $exception->node()->messages()[0];
+
+            self::assertSame('Value 1337 does not match integer value 42.', (string)$error);
+        }
+    }
+
+    public function test_invalid_integer_range_throws_exception(): void
+    {
+        try {
+            (new MapperBuilder())->mapper()->map('int<42, 1337>', 'foo');
+        } catch (MappingError $exception) {
+            $error = $exception->node()->messages()[0];
+
+            self::assertSame("Value 'foo' is not a valid integer between 42 and 1337.", (string)$error);
+        }
+    }
+
+    /**
+     * @requires PHP >= 8.1
+     */
+    public function test_invalid_enum_value_throws_exception(): void
+    {
+        try {
+            (new MapperBuilder())->mapper()->map(PureEnum::class, 'foo');
+        } catch (MappingError $exception) {
+            $error = $exception->node()->messages()[0];
+
+            self::assertSame("Value 'foo' does not match any of 'FOO', 'BAR', 'BAZ'.", (string)$error);
+        }
+    }
+
+    /**
+     * @requires PHP >= 8.1
+     */
+    public function test_invalid_string_enum_value_throws_exception(): void
+    {
+        try {
+            (new MapperBuilder())->mapper()->map(BackedStringEnum::class, new stdClass());
+        } catch (MappingError $exception) {
+            $error = $exception->node()->messages()[0];
+
+            self::assertSame("Value object(stdClass) does not match any of 'foo', 'bar', 'baz'.", (string)$error);
+        }
+    }
+
+    /**
+     * @requires PHP >= 8.1
+     */
+    public function test_invalid_integer_enum_value_throws_exception(): void
+    {
+        try {
+            (new MapperBuilder())->mapper()->map(BackedIntegerEnum::class, false);
+        } catch (MappingError $exception) {
+            $error = $exception->node()->messages()[0];
+
+            self::assertSame("Value false does not match any of 42, 404, 1337.", (string)$error);
+        }
+    }
+
+    public function test_invalid_union_value_throws_exception(): void
+    {
+        try {
+            (new MapperBuilder())->mapper()->map('bool|int|float', 'foo');
+        } catch (MappingError $exception) {
+            $error = $exception->node()->messages()[0];
+
+            self::assertSame('1607027306', $error->code());
+            self::assertSame("Value 'foo' does not match any of `bool`, `int`, `float`.", (string)$error);
+        }
+    }
+
+    public function test_null_in_union_value_throws_exception(): void
+    {
+        try {
+            (new MapperBuilder())->mapper()->map('bool|int|float', null);
+        } catch (MappingError $exception) {
+            $error = $exception->node()->messages()[0];
+
+            self::assertSame('1607027306', $error->code());
+            self::assertSame("Cannot be empty and must be filled with a value matching any of `bool`, `int`, `float`.", (string)$error);
+        }
+    }
+
+    public function test_invalid_array_value_throws_exception(): void
+    {
+        try {
+            (new MapperBuilder())->mapper()->map('array<float>', 'foo');
+        } catch (MappingError $exception) {
+            $error = $exception->node()->messages()[0];
+
+            self::assertSame('1618739163', $error->code());
+            self::assertSame("Value 'foo' does not match type `array<float>`.", (string)$error);
+        }
+    }
+
+    public function test_invalid_list_value_throws_exception(): void
+    {
+        try {
+            (new MapperBuilder())->mapper()->map('list<float>', 'foo');
+        } catch (MappingError $exception) {
+            $error = $exception->node()->messages()[0];
+
+            self::assertSame('1618739163', $error->code());
+            self::assertSame("Value 'foo' does not match type `list<float>`.", (string)$error);
+        }
+    }
+
+    public function test_invalid_shaped_array_value_throws_exception(): void
+    {
+        try {
+            (new MapperBuilder())->mapper()->map('array{foo: string}', 'foo');
+        } catch (MappingError $exception) {
+            $error = $exception->node()->messages()[0];
+
+            self::assertSame('1618739163', $error->code());
+            self::assertSame("Value 'foo' does not match type `array{foo: string}`.", (string)$error);
+        }
+    }
+
+    public function test_invalid_shaped_array_with_object_value_throws_exception(): void
+    {
+        try {
+            (new MapperBuilder())->mapper()->map('array{foo: stdClass}', 'foo');
+        } catch (MappingError $exception) {
+            $error = $exception->node()->messages()[0];
+
+            self::assertSame('1618739163', $error->code());
+            self::assertSame("Invalid value 'foo'.", (string)$error);
         }
     }
 }

--- a/tests/Integration/Mapping/Other/SuperfluousKeysMappingTest.php
+++ b/tests/Integration/Mapping/Other/SuperfluousKeysMappingTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Mapping\Other;
+
+use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\Mapper\TreeMapper;
+use CuyZ\Valinor\MapperBuilder;
+use CuyZ\Valinor\Tests\Integration\IntegrationTest;
+
+final class SuperfluousKeysMappingTest extends IntegrationTest
+{
+    private TreeMapper $mapper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mapper = (new MapperBuilder())->enableSuperfluousKeys()->mapper();
+    }
+
+    public function test_superfluous_shaped_array_values_are_mapped_properly(): void
+    {
+        $source = [
+            'foo' => 'foo',
+            'bar' => 42,
+            'fiz' => 1337.404,
+        ];
+
+        foreach (['array{foo: string, bar: int}', 'array{bar: int, fiz: float}'] as $signature) {
+            try {
+                $result = $this->mapper->map($signature, $source);
+            } catch (MappingError $error) {
+                $this->mappingFail($error);
+            }
+
+            self::assertSame(42, $result['bar']);
+        }
+    }
+
+    public function test_source_matching_two_unions_maps_the_one_with_most_arguments(): void
+    {
+        try {
+            $result = $this->mapper->map(UnionOfBarAndFizAndFoo::class, [
+                ['foo' => 'foo', 'bar' => 'bar', 'fiz' => 'fiz'],
+            ]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        $object = $result->objects[0];
+
+        self::assertInstanceOf(SomeBarAndFizObject::class, $object);
+        self::assertSame('bar', $object->bar);
+        self::assertSame('fiz', $object->fiz);
+    }
+}

--- a/tests/Integration/Mapping/Other/SuperfluousKeysMappingTest.php
+++ b/tests/Integration/Mapping/Other/SuperfluousKeysMappingTest.php
@@ -17,7 +17,7 @@ final class SuperfluousKeysMappingTest extends IntegrationTest
     {
         parent::setUp();
 
-        $this->mapper = (new MapperBuilder())->enableSuperfluousKeys()->mapper();
+        $this->mapper = (new MapperBuilder())->allowSuperfluousKeys()->mapper();
     }
 
     public function test_superfluous_shaped_array_values_are_mapped_properly(): void

--- a/tests/Unit/MapperBuilderTest.php
+++ b/tests/Unit/MapperBuilderTest.php
@@ -34,8 +34,8 @@ final class MapperBuilderTest extends TestCase
         $builderE = $builderA->alter(static fn (string $value): string => 'foo');
         $builderF = $builderA->flexible();
         $builderG = $builderA->enableFlexibleCasting();
-        $builderH = $builderA->enableSuperfluousKeys();
-        $builderI = $builderA->enablePermissiveTypes();
+        $builderH = $builderA->allowSuperfluousKeys();
+        $builderI = $builderA->allowPermissiveTypes();
         $builderJ = $builderA->filterExceptions(fn () => new FakeErrorMessage());
         $builderK = $builderA->withCache(new FakeCache());
         $builderL = $builderA->withCacheDir(sys_get_temp_dir());

--- a/tests/Unit/MapperBuilderTest.php
+++ b/tests/Unit/MapperBuilderTest.php
@@ -33,10 +33,13 @@ final class MapperBuilderTest extends TestCase
         $builderD = $builderA->registerConstructor(static fn (): stdClass => new stdClass());
         $builderE = $builderA->alter(static fn (string $value): string => 'foo');
         $builderF = $builderA->flexible();
-        $builderG = $builderA->filterExceptions(fn () => new FakeErrorMessage());
-        $builderH = $builderA->withCache(new FakeCache());
-        $builderI = $builderA->withCacheDir(sys_get_temp_dir());
-        $builderJ = $builderA->enableLegacyDoctrineAnnotations();
+        $builderG = $builderA->enableFlexibleCasting();
+        $builderH = $builderA->enableSuperfluousKeys();
+        $builderI = $builderA->enablePermissiveTypes();
+        $builderJ = $builderA->filterExceptions(fn () => new FakeErrorMessage());
+        $builderK = $builderA->withCache(new FakeCache());
+        $builderL = $builderA->withCacheDir(sys_get_temp_dir());
+        $builderM = $builderA->enableLegacyDoctrineAnnotations();
 
         self::assertNotSame($builderA, $builderB);
         self::assertNotSame($builderA, $builderC);
@@ -47,6 +50,9 @@ final class MapperBuilderTest extends TestCase
         self::assertNotSame($builderA, $builderH);
         self::assertNotSame($builderA, $builderI);
         self::assertNotSame($builderA, $builderJ);
+        self::assertNotSame($builderA, $builderK);
+        self::assertNotSame($builderA, $builderL);
+        self::assertNotSame($builderA, $builderM);
     }
 
     public function test_mapper_instance_is_the_same(): void


### PR DESCRIPTION
The flexible mode has been deprecated in favor of three modes with
distinct roles.

1. **The flexible casting**

   Changes the behaviours explained below:

   ```php
   $flexibleMapper = (new \CuyZ\Valinor\MapperBuilder())
       ->enableFlexibleCasting()
       ->mapper();

   // ---
   // Scalar types will accept non-strict values; for instance an
   // integer type will accept any valid numeric value like the
   // *string* "42".

   $flexibleMapper->map('int', '42');
   // => 42

   // ---
   // List type will accept non-incremental keys.

   $flexibleMapper->map('list<int>', ['foo' => 42, 'bar' => 1337]);
   // => [0 => 42, 1 => 1338]

   // ---
   // If a value is missing in a source for a node that accepts `null`,
   // the node will be filled with `null`.

   $flexibleMapper->map(
       'array{foo: string, bar: null|string}',
       ['foo' => 'foo'] // `bar` is missing
   );
   // => ['foo' => 'foo', 'bar' => null]

   // ---
   // Array and list types will convert `null` or missing values to an
   // empty array.

   $flexibleMapper->map(
       'array{foo: string, bar: array<string>}',
       ['foo' => 'foo'] // `bar` is missing
   );
   // => ['foo' => 'foo', 'bar' => []]
   ```

2. **The superfluous keys**

   Superfluous keys in source arrays will be ignored, preventing errors
   when a value is not bound to any object property/parameter or shaped
   array element.

   ```php
   (new \CuyZ\Valinor\MapperBuilder())
       ->enableSuperfluousKeys()
       ->mapper()
       ->map(
           'array{foo: string, bar: int}',
           [
               'foo' => 'foo',
               'bar' => 42,
               'baz' => 1337.404, // `baz` will be ignored
           ]
       );
   ```

3. **The permissive types**

   Allows permissive types `mixed` and `object` to be used during
   mapping.

   ```php
   (new \CuyZ\Valinor\MapperBuilder())
       ->enablePermissiveTypes()
       ->mapper()
       ->map(
           'array{foo: string, bar: mixed}',
           [
               'foo' => 'foo',
               'bar' => 42, // Could be any value
           ]
       );
   ```