### PR TITLE
feat: introduce mapper to map arguments of a callable

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
       - Type strictness: mapping/type-strictness.md
       - Construction strategy: mapping/construction-strategy.md
       - Inferring interfaces: mapping/inferring-interfaces.md
+      - Arguments mapping: mapping/arguments-mapping.md
       - Handled types: mapping/handled-types.md
   - Other:
       - Performance & caching: other/performance-and-cache.md

--- a/docs/pages/mapping/arguments-mapping.md
+++ b/docs/pages/mapping/arguments-mapping.md
@@ -1,0 +1,53 @@
+# Mapping arguments of a callable
+
+This library can map the arguments of a callable; it can be used to ensure a
+source has the right shape before calling a function/method.
+
+The mapper builder can be configured the same way it would be with a tree 
+mapper, for instance to customize the [type strictness](type-strictness.md).
+
+```php
+$someFunction = function(string $foo, int $bar): string {
+    return "$foo / $bar";
+}
+
+try {
+    $arguments = (new \CuyZ\Valinor\MapperBuilder())
+        ->argumentsMapper()
+        ->mapArguments($someFunction, [
+            'foo' => 'some value',
+            'bar' => 42,
+        ]);
+    
+    // some value / 42
+    echo $someFunction(...$arguments);
+} catch (\CuyZ\Valinor\Mapper\MappingError $error) {
+    // Do something…
+}
+```
+
+Any callable can be given to the arguments mapper:
+
+```php
+final class SomeController
+{
+    public static function someAction(string $foo, int $bar): string
+    {
+        return "$foo / $bar";
+    }
+}
+
+try {
+    $arguments = (new \CuyZ\Valinor\MapperBuilder())
+        ->argumentsMapper()
+        ->mapArguments(SomeController::someAction(...), [
+            'foo' => 'some value',
+            'bar' => 42,
+        ]);
+    
+    // some value / 42
+    echo SomeController::someAction(...$arguments);
+} catch (\CuyZ\Valinor\Mapper\MappingError $error) {
+    // Do something…
+}
+```

