### PR TITLE
feat: add support for class inferring

### DIFF
--- a/docs/pages/how-to/infer-interfaces.md
+++ b/docs/pages/how-to/infer-interfaces.md
@@ -9,7 +9,7 @@ implements the interface. Any arguments can be required by the callback; they
 will be mapped properly using the given source.
 
 If the callback can return several class names, it needs to provide a return
-signature with the list of all class-strings that can be returned (see below).
+signature with the list of all class-strings that can be returned.
 
 ```php
 $mapper = (new \CuyZ\Valinor\MapperBuilder())
@@ -53,4 +53,74 @@ final class SecondImplementation implements SomeInterface
 
     public readonly int $someInt;
 }
+```
+
+## Inferring classes
+
+The same mechanics can be applied to infer abstract or parent classes.
+
+Example with an abstract class:
+
+```php
+abstract class SomeAbstractClass
+{
+    public string $foo;
+
+    public string $bar;
+}
+
+final class SomeChildClass extends SomeAbstractClass
+{
+    public string $baz;
+}
+
+$result = (new \CuyZ\Valinor\MapperBuilder())
+    ->infer(
+        SomeAbstractClass::class, 
+        fn () => SomeChildClass::class
+    )
+    ->mapper()
+    ->map(SomeAbstractClass::class, [
+        'foo' => 'foo',
+        'bar' => 'bar',
+        'baz' => 'baz',
+    ]);
+
+assert($result instanceof SomeChildClass);
+assert($result->foo === 'foo');
+assert($result->bar === 'bar');
+assert($result->baz === 'baz');
+```
+
+Example with inheritance:
+
+```php
+class SomeParentClass
+{
+    public string $foo;
+
+    public string $bar;
+}
+
+final class SomeChildClass extends SomeParentClass
+{
+    public string $baz;
+}
+
+$result = (new \CuyZ\Valinor\MapperBuilder())
+    ->infer(
+        SomeParentClass::class, 
+        fn () => SomeChildClass::class
+    )
+    ->mapper()
+    ->map(SomeParentClass::class, [
+        'foo' => 'foo',
+        'bar' => 'bar',
+        'baz' => 'baz',
+    ]);
+
+assert($result instanceof SomeChildClass);
+assert($result->foo === 'foo');
+assert($result->bar === 'bar');
+assert($result->baz === 'baz');
 ```

--- a/rector.php
+++ b/rector.php
@@ -7,6 +7,7 @@ use Rector\Config\RectorConfig;
 use Rector\Core\Configuration\Option;
 use Rector\Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+use Rector\Php80\Rector\FunctionLike\UnionTypesRector;
 use Rector\Set\ValueObject\LevelSetList;
 
 return static function (RectorConfig $config): void {
@@ -29,5 +30,8 @@ return static function (RectorConfig $config): void {
     $config->skip([
         AddLiteralSeparatorToNumberRector::class,
         ClassPropertyAssignToConstructorPromotionRector::class,
+        UnionTypesRector::class => [
+            __DIR__ . '/src/MapperBuilder.php'
+        ],
     ]);
 };

--- a/src/Cache/Warmup/RecursiveCacheWarmupService.php
+++ b/src/Cache/Warmup/RecursiveCacheWarmupService.php
@@ -61,7 +61,13 @@ final class RecursiveCacheWarmupService
 
     private function warmupInterfaceType(InterfaceType $type): void
     {
-        $function = $this->implementations->function($type->className());
+        $interfaceName = $type->className();
+
+        if (! $this->implementations->has($interfaceName)) {
+            return;
+        }
+
+        $function = $this->implementations->function($interfaceName);
 
         $this->warmupType($function->returnType());
 

--- a/src/Definition/ClassDefinition.php
+++ b/src/Definition/ClassDefinition.php
@@ -15,6 +15,7 @@ final class ClassDefinition
         private Properties $properties,
         private Methods $methods,
         private bool $isFinal,
+        private bool $isAbstract,
     ) {
     }
 
@@ -49,5 +50,10 @@ final class ClassDefinition
     public function isFinal(): bool
     {
         return $this->isFinal;
+    }
+
+    public function isAbstract(): bool
+    {
+        return $this->isAbstract;
     }
 }

