### PR TITLE
misc: remove `@` from comments for future PHP versions changes

### DIFF
--- a/src/Cache/ChainCache.php
+++ b/src/Cache/ChainCache.php
@@ -30,7 +30,7 @@ final class ChainCache implements CacheInterface
     }
 
     /**
-     * @PHP8.0 add `mixed` return type and remove PHPDoc
+     * PHP8.0 add `mixed` return type and remove PHPDoc
      *
      * @return EntryType|null
      */

--- a/src/Cache/Compiled/CompiledPhpFileCache.php
+++ b/src/Cache/Compiled/CompiledPhpFileCache.php
@@ -64,7 +64,7 @@ final class CompiledPhpFileCache implements CacheInterface
     }
 
     /**
-     * @PHP8.0 add `mixed` return type and remove PHPDoc
+     * PHP8.0 add `mixed` return type and remove PHPDoc
      *
      * @return EntryType|null
      */
@@ -227,7 +227,7 @@ final class CompiledPhpFileCache implements CacheInterface
             try {
                 $object = include $filename;
             } catch (Error $exception) {
-                // @PHP8.0 remove variable
+                // PHP8.0 remove variable
             }
 
             if (! isset($object) || ! $object instanceof PhpCacheFile) {

--- a/src/Cache/FileSystemCache.php
+++ b/src/Cache/FileSystemCache.php
@@ -52,7 +52,7 @@ final class FileSystemCache implements CacheInterface
     }
 
     /**
-     * @PHP8.0 add `mixed` return type and remove PHPDoc
+     * PHP8.0 add `mixed` return type and remove PHPDoc
      *
      * @return EntryType|null
      */

--- a/src/Cache/FileWatchingCache.php
+++ b/src/Cache/FileWatchingCache.php
@@ -58,7 +58,7 @@ final class FileWatchingCache implements CacheInterface
     }
 
     /**
-     * @PHP8.0 add `mixed` return type and remove PHPDoc
+     * PHP8.0 add `mixed` return type and remove PHPDoc
      *
      * @return EntryType|TimestampsArray|null
      */

--- a/src/Cache/KeySanitizerCache.php
+++ b/src/Cache/KeySanitizerCache.php
@@ -44,7 +44,7 @@ final class KeySanitizerCache implements CacheInterface
     }
 
     /**
-     * @PHP8.0 add `mixed` return type and remove PHPDoc
+     * PHP8.0 add `mixed` return type and remove PHPDoc
      *
      * @return EntryType|null
      */

--- a/src/Cache/RuntimeCache.php
+++ b/src/Cache/RuntimeCache.php
@@ -25,7 +25,7 @@ final class RuntimeCache implements CacheInterface
     private array $entries = [];
 
     /**
-     * @PHP8.0 add `mixed` return type and remove PHPDoc
+     * PHP8.0 add `mixed` return type and remove PHPDoc
      *
      * @return EntryType|null
      */

--- a/src/Definition/NativeAttributes.php
+++ b/src/Definition/NativeAttributes.php
@@ -25,7 +25,7 @@ final class NativeAttributes implements Attributes
     private array $reflectionAttributes;
 
     /**
-     * @PHP8.0 union
+     * PHP8.0 union
      * @param ReflectionClass<object>|ReflectionProperty|ReflectionMethod|ReflectionFunction|ReflectionParameter $reflection
      */
     public function __construct(Reflector $reflection)
@@ -83,7 +83,7 @@ final class NativeAttributes implements Attributes
     }
 
     /**
-     * @PHP8.0 union
+     * PHP8.0 union
      * @param ReflectionClass<object>|ReflectionProperty|ReflectionMethod|ReflectionFunction|ReflectionParameter $reflection
      * @return array<ReflectionAttribute<object>>
      */

--- a/src/Definition/Repository/Cache/Compiler/TypeCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/TypeCompiler.php
@@ -85,7 +85,7 @@ final class TypeCompiler
 
                 return "new $class(" . implode(', ', $subTypes) . ')';
             case $type instanceof ArrayKeyType:
-                // @PHP8.0 match
+                // PHP8.0 match
                 if ($type->toString() === 'string') {
                     return "$class::string()";
                 }