--- a/docs/pages/other/static-analysis.md
+++ b/docs/pages/other/static-analysis.md
@@ -63,6 +63,24 @@ echo $array['foo'] * $array['bar'];
 echo $array['fiz']; 
 ```
 
+**Mapping arguments of a callable**
+
+```php
+$someFunction = function(string $foo, int $bar): string {
+	return "$foo / $bar";
+};
+
+$arguments = (new \CuyZ\Valinor\MapperBuilder())
+    ->argumentsMapper()
+    ->mapArguments($someFunction, [
+        'foo' => 'some value',
+        'bar' => 42,
+    ]);
+
+// ✅ Arguments have a correct shape, no error reported
+echo $someFunction(...$arguments);
+```
+
 ---
 
 To activate this feature, the configuration must be updated for the installed

--- a/qa/PHPStan/Extension/ArgumentsMapperPHPStanExtension.php
+++ b/qa/PHPStan/Extension/ArgumentsMapperPHPStanExtension.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\QA\PHPStan\Extension;
+
+use CuyZ\Valinor\Mapper\ArgumentsMapper;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ClosureType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\Type;
+
+use function count;
+
+final class ArgumentsMapperPHPStanExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return ArgumentsMapper::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'mapArguments';
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+    {
+        $arguments = $methodCall->getArgs();
+
+        if (count($arguments) === 0) {
+            return new MixedType();
+        }
+
+        $type = $scope->getType($arguments[0]->value);
+
+        if ($type instanceof ClosureType) {
+            $parameters = $type->getParameters();
+        } elseif ($type instanceof ConstantArrayType) {
+            $acceptors = $type->getCallableParametersAcceptors($scope);
+
+            if (count($acceptors) !== 1) {
+                return new MixedType();
+            }
+
+            $parameters = $acceptors[0]->getParameters();
+        } else {
+            return new MixedType();
+        }
+
+        $builder = ConstantArrayTypeBuilder::createEmpty();
+
+        foreach ($parameters as $parameter) {
+            $builder->setOffsetValueType(new ConstantStringType($parameter->getName()), $parameter->getType(), $parameter->isOptional());
+        }
+
+        return $builder->getArray();
+    }
+}

--- a/qa/PHPStan/Extension/TreeMapperPHPStanExtension.php
+++ b/qa/PHPStan/Extension/TreeMapperPHPStanExtension.php
@@ -37,8 +37,13 @@ final class TreeMapperPHPStanExtension implements DynamicMethodReturnTypeExtensi
 
     public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
     {
-        $argument = $methodCall->getArgs()[0]->value;
-        $type = $scope->getType($argument);
+        $arguments = $methodCall->getArgs();
+
+        if (count($arguments) === 0) {
+            return new MixedType();
+        }
+
+        $type = $scope->getType($arguments[0]->value);
 
         if ($type instanceof UnionType) {
             return $type->traverse(fn (Type $type) => $this->type($type));

--- a/qa/PHPStan/valinor-phpstan-configuration.php
+++ b/qa/PHPStan/valinor-phpstan-configuration.php
@@ -1,5 +1,6 @@
 <?php
 
+use CuyZ\Valinor\QA\PHPStan\Extension\ArgumentsMapperPHPStanExtension;
 use CuyZ\Valinor\QA\PHPStan\Extension\TreeMapperPHPStanExtension;
 
 require_once 'Extension/TreeMapperPHPStanExtension.php';
@@ -9,6 +10,9 @@ return [
         [
             'class' => TreeMapperPHPStanExtension::class,
             'tags' => ['phpstan.broker.dynamicMethodReturnTypeExtension']
-        ]
+        ], [
+            'class' => ArgumentsMapperPHPStanExtension::class,
+            'tags' => ['phpstan.broker.dynamicMethodReturnTypeExtension']
+        ],
     ],
 ];

--- a/qa/Psalm/Plugin/ArgumentsMapperPsalmPlugin.php
+++ b/qa/Psalm/Plugin/ArgumentsMapperPsalmPlugin.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\QA\Psalm\Plugin;
+
+use CuyZ\Valinor\Mapper\ArgumentsMapper;
+use Psalm\Internal\Type\Comparator\CallableTypeComparator;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Type\Atomic\TClosure;
+use Psalm\Type\Atomic\TKeyedArray;
+use Psalm\Type\Atomic\TMixed;
+use Psalm\Type\Union;
+
+use function count;
+use function reset;
+
+final class ArgumentsMapperPsalmPlugin implements MethodReturnTypeProviderInterface
+{
+    public static function getClassLikeNames(): array
+    {
+        return [ArgumentsMapper::class];
+    }
+
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        if ($event->getMethodNameLowercase() !== 'maparguments') {
+            return null;
+        }
+
+        $arguments = $event->getCallArgs();
+
+        if (count($arguments) === 0) {
+            return null;
+        }
+
+        $types = $event->getSource()->getNodeTypeProvider()->getType($arguments[0]->value);
+
+        if ($types === null) {
+            return null;
+        }
+
+        $types = $types->getAtomicTypes();
+
+        if (count($types) !== 1) {
+            return null;
+        }
+
+        $type = reset($types);
+
+        if ($type instanceof TKeyedArray) {
+            // Internal class usage, see https://github.com/vimeo/psalm/issues/8726
+            $type = CallableTypeComparator::getCallableFromAtomic($event->getSource()->getCodebase(), $type);
+        }
+
+        if (! $type instanceof TClosure) {
+            return null;
+        }
+
+        if (empty($type->params ?? [])) {
+            return null;
+        }
+
+        $params = [];
+
+        foreach ($type->params as $param) {
+            $params[$param->name] = $param->type ?? new Union([new TMixed()]);
+        }
+
+        return new Union([new TKeyedArray($params)]);
+    }
+}

--- a/qa/Psalm/Plugin/TreeMapperPsalmPlugin.php
+++ b/qa/Psalm/Plugin/TreeMapperPsalmPlugin.php
@@ -27,7 +27,13 @@ final class TreeMapperPsalmPlugin implements MethodReturnTypeProviderInterface
             return null;
         }
 
-        $type = $event->getSource()->getNodeTypeProvider()->getType($event->getCallArgs()[0]->value);
+        $arguments = $event->getCallArgs();
+
+        if (count($arguments) === 0) {
+            return null;
+        }
+
+        $type = $event->getSource()->getNodeTypeProvider()->getType($arguments[0]->value);
 
         if (! $type) {
             return null;
@@ -43,10 +49,6 @@ final class TreeMapperPsalmPlugin implements MethodReturnTypeProviderInterface
             }
 
             $types[] = $inferred;
-        }
-
-        if (count($types) === 0) {
-            return null;
         }
 
         return Type::combineUnionTypeArray($types, $event->getSource()->getCodebase());

--- a/qa/Psalm/ValinorPsalmPlugin.php
+++ b/qa/Psalm/ValinorPsalmPlugin.php
@@ -2,6 +2,7 @@
 
 namespace CuyZ\Valinor\QA\Psalm;
 
+use CuyZ\Valinor\QA\Psalm\Plugin\ArgumentsMapperPsalmPlugin;
 use CuyZ\Valinor\QA\Psalm\Plugin\TreeMapperPsalmPlugin;
 use Psalm\Plugin\PluginEntryPointInterface;
 use Psalm\Plugin\RegistrationInterface;
@@ -12,7 +13,9 @@ class ValinorPsalmPlugin implements PluginEntryPointInterface
     public function __invoke(RegistrationInterface $api, SimpleXMLElement $config = null): void
     {
         require_once __DIR__ . '/Plugin/TreeMapperPsalmPlugin.php';
+        require_once __DIR__ . '/Plugin/ArgumentsMapperPsalmPlugin.php';
 
         $api->registerHooksFromClass(TreeMapperPsalmPlugin::class);
+        $api->registerHooksFromClass(ArgumentsMapperPsalmPlugin::class);
     }
 }

--- a/src/Library/Container.php
+++ b/src/Library/Container.php
@@ -19,6 +19,7 @@ use CuyZ\Valinor\Definition\Repository\Reflection\DoctrineAnnotationsRepository;
 use CuyZ\Valinor\Definition\Repository\Reflection\NativeAttributesRepository;
 use CuyZ\Valinor\Definition\Repository\Reflection\ReflectionClassDefinitionRepository;
 use CuyZ\Valinor\Definition\Repository\Reflection\ReflectionFunctionDefinitionRepository;
+use CuyZ\Valinor\Mapper\ArgumentsMapper;
 use CuyZ\Valinor\Mapper\Object\Factory\AttributeObjectBuilderFactory;
 use CuyZ\Valinor\Mapper\Object\Factory\CacheObjectBuilderFactory;
 use CuyZ\Valinor\Mapper\Object\Factory\CollisionObjectBuilderFactory;
@@ -49,7 +50,8 @@ use CuyZ\Valinor\Mapper\Tree\Builder\ValueAlteringNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Visitor\AttributeShellVisitor;
 use CuyZ\Valinor\Mapper\Tree\Visitor\ShellVisitor;
 use CuyZ\Valinor\Mapper\TreeMapper;
-use CuyZ\Valinor\Mapper\TreeMapperContainer;
+use CuyZ\Valinor\Mapper\TypeArgumentsMapper;
+use CuyZ\Valinor\Mapper\TypeTreeMapper;
 use CuyZ\Valinor\Type\Parser\CachedParser;
 use CuyZ\Valinor\Type\Parser\Factory\LexingTypeParserFactory;
 use CuyZ\Valinor\Type\Parser\Factory\Specifications\HandleClassGenericSpecification;
@@ -81,9 +83,14 @@ final class Container
     public function __construct(Settings $settings)
     {
         $this->factories = [
-            TreeMapper::class => fn () => new TreeMapperContainer(
+            TreeMapper::class => fn () => new TypeTreeMapper(
                 $this->get(TypeParser::class),
                 new RootNodeBuilder($this->get(NodeBuilder::class))
+            ),
+
+            ArgumentsMapper::class => fn () => new TypeArgumentsMapper(
+                $this->get(TreeMapper::class),
+                $this->get(FunctionDefinitionRepository::class)
             ),
 
             ShellVisitor::class => fn () => new AttributeShellVisitor(),
@@ -236,6 +243,11 @@ final class Container
     public function treeMapper(): TreeMapper
     {
         return $this->get(TreeMapper::class);
+    }
+
+    public function argumentsMapper(): ArgumentsMapper
+    {
+        return $this->get(ArgumentsMapper::class);
     }
 
     public function cacheWarmupService(): RecursiveCacheWarmupService

--- a/src/Mapper/ArgumentsMapper.php
+++ b/src/Mapper/ArgumentsMapper.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper;
+
+/** @api */
+interface ArgumentsMapper
+{
+    /**
+     * @param mixed $source
+     * @return array<string, mixed>
+     *
+     * @throws MappingError
+     */
+    public function mapArguments(callable $callable, $source): array;
+}

--- a/src/Mapper/ArgumentsMapperError.php
+++ b/src/Mapper/ArgumentsMapperError.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper;
+
+use CuyZ\Valinor\Definition\FunctionDefinition;
+use CuyZ\Valinor\Mapper\Tree\Message\Messages;
+use CuyZ\Valinor\Mapper\Tree\Node;
+use CuyZ\Valinor\Utility\ValueDumper;
+use RuntimeException;
+
+/** @internal */
+final class ArgumentsMapperError extends RuntimeException implements MappingError
+{
+    private Node $node;
+
+    public function __construct(FunctionDefinition $function, Node $node)
+    {
+        $this->node = $node;
+
+        $errors = Messages::flattenFromNode($node)->errors();
+        $errorsCount = count($errors);
+
+        if ($errorsCount === 1) {
+            $body = $errors
+                ->toArray()[0]
+                ->withBody("Could not map arguments of `{$function->signature()}`. An error occurred at path {node_path}: {original_message}")
+                ->toString();
+        } else {
+            $source = ValueDumper::dump($node->sourceValue());
+            $body = "Could not map arguments of `{$function->signature()}` with value $source. A total of $errorsCount errors were encountered.";
+        }
+
+        parent::__construct($body, 1617193185);
+    }
+
+    public function node(): Node
+    {
+        return $this->node;
+    }
+}

--- a/src/Mapper/MappingError.php
+++ b/src/Mapper/MappingError.php
@@ -4,39 +4,11 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper;
 
-use CuyZ\Valinor\Mapper\Tree\Message\Messages;
 use CuyZ\Valinor\Mapper\Tree\Node;
-use CuyZ\Valinor\Utility\ValueDumper;
-use RuntimeException;
+use Throwable;
 
 /** @api */
-final class MappingError extends RuntimeException
+interface MappingError extends Throwable
 {
-    private Node $node;
-
-    public function __construct(Node $node)
-    {
-        $this->node = $node;
-
-        $source = ValueDumper::dump($node->sourceValue());
-
-        $errors = Messages::flattenFromNode($node)->errors();
-        $errorsCount = count($errors);
-
-        $body = "Could not map type `{$node->type()}` with value $source. A total of $errorsCount errors were encountered.";
-
-        if ($errorsCount === 1) {
-            $body = $errors->getIterator()->current()
-                ->withParameter('root_type', $node->type())
-                ->withBody("Could not map type `{root_type}`. An error occurred at path {node_path}: {original_message}")
-                ->toString();
-        }
-
-        parent::__construct($body, 1617193185);
-    }
-
-    public function node(): Node
-    {
-        return $this->node;
-    }
+    public function node(): Node;
 }

--- a/src/Mapper/TypeArgumentsMapper.php
+++ b/src/Mapper/TypeArgumentsMapper.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper;
+
+use CuyZ\Valinor\Definition\ParameterDefinition;
+use CuyZ\Valinor\Definition\Parameters;
+use CuyZ\Valinor\Definition\Repository\FunctionDefinitionRepository;
+use CuyZ\Valinor\Type\Types\ShapedArrayElement;
+use CuyZ\Valinor\Type\Types\ShapedArrayType;
+use CuyZ\Valinor\Type\Types\StringValueType;
+
+use function array_values;
+
+/** @internal */
+final class TypeArgumentsMapper implements ArgumentsMapper
+{
+    private TreeMapper $delegate;
+
+    private FunctionDefinitionRepository $functionDefinitionRepository;
+
+    public function __construct(TreeMapper $delegate, FunctionDefinitionRepository $functionDefinitionRepository)
+    {
+        $this->delegate = $delegate;
+        $this->functionDefinitionRepository = $functionDefinitionRepository;
+    }
+
+    public function mapArguments(callable $callable, $source): array
+    {
+        $function = $this->functionDefinitionRepository->for($callable);
+        $parameters = $function->parameters();
+
+        $signature = $this->signature($parameters);
+
+        try {
+            $result = $this->delegate->map($signature, $source);
+        } catch (MappingError $error) {
+            throw new ArgumentsMapperError($function, $error->node());
+        }
+
+        if (count($parameters) === 1) {
+            $result = [$parameters->at(0)->name() => $result];
+        }
+
+        return $result;
+    }
+
+    private function signature(Parameters $parameters): string
+    {
+        if (count($parameters) === 1) {
+            return $parameters->at(0)->type()->toString();
+        }
+
+        $elements = array_map(
+            fn (ParameterDefinition $parameter) => new ShapedArrayElement(
+                new StringValueType($parameter->name()),
+                $parameter->type(),
+                $parameter->isOptional()
+            ),
+            iterator_to_array($parameters)
+        );
+
+        // PHP8.0 Remove `array_values`
+        return (new ShapedArrayType(...array_values($elements)))->toString();
+    }
+}

--- a/src/Mapper/TypeTreeMapper.php
+++ b/src/Mapper/TypeTreeMapper.php
@@ -12,7 +12,7 @@ use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use CuyZ\Valinor\Type\Parser\TypeParser;
 
 /** @internal */
-final class TreeMapperContainer implements TreeMapper
+final class TypeTreeMapper implements TreeMapper
 {
     private TypeParser $typeParser;
 
@@ -29,7 +29,7 @@ final class TreeMapperContainer implements TreeMapper
         $node = $this->node($signature, $source);
 
         if (! $node->isValid()) {
-            throw new MappingError($node->node());
+            throw new TypeTreeMapperError($node->node());
         }
 
         return $node->value();

--- a/src/Mapper/TypeTreeMapperError.php
+++ b/src/Mapper/TypeTreeMapperError.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper;
+
+use CuyZ\Valinor\Mapper\Tree\Message\Messages;
+use CuyZ\Valinor\Mapper\Tree\Node;
+use CuyZ\Valinor\Utility\ValueDumper;
+use RuntimeException;
+
+/** @internal */
+final class TypeTreeMapperError extends RuntimeException implements MappingError
+{
+    private Node $node;
+
+    public function __construct(Node $node)
+    {
+        $this->node = $node;
+
+        $errors = Messages::flattenFromNode($node)->errors();
+        $errorsCount = count($errors);
+
+        if ($errorsCount === 1) {
+            $body = $errors
+                ->toArray()[0]
+                ->withParameter('root_type', $node->type())
+                ->withBody("Could not map type `{root_type}`. An error occurred at path {node_path}: {original_message}")
+                ->toString();
+        } else {
+            $source = ValueDumper::dump($node->sourceValue());
+            $body = "Could not map type `{$node->type()}` with value $source. A total of $errorsCount errors were encountered.";
+        }
+
+        parent::__construct($body, 1617193185);
+    }
+
+    public function node(): Node
+    {
+        return $this->node;
+    }
+}

--- a/src/MapperBuilder.php
+++ b/src/MapperBuilder.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor;
 use CuyZ\Valinor\Cache\FileSystemCache;
 use CuyZ\Valinor\Library\Container;
 use CuyZ\Valinor\Library\Settings;
+use CuyZ\Valinor\Mapper\ArgumentsMapper;
 use CuyZ\Valinor\Mapper\Object\DateTimeFormatConstructor;
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
 use CuyZ\Valinor\Mapper\TreeMapper;
@@ -458,6 +459,11 @@ final class MapperBuilder
     public function mapper(): TreeMapper
     {
         return $this->container()->treeMapper();
+    }
+
+    public function argumentsMapper(): ArgumentsMapper
+    {
+        return $this->container()->argumentsMapper();
     }
 
     public function __clone()

--- a/tests/Integration/Mapping/Closure/ArgumentsMappingTest.php
+++ b/tests/Integration/Mapping/Closure/ArgumentsMappingTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Mapping\Closure;
+
+use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\MapperBuilder;
+use CuyZ\Valinor\Tests\Integration\IntegrationTest;
+
+use function array_values;
+
+final class ArgumentsMappingTest extends IntegrationTest
+{
+    public function test_can_map_to_anonymous_function(): void
+    {
+        $function = fn (string $foo, int $bar): string => "$foo / $bar";
+
+        try {
+            $arguments = (new MapperBuilder())->argumentsMapper()->mapArguments($function, [
+                'foo' => 'foo',
+                'bar' => 42,
+            ]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        // PHP8.0 Remove `array_values`
+        self::assertSame('foo / 42', $function(...array_values($arguments)));
+    }
+
+    public function test_can_map_to_class_method(): void
+    {
+        $object = new SomeClassWithMethods();
+
+        try {
+            // PHP8.1 First-class callable syntax
+            $arguments = (new MapperBuilder())->argumentsMapper()->mapArguments([$object, 'somePublicMethod'], [
+                'foo' => 'foo',
+                'bar' => 42,
+            ]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        // PHP8.0 Remove `array_values`
+        self::assertSame('foo / 42', $object->somePublicMethod(...array_values($arguments)));
+    }
+
+    public function test_can_map_to_class_static_method(): void
+    {
+        try {
+            // PHP8.1 First-class callable syntax
+            $arguments = (new MapperBuilder())->argumentsMapper()->mapArguments([SomeClassWithMethods::class, 'somePublicStaticMethod'], [
+                'foo' => 'foo',
+                'bar' => 42,
+            ]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        // PHP8.0 Remove `array_values`
+        self::assertSame('foo / 42', SomeClassWithMethods::somePublicStaticMethod(...array_values($arguments)));
+    }
+
+    public function test_can_map_to_function_with_single_argument(): void
+    {
+        $function = fn (string $foo): string => $foo;
+
+        try {
+            $arguments = (new MapperBuilder())->argumentsMapper()->mapArguments($function, 'foo');
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        // PHP8.0 Remove `array_values`
+        self::assertSame('foo', $function(...array_values($arguments)));
+    }
+
+    public function test_invalid_source_with_one_error_throws_mapping_error(): void
+    {
+        $function = fn (string $foo, int $bar): string => "$foo / $bar";
+
+        try {
+            (new MapperBuilder())->argumentsMapper()->mapArguments($function, [
+                'foo' => false,
+                'bar' => false,
+            ]);
+        } catch (MappingError $exception) {
+            self::assertMatchesRegularExpression('/Could not map arguments of `[^`]+` with value array{foo: false, bar: false}. A total of 2 errors were encountered./', $exception->getMessage());
+
+            self::assertSame('Value false is not a valid string.', (string)$exception->node()->children()['foo']->messages()[0]);
+            self::assertSame('Value false is not a valid integer.', (string)$exception->node()->children()['bar']->messages()[0]);
+        }
+    }
+
+    public function test_invalid_source_with_two_errors_throws_mapping_error(): void
+    {
+        $function = fn (string $foo, int $bar): string => "$foo / $bar";
+
+        try {
+            (new MapperBuilder())->argumentsMapper()->mapArguments($function, [
+                'foo' => false,
+                'bar' => 42,
+            ]);
+        } catch (MappingError $exception) {
+            self::assertMatchesRegularExpression('/Could not map arguments of `[^`]+`. An error occurred at path foo: Value false is not a valid string./', $exception->getMessage());
+
+            self::assertSame('Value false is not a valid string.', (string)$exception->node()->children()['foo']->messages()[0]);
+        }
+    }
+}
+
+final class SomeClassWithMethods
+{
+    public function somePublicMethod(string $foo, int $bar): string
+    {
+        return "$foo / $bar";
+    }
+
+    public static function somePublicStaticMethod(string $foo, int $bar): string
+    {
+        return "$foo / $bar";
+    }
+}