--- a/src/Definition/ClassDefinition.php
+++ b/src/Definition/ClassDefinition.php
@@ -13,7 +13,8 @@ final class ClassDefinition
         private ClassType $type,
         private Attributes $attributes,
         private Properties $properties,
-        private Methods $methods
+        private Methods $methods,
+        private bool $isFinal,
     ) {
     }
 
@@ -43,5 +44,10 @@ final class ClassDefinition
     public function methods(): Methods
     {
         return $this->methods;
+    }
+
+    public function isFinal(): bool
+    {
+        return $this->isFinal;
     }
 }

--- a/src/Definition/Repository/Cache/Compiler/ClassDefinitionCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/ClassDefinitionCompiler.php
@@ -55,12 +55,15 @@ final class ClassDefinitionCompiler implements CacheCompiler
         $methods = implode(', ', $methods);
         $attributes = $this->attributesCompiler->compile($value->attributes());
 
+        $isFinal = var_export($value->isFinal(), true);
+
         return <<<PHP
         new \CuyZ\Valinor\Definition\ClassDefinition(
             $type,
             $attributes,
             new \CuyZ\Valinor\Definition\Properties($properties),
-            new \CuyZ\Valinor\Definition\Methods($methods)
+            new \CuyZ\Valinor\Definition\Methods($methods),
+            $isFinal,
         )
         PHP;
     }

--- a/src/Definition/Repository/Cache/Compiler/ClassDefinitionCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/ClassDefinitionCompiler.php
@@ -56,6 +56,7 @@ final class ClassDefinitionCompiler implements CacheCompiler
         $attributes = $this->attributesCompiler->compile($value->attributes());
 
         $isFinal = var_export($value->isFinal(), true);
+        $isAbstract = var_export($value->isAbstract(), true);
 
         return <<<PHP
         new \CuyZ\Valinor\Definition\ClassDefinition(
@@ -64,6 +65,7 @@ final class ClassDefinitionCompiler implements CacheCompiler
             new \CuyZ\Valinor\Definition\Properties($properties),
             new \CuyZ\Valinor\Definition\Methods($methods),
             $isFinal,
+            $isAbstract,
         )
         PHP;
     }

--- a/src/Definition/Repository/Reflection/ReflectionClassDefinitionRepository.php
+++ b/src/Definition/Repository/Reflection/ReflectionClassDefinitionRepository.php
@@ -63,6 +63,7 @@ final class ReflectionClassDefinitionRepository implements ClassDefinitionReposi
             $this->attributesFactory->for($reflection),
             new Properties(...$this->properties($type)),
             new Methods(...$this->methods($type)),
+            $reflection->isFinal(),
         );
     }
 

--- a/src/Definition/Repository/Reflection/ReflectionClassDefinitionRepository.php
+++ b/src/Definition/Repository/Reflection/ReflectionClassDefinitionRepository.php
@@ -64,6 +64,7 @@ final class ReflectionClassDefinitionRepository implements ClassDefinitionReposi
             new Properties(...$this->properties($type)),
             new Methods(...$this->methods($type)),
             $reflection->isFinal(),
+            $reflection->isAbstract(),
         );
     }
 

--- a/src/Library/Container.php
+++ b/src/Library/Container.php
@@ -151,7 +151,7 @@ final class Container
             ObjectImplementations::class => fn () => new ObjectImplementations(
                 new FunctionsContainer(
                     $this->get(FunctionDefinitionRepository::class),
-                    $settings->interfaceMapping
+                    $settings->inferredMapping
                 ),
                 $this->get(TypeParser::class),
             ),

--- a/src/Library/Settings.php
+++ b/src/Library/Settings.php
@@ -13,8 +13,8 @@ use Throwable;
 /** @internal */
 final class Settings
 {
-    /** @var array<interface-string, callable> */
-    public array $interfaceMapping = [];
+    /** @var array<class-string|interface-string, callable> */
+    public array $inferredMapping = [];
 
     /** @var array<class-string, null> */
     public array $nativeConstructors = [];
@@ -39,7 +39,7 @@ final class Settings
 
     public function __construct()
     {
-        $this->interfaceMapping[DateTimeInterface::class] = static fn () => DateTimeImmutable::class;
+        $this->inferredMapping[DateTimeInterface::class] = static fn () => DateTimeImmutable::class;
         $this->exceptionFilter = fn (Throwable $exception) => throw $exception;
     }
 }

