### PR TITLE
misc!: remove support for `strict-array` type

### DIFF
--- a/src/Type/Parser/Lexer/NativeLexer.php
+++ b/src/Type/Parser/Lexer/NativeLexer.php
@@ -74,7 +74,6 @@ final class NativeLexer implements TypeLexer
             case 'integer':
                 return IntegerToken::get();
             case 'array':
-            case 'strict-array':
                 return ArrayToken::array();
             case 'non-empty-array':
                 return ArrayToken::nonEmptyArray();

--- a/tests/Functional/Type/Parser/Lexer/NativeLexerTest.php
+++ b/tests/Functional/Type/Parser/Lexer/NativeLexerTest.php
@@ -628,12 +628,6 @@ final class NativeLexerTest extends TestCase
             'type' => ShapedArrayType::class,
         ];
 
-        yield 'Strict shaped array' => [
-            'raw' => 'strict-array{foo: string}',
-            'transformed' => 'array{foo: string}',
-            'type' => ShapedArrayType::class,
-        ];
-
         yield 'Shaped array with single quote key' => [
             'raw' => "array{'foo': string}",
             'transformed' => "array{'foo': string}",


### PR DESCRIPTION
Psalm went backward on the introduction of the new `strict-array` type, see https://github.com/vimeo/psalm/pull/8701 for more information.