### PR TITLE
fix: allow mapping `null` to single node nullable type

### DIFF
--- a/src/Mapper/Object/FilledArguments.php
+++ b/src/Mapper/Object/FilledArguments.php
@@ -89,9 +89,8 @@ final class FilledArguments implements IteratorAggregate
     private function transform($source): array
     {
         $isArray = is_array($source);
-        $argumentsCount = count($this->arguments);
 
-        if ($argumentsCount === 1 && $source !== [] && $source !== null) {
+        if (count($this->arguments) === 1 && $source !== []) {
             /** @var array<mixed> $source */
             $argument = $this->arguments->at(0);
             $name = $argument->name();

--- a/tests/Integration/Mapping/SingleNodeMappingTest.php
+++ b/tests/Integration/Mapping/SingleNodeMappingTest.php
@@ -21,6 +21,8 @@ final class SingleNodeMappingTest extends IntegrationTest
         try {
             $singleScalarProperty = $mapper->map(SingleScalarProperty::class, $scalarSource);
             $singleConstructorScalarParameter = $mapper->map(SingleConstructorScalarParameter::class, $scalarSource);
+            $singleNullableScalarProperty = $mapper->map(SingleNullableScalarProperty::class, null);
+            $singleConstructorNullableScalarParameter = $mapper->map(SingleConstructorNullableScalarParameter::class, null);
             $singleArrayProperty = $mapper->map(SingleArrayProperty::class, $arraySource);
             $singleConstructorArrayParameter = $mapper->map(SingleConstructorArrayParameter::class, $arraySource);
             $singleScalarPropertyWithDefaultValue = $mapper->map(SingleScalarPropertyWithDefaultValue::class, []);
@@ -31,6 +33,8 @@ final class SingleNodeMappingTest extends IntegrationTest
 
         self::assertSame('foo', $singleScalarProperty->value);
         self::assertSame('foo', $singleConstructorScalarParameter->value);
+        self::assertSame(null, $singleNullableScalarProperty->value);
+        self::assertSame(null, $singleConstructorNullableScalarParameter->value);
         self::assertSame(['foo', '42.404', '1337'], $singleArrayProperty->value);
         self::assertSame(['foo', '42.404', '1337'], $singleConstructorArrayParameter->value);
         self::assertSame('foo', $singleScalarPropertyWithDefaultValue->value);
@@ -46,6 +50,20 @@ class SingleScalarProperty
 class SingleConstructorScalarParameter extends SingleScalarProperty
 {
     public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+}
+
+class SingleNullableScalarProperty
+{
+    /** @noRector \Rector\Php74\Rector\Property\RestoreDefaultNullToNullableTypePropertyRector */
+    public ?string $value;
+}
+
+class SingleConstructorNullableScalarParameter extends SingleNullableScalarProperty
+{
+    public function __construct(?string $value)
     {
         $this->value = $value;
     }


### PR DESCRIPTION
Fixes #245 