--- a/tests/StaticAnalysis/can-infer-callable-arguments-mapper-result.php
+++ b/tests/StaticAnalysis/can-infer-callable-arguments-mapper-result.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use CuyZ\Valinor\Mapper\ArgumentsMapper;
+
+/**
+ * @param mixed $input
+ * @return array{foo: string, bar?: int|null}
+ */
+function mappingFunctionArgumentsWillInferObjectOfSameType(ArgumentsMapper $mapper, $input): array
+{
+    return $mapper->mapArguments(fn (string $foo, int $bar = null): string => "$foo / $bar", $input);
+}
+
+/**
+ * @param mixed $input
+ * @return array{foo: string, bar?: int|null}
+ */
+function mappingStaticMethodArgumentsWillInferObjectOfSameType(ArgumentsMapper $mapper, $input): array
+{
+    // PHP8.1 First-class callable syntax
+    return $mapper->mapArguments(Closure::fromCallable([SomeClass::class, 'someStaticMethod']), $input);
+}
+
+/**
+ * @param mixed $input
+ * @return array{foo: string, bar?: int|null}
+ */
+function mappingMethodArgumentsWillInferObjectOfSameType(ArgumentsMapper $mapper, $input): array
+{
+    // PHP8.1 First-class callable syntax
+    return $mapper->mapArguments(Closure::fromCallable([new SomeClass(), 'someMethod']), $input);
+}
+
+/** @internal */
+final class SomeClass
+{
+    public static function someStaticMethod(string $foo, int $bar = null): string
+    {
+        return "$foo / $bar";
+    }
+
+    public function someMethod(string $foo, int $bar = null): string
+    {
+        return "$foo / $bar";
+    }
+}