--- a/src/Definition/Repository/Reflection/ReflectionPropertyDefinitionBuilder.php
+++ b/src/Definition/Repository/Reflection/ReflectionPropertyDefinitionBuilder.php
@@ -54,7 +54,7 @@ final class ReflectionPropertyDefinitionBuilder
 
     private function hasDefaultValue(ReflectionProperty $reflection, Type $type): bool
     {
-        // @PHP8.0 `$reflection->hasDefaultValue()`
+        // PHP8.0 `$reflection->hasDefaultValue()`
         $defaultProperties = $reflection->getDeclaringClass()->getDefaultProperties();
 
         if (! $reflection->hasType() && $defaultProperties[$reflection->name] === null && ! NullType::get()->matches($type)) {
@@ -69,7 +69,7 @@ final class ReflectionPropertyDefinitionBuilder
      */
     private function defaultValue(ReflectionProperty $reflection)
     {
-        // @PHP8.0 `$reflection->getDefaultValue()`
+        // PHP8.0 `$reflection->getDefaultValue()`
         $defaultProperties = $reflection->getDeclaringClass()->getDefaultProperties();
 
         return $defaultProperties[$reflection->name] ?? null;

--- a/src/Library/Settings.php
+++ b/src/Library/Settings.php
@@ -43,7 +43,7 @@ final class Settings
     {
         $this->interfaceMapping[DateTimeInterface::class] = static fn () => DateTimeImmutable::class;
         $this->exceptionFilter = function (Throwable $exception) {
-            // @PHP8.0 use throw exception expression in short closure
+            // PHP8.0 use throw exception expression in short closure
             throw $exception;
         };
     }

--- a/src/Mapper/Object/Arguments.php
+++ b/src/Mapper/Object/Arguments.php
@@ -35,7 +35,7 @@ final class Arguments implements IteratorAggregate, Countable
     {
         return new self(...array_map(
             fn (ParameterDefinition $parameter) => Argument::fromParameter($parameter),
-            array_values(iterator_to_array($parameters)) // @PHP8.1 array unpacking
+            array_values(iterator_to_array($parameters)) // PHP8.1 array unpacking
         ));
     }
 
@@ -43,7 +43,7 @@ final class Arguments implements IteratorAggregate, Countable
     {
         return new self(...array_map(
             fn (PropertyDefinition $property) => Argument::fromProperty($property),
-            array_values(iterator_to_array($properties)) // @PHP8.1 array unpacking
+            array_values(iterator_to_array($properties)) // PHP8.1 array unpacking
         ));
     }
 

--- a/src/Mapper/Object/BackwardCompatibilityDateTimeConstructor.php
+++ b/src/Mapper/Object/BackwardCompatibilityDateTimeConstructor.php
@@ -56,7 +56,7 @@ final class BackwardCompatibilityDateTimeConstructor
         }
 
         if (! $date) {
-            // @PHP8.0 use throw exception expression
+            // PHP8.0 use throw exception expression
             throw new CannotParseToBackwardCompatibilityDateTime();
         }
 

--- a/src/Mapper/Object/DateTimeFormatConstructor.php
+++ b/src/Mapper/Object/DateTimeFormatConstructor.php
@@ -45,7 +45,7 @@ final class DateTimeFormatConstructor
     /**
      * @param class-string<DateTime|DateTimeImmutable> $className
      * @param non-empty-string|positive-int $value
-     * @PHP8.0 union
+     * PHP8.0 union
      */
     #[DynamicConstructor]
     public function __invoke(string $className, $value): DateTimeInterface

--- a/src/Mapper/Object/Factory/ConstructorObjectBuilderFactory.php
+++ b/src/Mapper/Object/Factory/ConstructorObjectBuilderFactory.php
@@ -116,7 +116,7 @@ final class ConstructorObjectBuilderFactory implements ObjectBuilderFactory
         }
 
         if (! $definition->attributes()->has(DynamicConstructor::class)
-            // @PHP8.0 remove
+            // PHP8.0 remove
             && $definition->class() !== DateTimeFormatConstructor::class
             && $definition->class() !== BackwardCompatibilityDateTimeConstructor::class
         ) {

--- a/src/Mapper/Object/FilteredObjectBuilder.php
+++ b/src/Mapper/Object/FilteredObjectBuilder.php
@@ -79,7 +79,7 @@ final class FilteredObjectBuilder implements ObjectBuilder
     }
 
     /**
-     * @PHP8.0 union
+     * PHP8.0 union
      *
      * @param mixed $source
      * @return false|int<0, max>

--- a/src/Mapper/Object/FunctionObjectBuilder.php
+++ b/src/Mapper/Object/FunctionObjectBuilder.php
@@ -30,11 +30,11 @@ final class FunctionObjectBuilder implements ObjectBuilder
 
         $arguments = array_map(
             fn (ParameterDefinition $parameter) => Argument::fromParameter($parameter),
-            array_values(iterator_to_array($definition->parameters())) // @PHP8.1 array unpacking
+            array_values(iterator_to_array($definition->parameters())) // PHP8.1 array unpacking
         );
 
         $this->isDynamicConstructor = $definition->attributes()->has(DynamicConstructor::class)
-            // @PHP8.0 remove
+            // PHP8.0 remove
             || $definition->class() === DateTimeFormatConstructor::class
             || $definition->class() === BackwardCompatibilityDateTimeConstructor::class;
 

--- a/src/Mapper/Object/MethodArguments.php
+++ b/src/Mapper/Object/MethodArguments.php
@@ -34,7 +34,7 @@ final class MethodArguments implements IteratorAggregate
             }
 
             if ($parameter->isVariadic()) {
-                // @PHP8.0 remove `array_values`? Behaviour might change, careful.
+                // PHP8.0 remove `array_values`? Behaviour might change, careful.
                 $this->arguments = [...$this->arguments, ...array_values($arguments[$name])]; // @phpstan-ignore-line we know that the argument is iterable
             } else {
                 $this->arguments[] = $arguments[$name];
@@ -44,7 +44,7 @@ final class MethodArguments implements IteratorAggregate
 
     public function getIterator(): Traversable
     {
-        // @PHP8.0 `array_values` can be removed
+        // PHP8.0 `array_values` can be removed
         yield from array_values($this->arguments);
     }
 }

--- a/src/Mapper/Object/ReflectionObjectBuilder.php
+++ b/src/Mapper/Object/ReflectionObjectBuilder.php
@@ -35,7 +35,7 @@ final class ReflectionObjectBuilder implements ObjectBuilder
             }
         }
 
-        // @PHP8.0 `$object = new ($this->class->name())();`
+        // PHP8.0 `$object = new ($this->class->name())();`
         $className = $this->class->name();
         $object = new $className();
 

--- a/src/Mapper/Source/JsonSource.php
+++ b/src/Mapper/Source/JsonSource.php
@@ -28,7 +28,7 @@ final class JsonSource implements IteratorAggregate
 
     public function __construct(string $jsonSource)
     {
-        // @PHP8.0 ext-json always bundled, see https://php.watch/versions/8.0/ext-json
+        // PHP8.0 ext-json always bundled, see https://php.watch/versions/8.0/ext-json
         /** @infection-ignore-all */
         // @codeCoverageIgnoreStart
         if (! function_exists('json_decode')) {

--- a/src/Mapper/Tree/Builder/ObjectImplementations.php
+++ b/src/Mapper/Tree/Builder/ObjectImplementations.php
@@ -60,7 +60,7 @@ final class ObjectImplementations
         $class = $this->call($name, $arguments);
 
         if (! isset($this->implementations[$name][$class])) {
-            // @PHP8.0 use throw exception expression
+            // PHP8.0 use throw exception expression
             throw new ObjectImplementationNotRegistered($class, $name, $this->implementations[$name]);
         }
 
@@ -95,7 +95,7 @@ final class ObjectImplementations
         try {
             $type = $this->typeParser->parse($name);
         } catch (InvalidType $exception) {
-            // @PHP8.0 remove variable
+            // PHP8.0 remove variable
         }
 
         if (! isset($type) || ! $type instanceof InterfaceType) {

--- a/src/Mapper/Tree/Exception/CannotResolveTypeFromUnion.php
+++ b/src/Mapper/Tree/Exception/CannotResolveTypeFromUnion.php
@@ -30,7 +30,7 @@ final class CannotResolveTypeFromUnion extends RuntimeException implements Error
         $this->parameters = [
             'allowed_types' => implode(
                 ', ',
-                // @PHP8.1 First-class callable syntax
+                // PHP8.1 First-class callable syntax
                 array_map([TypeHelper::class, 'dump'], $unionType->types())
             ),
         ];

--- a/src/Type/Parser/Lexer/Token/ArrayToken.php
+++ b/src/Type/Parser/Lexer/Token/ArrayToken.php
@@ -80,7 +80,7 @@ final class ArrayToken implements TraversingToken
 
     private function arrayType(TokenStream $stream): CompositeTraversableType
     {
-        // @PHP8.0 use `new ($this->arrayType)(...)`
+        // PHP8.0 use `new ($this->arrayType)(...)`
         $arrayClassType = $this->arrayType;
         $stream->forward();
         $type = $stream->read();

--- a/src/Type/Parser/Lexer/Token/ClassNameToken.php
+++ b/src/Type/Parser/Lexer/Token/ClassNameToken.php
@@ -102,7 +102,7 @@ final class ClassNameToken implements TraversingToken
         $cases = array_map(static fn ($value) => ValueTypeFactory::from($value), $cases);
 
         if (count($cases) > 1) {
-            // @PHP8.0 remove `array_values`
+            // PHP8.0 remove `array_values`
             // @infection-ignore-all
             return new UnionType(...array_values($cases));
         }
@@ -115,7 +115,7 @@ final class ClassNameToken implements TraversingToken
      */
     private function cases(): array
     {
-        // @PHP8.0 use `getConstants(ReflectionClassConstant::IS_PUBLIC)`
+        // PHP8.0 use `getConstants(ReflectionClassConstant::IS_PUBLIC)`
         $cases = [];
 
         foreach ($this->reflection->getReflectionConstants() as $constant) {

--- a/src/Type/Parser/Lexer/Token/ListToken.php
+++ b/src/Type/Parser/Lexer/Token/ListToken.php
@@ -48,7 +48,7 @@ final class ListToken implements TraversingToken
 
             $subType = $stream->read();
 
-            // @PHP8.0 use `new ($this->listType)(...)`
+            // PHP8.0 use `new ($this->listType)(...)`
             $listClass = $this->listType;
             $listType = new $listClass($subType);
 

--- a/src/Type/Parser/Lexer/Token/NativeToken.php
+++ b/src/Type/Parser/Lexer/Token/NativeToken.php
@@ -64,7 +64,7 @@ final class NativeToken implements TraversingToken
 
     private static function type(string $symbol): ?Type
     {
-        // @PHP8.0 match
+        // PHP8.0 match
         switch ($symbol) {
             case 'null':
                 return NullType::get();

--- a/src/Type/Types/ClassStringType.php
+++ b/src/Type/Types/ClassStringType.php
@@ -107,7 +107,7 @@ final class ClassStringType implements StringType, CompositeType
     public function canCast($value): bool
     {
         return (is_string($value)
-                // @PHP8.0 `$value instanceof Stringable`
+                // PHP8.0 `$value instanceof Stringable`
                 || (is_object($value) && method_exists($value, '__toString'))
         ) && $this->accepts((string)$value);
     }

--- a/src/Type/Types/NativeStringType.php
+++ b/src/Type/Types/NativeStringType.php
@@ -40,7 +40,7 @@ final class NativeStringType implements StringType
     {
         return is_string($value)
             || is_numeric($value)
-            // @PHP8.0 `$value instanceof Stringable`
+            // PHP8.0 `$value instanceof Stringable`
             || (is_object($value) && method_exists($value, '__toString'));
     }
 

--- a/src/Type/Types/NonEmptyStringType.php
+++ b/src/Type/Types/NonEmptyStringType.php
@@ -41,7 +41,7 @@ final class NonEmptyStringType implements StringType
     {
         return (is_string($value)
                 || is_numeric($value)
-                // @PHP8.0 `$value instanceof Stringable`
+                // PHP8.0 `$value instanceof Stringable`
                 || (is_object($value) && method_exists($value, '__toString'))
         ) && (string)$value !== '';
     }

--- a/src/Type/Types/NumericStringType.php
+++ b/src/Type/Types/NumericStringType.php
@@ -38,7 +38,7 @@ final class NumericStringType implements StringType
 
     public function canCast($value): bool
     {
-        // @PHP8.0 `$value instanceof Stringable`
+        // PHP8.0 `$value instanceof Stringable`
         if (is_object($value) && method_exists($value, '__toString')) {
             $value = (string)$value;
         }

--- a/src/Type/Types/StringValueType.php
+++ b/src/Type/Types/StringValueType.php
@@ -71,7 +71,7 @@ final class StringValueType implements StringType, FixedType
     {
         return (is_string($value)
                 || is_numeric($value)
-                // @PHP8.0 `$value instanceof Stringable`
+                // PHP8.0 `$value instanceof Stringable`
                 || (is_object($value) && method_exists($value, '__toString'))
         ) && (string)$value === $this->value;
     }

--- a/src/Utility/IsSingleton.php
+++ b/src/Utility/IsSingleton.php
@@ -10,7 +10,7 @@ trait IsSingleton
     private static self $instance;
 
     /**
-     * @PHP8.0
+     * PHP8.0
      * @return static
      */
     public static function get(): self

--- a/src/Utility/Polyfill.php
+++ b/src/Utility/Polyfill.php
@@ -18,7 +18,7 @@ use function substr_compare;
 final class Polyfill
 {
     /**
-     * @PHP8.0 use native function
+     * PHP8.0 use native function
      */
     public static function str_contains(string $haystack, string $needle): bool
     {
@@ -26,7 +26,7 @@ final class Polyfill
     }
 
     /**
-     * @PHP8.0 use native function
+     * PHP8.0 use native function
      */
     public static function str_starts_with(string $haystack, string $needle): bool
     {
@@ -34,7 +34,7 @@ final class Polyfill
     }
 
     /**
-     * @PHP8.0 use native function
+     * PHP8.0 use native function
      */
     public static function str_ends_with(string $haystack, string $needle): bool
     {

--- a/src/Utility/Reflection/TokenParser.php
+++ b/src/Utility/Reflection/TokenParser.php
@@ -72,14 +72,14 @@ final class TokenParser
 
         while ($token = $this->next()) {
             if (! $explicitAlias && $token[0] === T_STRING) {
-                $class .= $token[1]; // @PHP8.0 remove concatenation
+                $class .= $token[1]; // PHP8.0 remove concatenation
                 $alias = $token[1];
             } elseif ($explicitAlias && $token[0] === T_STRING) {
                 $alias = $token[1];
-            } elseif (PHP_VERSION_ID >= 80000 // @PHP8.0 remove condition
+            } elseif (PHP_VERSION_ID >= 80000 // PHP8.0 remove condition
                 && ($token[0] === T_NAME_QUALIFIED || $token[0] === T_NAME_FULLY_QUALIFIED)
             ) {
-                $class .= $token[1]; // @PHP8.0 remove concatenation
+                $class .= $token[1]; // PHP8.0 remove concatenation
                 $classSplit = explode('\\', $token[1]);
                 $alias = $classSplit[count($classSplit) - 1];
             } elseif ($token[0] === T_NS_SEPARATOR) {
@@ -134,10 +134,10 @@ final class TokenParser
     {
         $name = '';
 
-        // @PHP8.0 remove `infection-ignore-all`
+        // PHP8.0 remove `infection-ignore-all`
         // @infection-ignore-all
         while (($token = $this->next())
-            // @PHP8.0 remove conditions
+            // PHP8.0 remove conditions
             && (
                 (
                     PHP_VERSION_ID < 80000
@@ -149,7 +149,7 @@ final class TokenParser
                 )
             )
         ) {
-            $name .= $token[1]; // @PHP8.0 `return $token[1];` and `throw Error()` at the end of the method
+            $name .= $token[1]; // PHP8.0 `return $token[1];` and `throw Error()` at the end of the method
         }
 
         return $name;

--- a/src/Utility/String/StringFormatter.php
+++ b/src/Utility/String/StringFormatter.php
@@ -39,7 +39,7 @@ final class StringFormatter
     {
         $message = MessageFormatter::formatMessage($locale, $body, $parameters);
 
-        // @PHP8.0 use throw exception expression
+        // PHP8.0 use throw exception expression
         if ($message === false) {
             throw new StringFormatterError($body);
         }


### PR DESCRIPTION
Context:

As currently stands for the 1.14.x branch of the `doctrine/annotations`, code units with `@PHP8` annotations fail to be loaded.

This happens because the default list of implicitly ignored annotations does not contain `PHP8` in it, and therefore in scenarios where applications are loaded with components with such annotations fail with errors of this nature:

```sh
PHP Fatal error:  Uncaught Doctrine\Common\Annotations\AnnotationException: [Semantical Error] The annotation "@PHP8" in method CuyZ\Valinor\Cache\FileSystemCache::get() was never imported. Did you maybe forget to add a "use" statement for this annotation? in vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/AnnotationException.php:40
```

This change introduces the `TODO` annotation which is implicitly ignored by default, which helps avoid applications running into issues because of the annotation not being loaded.