--- a/src/Mapper/Object/ArgumentsValues.php
+++ b/src/Mapper/Object/ArgumentsValues.php
@@ -30,10 +30,7 @@ final class ArgumentsValues implements IteratorAggregate
         $this->arguments = $arguments;
     }
 
-    /**
-     * @param mixed $value
-     */
-    public static function forInterface(Arguments $arguments, $value): self
+    public static function forInterface(Arguments $arguments, mixed $value): self
     {
         $self = new self($arguments);
 
@@ -44,10 +41,7 @@ final class ArgumentsValues implements IteratorAggregate
         return $self;
     }
 
-    /**
-     * @param mixed $value
-     */
-    public static function forClass(Arguments $arguments, $value): self
+    public static function forClass(Arguments $arguments, mixed $value): self
     {
         $self = new self($arguments);
         $self->value = $self->transform($value);
@@ -60,10 +54,7 @@ final class ArgumentsValues implements IteratorAggregate
         return array_key_exists($name, $this->value);
     }
 
-    /**
-     * @return mixed
-     */
-    public function getValue(string $name)
+    public function getValue(string $name): mixed
     {
         return $this->value[$name];
     }
@@ -80,10 +71,9 @@ final class ArgumentsValues implements IteratorAggregate
     }
 
     /**
-     * @param mixed $value
      * @return mixed[]
      */
-    private function transform($value): array
+    private function transform(mixed $value): array
     {
         $isValid = true;
 

--- a/src/Mapper/Tree/Builder/ClassNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ClassNodeBuilder.php
@@ -16,7 +16,6 @@ final class ClassNodeBuilder
 {
     public function __construct(private bool $allowSuperfluousKeys)
     {
-        $this->allowSuperfluousKeys = $allowSuperfluousKeys;
     }
 
     public function build(ObjectBuilder $builder, Shell $shell, RootNodeBuilder $rootBuilder): TreeNode

--- a/src/Mapper/Tree/Builder/ObjectImplementations.php
+++ b/src/Mapper/Tree/Builder/ObjectImplementations.php
@@ -6,7 +6,6 @@ namespace CuyZ\Valinor\Mapper\Tree\Builder;
 
 use CuyZ\Valinor\Definition\FunctionDefinition;
 use CuyZ\Valinor\Definition\FunctionsContainer;
-use CuyZ\Valinor\Mapper\Tree\Exception\CannotResolveObjectType;
 use CuyZ\Valinor\Mapper\Tree\Exception\InvalidAbstractObjectName;
 use CuyZ\Valinor\Mapper\Tree\Exception\InvalidResolvedImplementationValue;
 use CuyZ\Valinor\Mapper\Tree\Exception\MissingObjectImplementationRegistration;
@@ -38,12 +37,13 @@ final class ObjectImplementations
         }
     }
 
+    public function has(string $name): bool
+    {
+        return $this->functions->has($name);
+    }
+
     public function function(string $name): FunctionDefinition
     {
-        if (! $this->functions->has($name)) {
-            throw new CannotResolveObjectType($name);
-        }
-
         return $this->functions->get($name)->definition();
     }
 
@@ -88,7 +88,7 @@ final class ObjectImplementations
         } catch (InvalidType) {
         }
 
