### PR TITLE
Allow for timestamps before the epoch

### DIFF
--- a/src/Mapper/Object/DateTimeFormatConstructor.php
+++ b/src/Mapper/Object/DateTimeFormatConstructor.php
@@ -44,7 +44,7 @@ final class DateTimeFormatConstructor
 
     /**
      * @param class-string<DateTime|DateTimeImmutable> $className
-     * @param non-empty-string $value
+     * @param non-empty-string|int $value
      */
     #[DynamicConstructor]
     public function __invoke(string $className, string|int $value): DateTimeInterface

--- a/src/Mapper/Object/DateTimeFormatConstructor.php
+++ b/src/Mapper/Object/DateTimeFormatConstructor.php
@@ -44,7 +44,7 @@ final class DateTimeFormatConstructor
 
     /**
      * @param class-string<DateTime|DateTimeImmutable> $className
-     * @param non-empty-string|positive-int $value
+     * @param non-empty-string $value
      */
     #[DynamicConstructor]
     public function __invoke(string $className, string|int $value): DateTimeInterface

--- a/tests/Integration/Mapping/Object/DateTimeMappingTest.php
+++ b/tests/Integration/Mapping/Object/DateTimeMappingTest.php
@@ -50,6 +50,32 @@ final class DateTimeMappingTest extends IntegrationTest
         self::assertSame('1659688380', $result->format('U'));
     }
 
+    public function test_default_date_constructor_with_timestamp_at_0_source_returns_datetime(): void
+    {
+        try {
+            $result = (new MapperBuilder())
+                ->mapper()
+                ->map(DateTimeInterface::class, 0);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame('0', $result->format('U'));
+    }
+
+    public function test_default_date_constructor_with_a_negative_timestamp_source_returns_datetime(): void
+    {
+        try {
+            $result = (new MapperBuilder())
+                ->mapper()
+                ->map(DateTimeInterface::class, -1);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame('-1', $result->format('U'));
+    }
+
     public function test_registered_date_constructor_with_valid_source_returns_datetime(): void
     {
         try {


### PR DESCRIPTION
I'm not sure this is the _right_ fix but timestamps can technically be negative numbers. I have some dates that I'm importing that range back to 1920 and am currently getting an error that `Value {source_value} does not match any of 'non-empty-string', 'positive-int'` for the value `-450734400`.

If you agree with this change I can expand the PR, update the tests, etc.