### PR TITLE
misc: improve return type signature for `TreeMapper`

### DIFF
--- a/src/Mapper/TreeMapper.php
+++ b/src/Mapper/TreeMapper.php
@@ -16,7 +16,7 @@ interface TreeMapper
      * @return (
      *     $signature is class-string<T>
      *         ? T
-     *         : mixed
+     *         : ($signature is class-string ? object : mixed)
      * )
      *
      * @throws MappingError


### PR DESCRIPTION
In situation when $signature is just type of class-string without exact class, return type expected by phpstan is mixin. With this change phpstan will expect return type object.

Bit more context here https://github.com/phpstan/phpstan/issues/8443