### PR TITLE
misc: prevent multiple cache round-trip

### DIFF
--- a/src/Cache/FileWatchingCache.php
+++ b/src/Cache/FileWatchingCache.php
@@ -54,6 +54,10 @@ final class FileWatchingCache implements CacheInterface
 
     public function get($key, $default = null): mixed
     {
+        if (! $this->has($key)) {
+            return $default;
+        }
+
         return $this->delegate->get($key, $default);
     }
 

--- a/src/Definition/Repository/Cache/CacheClassDefinitionRepository.php
+++ b/src/Definition/Repository/Cache/CacheClassDefinitionRepository.php
@@ -23,12 +23,10 @@ final class CacheClassDefinitionRepository implements ClassDefinitionRepository
     {
         $key = "class-definition-{$type->toString()}";
 
-        if ($this->cache->has($key)) {
-            $entry = $this->cache->get($key);
+        $entry = $this->cache->get($key);
 
-            if ($entry) {
-                return $entry;
-            }
+        if ($entry) {
+            return $entry;
         }
 
         $class = $this->delegate->for($type);

--- a/src/Definition/Repository/Cache/CacheFunctionDefinitionRepository.php
+++ b/src/Definition/Repository/Cache/CacheFunctionDefinitionRepository.php
@@ -24,12 +24,10 @@ final class CacheFunctionDefinitionRepository implements FunctionDefinitionRepos
         $reflection = Reflection::function($function);
         $key = "function-definition-{$reflection->getFileName()}-{$reflection->getStartLine()}-{$reflection->getEndLine()}";
 
-        if ($this->cache->has($key)) {
-            $entry = $this->cache->get($key);
+        $entry = $this->cache->get($key);
 
-            if ($entry) {
-                return $entry;
-            }
+        if ($entry) {
+            return $entry;
         }
 
         $definition = $this->delegate->for($function);

--- a/src/Mapper/Object/Factory/CacheObjectBuilderFactory.php
+++ b/src/Mapper/Object/Factory/CacheObjectBuilderFactory.php
@@ -22,12 +22,10 @@ final class CacheObjectBuilderFactory implements ObjectBuilderFactory
     {
         $signature = $class->type()->toString();
 
-        if ($this->cache->has($signature)) {
-            $entry = $this->cache->get($signature);
+        $entry = $this->cache->get($signature);
 
-            if ($entry) {
-                return $entry;
-            }
+        if ($entry) {
+            return $entry;
         }
 
         $builders = $this->delegate->for($class);


### PR DESCRIPTION
From PSR-16 specs:

> It is recommended that has() is only to be used for cache warming type
  purposes and not to be used within your live applications operations
  for get/set, as this method is subject to a race condition where your
  has() will return true and immediately after, another script can
  remove it, making the state of your app out of date.

Closes #241 