### PR TITLE
misc!: mark tree mapper and arguments mapper as `@pure`

### DIFF
--- a/src/Mapper/ArgumentsMapper.php
+++ b/src/Mapper/ArgumentsMapper.php
@@ -8,6 +8,8 @@ namespace CuyZ\Valinor\Mapper;
 interface ArgumentsMapper
 {
     /**
+     * @pure
+     *
      * @param mixed $source
      * @return array<string, mixed>
      *

--- a/src/Mapper/TreeMapper.php
+++ b/src/Mapper/TreeMapper.php
@@ -8,6 +8,8 @@ namespace CuyZ\Valinor\Mapper;
 interface TreeMapper
 {
     /**
+     * @pure
+     *
      * @template T of object
      *
      * @param string|class-string<T> $signature

--- a/src/Mapper/TypeArgumentsMapper.php
+++ b/src/Mapper/TypeArgumentsMapper.php
@@ -26,6 +26,7 @@ final class TypeArgumentsMapper implements ArgumentsMapper
         $this->functionDefinitionRepository = $functionDefinitionRepository;
     }
 
+    /** @pure */
     public function mapArguments(callable $callable, $source): array
     {
         $function = $this->functionDefinitionRepository->for($callable);

--- a/src/Mapper/TypeTreeMapper.php
+++ b/src/Mapper/TypeTreeMapper.php
@@ -24,6 +24,7 @@ final class TypeTreeMapper implements TreeMapper
         $this->nodeBuilder = $nodeBuilder;
     }
 
+    /** @pure */
     public function map(string $signature, $source)
     {
         $node = $this->node($signature, $source);

--- a/src/MapperBuilder.php
+++ b/src/MapperBuilder.php
@@ -35,6 +35,9 @@ final class MapperBuilder
      * using the given source. These arguments can then be used to decide which
      * implementation should be used.
      *
+     * The callback *must* be pure, its output must be deterministic.
+     * @see https://en.wikipedia.org/wiki/Pure_function
+     *
      * Example:
      *
      * ```php
@@ -53,6 +56,7 @@ final class MapperBuilder
      * ```
      *
      * @param interface-string $interfaceName
+     * @psalm-param pure-callable $callback
      */
     public function infer(string $interfaceName, callable $callback): self
     {
@@ -80,6 +84,9 @@ final class MapperBuilder
      * `__construct` method — of the targeted class. If for some reason it still
      * needs to be handled as well, the name of the class must be given to this
      * method.
+     *
+     * A constructor *must* be pure, its output must be deterministic.
+     * @see https://en.wikipedia.org/wiki/Pure_function
      *
      * ```php
      * final class SomeClass
@@ -157,6 +164,7 @@ final class MapperBuilder
      *     ]);
      * ```
      *
+     * @psalm-param pure-callable|class-string ...$constructors
      * @param callable|class-string ...$constructors
      */
     public function registerConstructor(...$constructors): self
@@ -238,6 +246,7 @@ final class MapperBuilder
 
     /**
      * @template T
+     * @psalm-param pure-callable(T): T $callback
      * @param callable(T): T $callback
      */
     public function alter(callable $callback): self
@@ -373,6 +382,9 @@ final class MapperBuilder
      * part of a query should never be allowed. Therefore, only an exhaustive
      * list of carefully chosen exceptions should be filtered.
      *
+     * The filter callback *must* be pure, its output must be deterministic.
+     * @see https://en.wikipedia.org/wiki/Pure_function
+     *
      * ```php
      * final class SomeClass
      * {
@@ -398,6 +410,7 @@ final class MapperBuilder
      *     ]);
      * ```
      *
+     * @psalm-param pure-callable(Throwable): ErrorMessage $filter
      * @param callable(Throwable): ErrorMessage $filter
      */
     public function filterExceptions(callable $filter): self


### PR DESCRIPTION
This change also impacts all callables that can be given to the mapper builder — they also need to be pure.

Although it reduces the scope of the mappers, it greatly improves their safety.