-        if (! isset($type) || ! $type instanceof InterfaceType) {
+        if (! isset($type) || (! $type instanceof InterfaceType && ! $type instanceof ClassType)) {
             throw new InvalidAbstractObjectName($name);
         }
 
@@ -99,7 +99,7 @@ final class ObjectImplementations
         }
 
         foreach ($classes as $classType) {
-            if (! $classType instanceof ClassType || ! $type->matches($classType)) {
+            if (! $classType instanceof ClassType || ! $classType->matches($type)) {
                 throw new ResolvedImplementationIsNotAccepted($name, $classType);
             }
         }

--- a/src/Mapper/Tree/Builder/ProxyClassNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ProxyClassNodeBuilder.php
@@ -15,24 +15,12 @@ use function assert;
 /** @internal */
 final class ProxyClassNodeBuilder implements NodeBuilder
 {
-    private ClassDefinitionRepository $classDefinitionRepository;
-
-    private ObjectBuilderFactory $objectBuilderFactory;
-
-    private ClassNodeBuilder $classBuilder;
-
-    private bool $enableFlexibleCasting;
-
     public function __construct(
-        ClassDefinitionRepository $classDefinitionRepository,
-        ObjectBuilderFactory $objectBuilderFactory,
-        ClassNodeBuilder $classBuilder,
-        bool $enableFlexibleCasting
+        private ClassDefinitionRepository $classDefinitionRepository,
+        private ObjectBuilderFactory $objectBuilderFactory,
+        private ClassNodeBuilder $classBuilder,
+        private bool $enableFlexibleCasting,
     ) {
-        $this->classDefinitionRepository = $classDefinitionRepository;
-        $this->objectBuilderFactory = $objectBuilderFactory;
-        $this->classBuilder = $classBuilder;
-        $this->enableFlexibleCasting = $enableFlexibleCasting;
     }
 
     public function build(Shell $shell, RootNodeBuilder $rootBuilder): TreeNode

--- a/src/Mapper/Tree/Exception/CannotInferFinalClass.php
+++ b/src/Mapper/Tree/Exception/CannotInferFinalClass.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Tree\Exception;
+
+use CuyZ\Valinor\Definition\FunctionDefinition;
+use CuyZ\Valinor\Type\Types\ClassType;
+use RuntimeException;
+
+/** @internal */
+final class CannotInferFinalClass extends RuntimeException
+{
+    public function __construct(ClassType $class, FunctionDefinition $function)
+    {
+        parent::__construct(
+            "Cannot infer final class `{$class->className()}` with function `{$function->signature()}`.",
+            1671468163
+        );
+    }
+}

--- a/src/MapperBuilder.php
+++ b/src/MapperBuilder.php
@@ -54,13 +54,13 @@ final class MapperBuilder
      *     ]);
      * ```
      *
-     * @param interface-string $interfaceName
+     * @param interface-string|class-string $name
      * @psalm-param pure-callable $callback
      */
-    public function infer(string $interfaceName, callable $callback): self
+    public function infer(string $name, callable $callback): self
     {
         $clone = clone $this;
-        $clone->settings->interfaceMapping[$interfaceName] = $callback;
+        $clone->settings->inferredMapping[$name] = $callback;
 
         return $clone;
     }

--- a/tests/Fake/Definition/FakeClassDefinition.php
+++ b/tests/Fake/Definition/FakeClassDefinition.php
@@ -32,6 +32,7 @@ final class FakeClassDefinition
             new Properties(),
             new Methods(),
             true,
+            false,
         );
     }
 
@@ -56,6 +57,7 @@ final class FakeClassDefinition
             new Properties(...$properties),
             new Methods(...$methods),
             $reflection->isFinal(),
+            $reflection->isAbstract(),
         );
     }
 }

--- a/tests/Fake/Definition/FakeClassDefinition.php
+++ b/tests/Fake/Definition/FakeClassDefinition.php
@@ -30,7 +30,8 @@ final class FakeClassDefinition
             new ClassType($name),
             new FakeAttributes(),
             new Properties(),
-            new Methods()
+            new Methods(),
+            true,
         );
     }
 
@@ -53,7 +54,8 @@ final class FakeClassDefinition
             new ClassType($reflection->name),
             new FakeAttributes(),
             new Properties(...$properties),
-            new Methods(...$methods)
+            new Methods(...$methods),
+            $reflection->isFinal(),
         );
     }
 }

--- a/tests/Functional/Definition/Repository/Cache/Compiler/ClassDefinitionCompilerTest.php
+++ b/tests/Functional/Definition/Repository/Cache/Compiler/ClassDefinitionCompilerTest.php
@@ -47,6 +47,7 @@ final class ClassDefinitionCompilerTest extends TestCase
 
         self::assertSame($className, $class->name());
         self::assertSame($className, $class->type()->className());
+        self::assertFalse($class->isFinal());
 
         $properties = $class->properties();
 
@@ -98,6 +99,16 @@ final class ClassDefinitionCompilerTest extends TestCase
         self::assertSame(ObjectWithParameterDefaultObjectValue::class, $class->name());
     }
 
+    public function test_final_class_is_compiled_correctly(): void
+    {
+        $class = FakeClassDefinition::fromReflection(new ReflectionClass(SomeFinalClass::class));
+
+        $class = $this->eval($this->compiler->compile($class));
+
+        self::assertInstanceOf(ClassDefinition::class, $class);
+        self::assertTrue($class->isFinal());
+    }
+
     private function eval(string $code): mixed
     {
         try {
@@ -106,4 +117,8 @@ final class ClassDefinitionCompilerTest extends TestCase
             self::fail($exception->getMessage());
         }
     }
+}
+
+final class SomeFinalClass
+{
 }

--- a/tests/Functional/Definition/Repository/Cache/Compiler/ClassDefinitionCompilerTest.php
+++ b/tests/Functional/Definition/Repository/Cache/Compiler/ClassDefinitionCompilerTest.php
@@ -48,6 +48,7 @@ final class ClassDefinitionCompilerTest extends TestCase
         self::assertSame($className, $class->name());
         self::assertSame($className, $class->type()->className());
         self::assertFalse($class->isFinal());
+        self::assertFalse($class->isAbstract());
 
         $properties = $class->properties();
 
@@ -109,6 +110,16 @@ final class ClassDefinitionCompilerTest extends TestCase
         self::assertTrue($class->isFinal());
     }
 
+    public function test_abstract_class_is_compiled_correctly(): void
+    {
+        $class = FakeClassDefinition::fromReflection(new ReflectionClass(SomeAbstractClass::class));
+
+        $class = $this->eval($this->compiler->compile($class));
+
+        self::assertInstanceOf(ClassDefinition::class, $class);
+        self::assertTrue($class->isAbstract());
+    }
+
     private function eval(string $code): mixed
     {
         try {
@@ -120,5 +131,9 @@ final class ClassDefinitionCompilerTest extends TestCase
 }
 
 final class SomeFinalClass
+{
+}
+
+abstract class SomeAbstractClass
 {
 }

--- a/tests/Integration/Mapping/ClassInheritanceInferringMappingTest.php
+++ b/tests/Integration/Mapping/ClassInheritanceInferringMappingTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Mapping;
+
+use CuyZ\Valinor\Mapper\Tree\Exception\CannotInferFinalClass;
+use CuyZ\Valinor\MapperBuilder;
+use CuyZ\Valinor\Tests\Integration\IntegrationTest;
+use LogicException;
+
+final class ClassInheritanceInferringMappingTest extends IntegrationTest
+{
+    public function test_infer_abstract_class_works_as_expected(): void
+    {
+        $result = (new MapperBuilder())
+            ->infer(
+                SomeAbstractClass::class,
+                fn () => SomeAbstractChildClass::class
+            )
+            ->mapper()
+            ->map(SomeAbstractClass::class, [
+                'foo' => 'foo',
+                'bar' => 'bar',
+                'baz' => 'baz',
+            ]);
+
+        self::assertInstanceOf(SomeAbstractChildClass::class, $result);
+        self::assertSame('foo', $result->foo);
+        self::assertSame('bar', $result->bar);
+        self::assertSame('baz', $result->baz);
+    }
+
+    public function test_infer_abstract_class_with_argument_in_callback_works_as_expected(): void
+    {
+        $result = (new MapperBuilder())
+            ->infer(
+                SomeAbstractClass::class,
+                /** @return class-string<SomeAbstractChildClass> */
+                fn (string $type) => match ($type) {
+                    'foo' => SomeAbstractChildClass::class,
+                    default => throw new LogicException("Invalid type $type.")
+                }
+            )
+            ->mapper()
+            ->map(SomeAbstractClass::class, [
+                'type' => 'foo',
+                'foo' => 'foo',
+                'bar' => 'bar',
+                'baz' => 'baz',
+            ]);
+
+        self::assertInstanceOf(SomeAbstractChildClass::class, $result);
+        self::assertSame('foo', $result->foo);
+        self::assertSame('bar', $result->bar);
+        self::assertSame('baz', $result->baz);
+    }
+
+    public function test_infer_class_works_as_expected(): void
+    {
+        $result = (new MapperBuilder())
+            ->infer(
+                SomeParentClass::class,
+                fn () => SomeChildClass::class
+            )
+            ->mapper()
+            ->map(SomeParentClass::class, [
+                'foo' => 'foo',
+                'bar' => 'bar',
+                'baz' => 'baz',
+            ]);
+
+        self::assertInstanceOf(SomeChildClass::class, $result);
+        self::assertSame('foo', $result->foo);
+        self::assertSame('bar', $result->bar);
+        self::assertSame('baz', $result->baz);
+    }
+
+    public function test_infer_class_with_argument_in_callback_works_as_expected(): void
+    {
+        $result = (new MapperBuilder())
+            ->infer(
+                SomeParentClass::class,
+                /** @return class-string<SomeChildClass> */
+                fn (string $type) => match ($type) {
+                    'foo' => SomeChildClass::class,
+                    default => throw new LogicException("Invalid type $type.")
+                }
+            )
+            ->mapper()
+            ->map(SomeParentClass::class, [
+                'type' => 'foo',
+                'foo' => 'foo',
+                'bar' => 'bar',
+                'baz' => 'baz',
+            ]);
+
+        self::assertInstanceOf(SomeChildClass::class, $result);
+        self::assertSame('foo', $result->foo);
+        self::assertSame('bar', $result->bar);
+        self::assertSame('baz', $result->baz);
+    }
+
+    public function test_infer_final_class_throws_exception(): void
+    {
+        $this->expectException(CannotInferFinalClass::class);
+        $this->expectExceptionCode(1671468163);
+        $this->expectExceptionMessage('Cannot infer final class `' . SomeAbstractChildClass::class . '` with function');
+
+        (new MapperBuilder())
+            ->infer(SomeAbstractChildClass::class, fn () => SomeAbstractChildClass::class)
+            ->mapper()
+            ->map(SomeAbstractChildClass::class, []);
+    }
+}
+
+abstract class SomeAbstractClass
+{
+    public string $foo;
+
+    public string $bar;
+}
+
+final class SomeAbstractChildClass extends SomeAbstractClass
+{
+    public string $baz;
+}
+
+class SomeParentClass
+{
+    public string $foo;
+
+    public string $bar;
+}
+
+final class SomeChildClass extends SomeParentClass
+{
+    public string $baz;
+}

--- a/tests/Unit/Definition/ClassDefinitionTest.php
+++ b/tests/Unit/Definition/ClassDefinitionTest.php
@@ -24,12 +24,13 @@ final class ClassDefinitionTest extends TestCase
         $properties = new Properties(FakePropertyDefinition::new());
         $methods = new Methods(FakeMethodDefinition::new());
 
-        $class = new ClassDefinition($type, $attributes, $properties, $methods);
+        $class = new ClassDefinition($type, $attributes, $properties, $methods, true);
 
         self::assertSame(stdClass::class, $class->name());
         self::assertSame($type, $class->type());
         self::assertSame($attributes, $class->attributes());
         self::assertSame($properties, $class->properties());
         self::assertSame($methods, $class->methods());
+        self::assertSame(true, $class->isFinal());
     }
 }

--- a/tests/Unit/Definition/ClassDefinitionTest.php
+++ b/tests/Unit/Definition/ClassDefinitionTest.php
@@ -24,7 +24,7 @@ final class ClassDefinitionTest extends TestCase
         $properties = new Properties(FakePropertyDefinition::new());
         $methods = new Methods(FakeMethodDefinition::new());
 
-        $class = new ClassDefinition($type, $attributes, $properties, $methods, true);
+        $class = new ClassDefinition($type, $attributes, $properties, $methods, true, false);
 
         self::assertSame(stdClass::class, $class->name());
         self::assertSame($type, $class->type());
@@ -32,5 +32,6 @@ final class ClassDefinitionTest extends TestCase
         self::assertSame($properties, $class->properties());
         self::assertSame($methods, $class->methods());
         self::assertSame(true, $class->isFinal());
+        self::assertSame(false, $class->isAbstract());
     }
 }


### PR DESCRIPTION
It is now possible to infer abstract or parent classes the same way it
can be done for interfaces.

Example with an abstract class:

```php
abstract class SomeAbstractClass
{
    public string $foo;

    public string $bar;
}

final class SomeChildClass extends SomeAbstractClass
{
    public string $baz;
}

$result = (new \CuyZ\Valinor\MapperBuilder())
    ->infer(
        SomeAbstractClass::class,
        fn () => SomeChildClass::class
    )
    ->mapper()
    ->map(SomeAbstractClass::class, [
        'foo' => 'foo',
        'bar' => 'bar',
        'baz' => 'baz',
    ]);

assert($result instanceof SomeChildClass);
assert($result->foo === 'foo');
assert($result->bar === 'bar');
assert($result->baz === 'baz');
```

Fixes #143 