--- a/tests/Unit/Mapper/TreeMapperErrorTest.php
+++ b/tests/Unit/Mapper/TreeMapperErrorTest.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Unit\Mapper;
 
-use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\Mapper\TypeTreeMapperError;
 use CuyZ\Valinor\Tests\Fake\Mapper\Tree\FakeNode;
 use PHPUnit\Framework\TestCase;
 
-final class MappingErrorTest extends TestCase
+final class TreeMapperErrorTest extends TestCase
 {
     public function test_node_can_be_retrieved(): void
     {
         $node = FakeNode::any();
 
-        $mappingError = new MappingError($node);
+        $mappingError = new TypeTreeMapperError($node);
 
         self::assertSame($node, $mappingError->node());
     }

--- a/tests/Unit/Mapper/TypeTreeMapperTest.php
+++ b/tests/Unit/Mapper/TypeTreeMapperTest.php
@@ -6,20 +6,20 @@ namespace CuyZ\Valinor\Tests\Unit\Mapper;
 
 use CuyZ\Valinor\Mapper\Exception\InvalidMappingTypeSignature;
 use CuyZ\Valinor\Mapper\Tree\Builder\RootNodeBuilder;
-use CuyZ\Valinor\Mapper\TreeMapperContainer;
+use CuyZ\Valinor\Mapper\TypeTreeMapper;
 use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Builder\FakeNodeBuilder;
 use CuyZ\Valinor\Tests\Fake\Type\Parser\FakeTypeParser;
 use PHPUnit\Framework\TestCase;
 
-final class TreeMapperContainerTest extends TestCase
+final class TypeTreeMapperTest extends TestCase
 {
-    private TreeMapperContainer $mapper;
+    private TypeTreeMapper $mapper;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->mapper = new TreeMapperContainer(
+        $this->mapper = new TypeTreeMapper(
             new FakeTypeParser(),
             new RootNodeBuilder(new FakeNodeBuilder()),
         );


### PR DESCRIPTION
This new mapper can be used to ensure a source has the right shape before calling a function/method.

The mapper builder can be configured the same way it would be with a tree mapper, for instance to customize the type strictness.

```php
$someFunction = function(string $foo, int $bar): string {
    return "$foo / $bar";
}

try {
    $arguments = (new \CuyZ\Valinor\MapperBuilder())
        ->argumentsMapper()
        ->mapArguments($someFunction, [
            'foo' => 'some value',
            'bar' => 42,
        ]);

    // some value / 42
    echo $someFunction(...$arguments);
} catch (\CuyZ\Valinor\Mapper\MappingError $error) {
    // Do something…
}
```

Any callable can be given to the arguments mapper:

```php
final class SomeController
{
    public static function someAction(string $foo, int $bar): string
    {
        return "$foo / $bar";
    }
}

try {
    $arguments = (new \CuyZ\Valinor\MapperBuilder())
        ->argumentsMapper()
        ->mapArguments(SomeController::someAction(...), [
            'foo' => 'some value',
            'bar' => 42,
        ]);

    // some value / 42
    echo SomeController::someAction(...$arguments);
} catch (\CuyZ\Valinor\Mapper\MappingError $error) {
    // Do something…
}
```