### PR TITLE
Fix Class not found exception in phpstan extension

### DIFF
--- a/qa/PHPStan/valinor-phpstan-configuration.php
+++ b/qa/PHPStan/valinor-phpstan-configuration.php
@@ -3,6 +3,7 @@
 use CuyZ\Valinor\QA\PHPStan\Extension\ArgumentsMapperPHPStanExtension;
 use CuyZ\Valinor\QA\PHPStan\Extension\TreeMapperPHPStanExtension;
 
+require_once 'Extension/ArgumentsMapperPHPStanExtension.php';
 require_once 'Extension/TreeMapperPHPStanExtension.php';
 
 return [


### PR DESCRIPTION
Fixes the following exception when including `vendor/cuyz/valinor/qa/PHPStan/valinor-phpstan-configuration.php`.

```
In Resolver.php line 111:

  [_PHPStan_9a6ded56a\Nette\DI\ServiceCreationException]
  Service (CuyZ\Valinor\QA\PHPStan\Extension\ArgumentsMapperPHPStanExtension::__construct()): Class 'CuyZ\Valinor\QA\PHPStan\Extension\ArgumentsMapperPHPStanExtension' not found.
```