### PR TITLE
qa: enhance Psalm plugin registration for Valinor

### DIFF
--- a/docs/pages/other/static-analysis.md
+++ b/docs/pages/other/static-analysis.md
@@ -75,6 +75,6 @@ includes:
 
 ```xml title="psalm.xml"
 <plugins>
-    <plugin filename="vendor/cuyz/valinor/qa/Psalm/Plugin/TreeMapperPsalmPlugin.php"/>
+    <pluginClass class="CuyZ\Valinor\QA\Psalm\ValinorPsalmPlugin"/>
 </plugins>
 ```

--- a/psalm.xml
+++ b/psalm.xml
@@ -12,4 +12,8 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+
+    <plugins>
+        <pluginClass class="CuyZ\Valinor\QA\Psalm\ValinorPsalmPlugin"/>
+    </plugins>
 </psalm>

--- a/qa/Psalm/ValinorPsalmPlugin.php
+++ b/qa/Psalm/ValinorPsalmPlugin.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace CuyZ\Valinor\QA\Psalm;
+
+use CuyZ\Valinor\QA\Psalm\Plugin\TreeMapperPsalmPlugin;
+use Psalm\Plugin\PluginEntryPointInterface;
+use Psalm\Plugin\RegistrationInterface;
+use SimpleXMLElement;
+
+class ValinorPsalmPlugin implements PluginEntryPointInterface
+{
+    public function __invoke(RegistrationInterface $api, SimpleXMLElement $config = null): void
+    {
+        require_once __DIR__ . '/Plugin/TreeMapperPsalmPlugin.php';
+
+        $api->registerHooksFromClass(TreeMapperPsalmPlugin::class);
+    }
+}


### PR DESCRIPTION
The plugin can now be registered like this in the `psalm.xml` file:

```xml
<plugins>
    <pluginClass class="CuyZ\Valinor\QA\Psalm\ValinorPsalmPlugin"/>
</plugins>
```