### PR TITLE
feat: allow usage of array input for single node during mapping

### DIFF
--- a/docs/pages/usage/object-construction.md
+++ b/docs/pages/usage/object-construction.md
@@ -14,9 +14,13 @@ constructors](../how-to/use-custom-object-constructors.md).
 
 ## Class with a single value
 
-When an object needs only one value (one constructor argument or one property), 
-the source given to the mapper must match the type of the value. See example 
-below:
+When an object needs only one value (one constructor argument or one property),
+the source given to the mapper can match the type of the value — it does not
+need to be an array with one value with a key matching the argument/property
+name.
+
+This can be useful when the application has control over the format of the 
+source given to the mapper, in order to lessen the structure of input.
 
 ```php
 final class Identifier
@@ -34,12 +38,16 @@ final class SomeClass
 $mapper = (new \CuyZ\Valinor\MapperBuilder())->mapper();
 
 $mapper->map(SomeClass::class, [
-    'identifier' => ['value' => 'some-identifier'], // ❌
+    'identifier' => [
+        // 👎 The `value` key feels a bit excessive
+        'value' => 'some-identifier'
+    ],
     'description' => 'Lorem ipsum…',
 ]); 
 
 $mapper->map(SomeClass::class, [
-    'identifier' => 'some-identifier', // ✅
+    // 👍 The input has been flattened and is easier to read
+    'identifier' => 'some-identifier',
     'description' => 'Lorem ipsum…',
 ]);
 ```

--- a/tests/Integration/Mapping/Object/NullableMappingTest.php
+++ b/tests/Integration/Mapping/Object/NullableMappingTest.php
@@ -10,7 +10,7 @@ use CuyZ\Valinor\Tests\Integration\IntegrationTest;
 
 final class NullableMappingTest extends IntegrationTest
 {
-    public function test_nullable_property_with_null_default_value_is_handled_properly(): void
+    public function test_nullable_properties_default_value_are_handled_properly(): void
     {
         try {
             $result = (new MapperBuilder())->mapper()->map(NullablePropertyWithNullDefaultValue::class, []);
@@ -19,10 +19,13 @@ final class NullableMappingTest extends IntegrationTest
         }
 
         self::assertSame(null, $result->nullableWithNull);
+        self::assertSame('foo', $result->nullableWithString);
     }
 }
 
 final class NullablePropertyWithNullDefaultValue
 {
     public ?string $nullableWithNull = null;
+
+    public ?string $nullableWithString = 'foo';
 }

--- a/tests/Integration/Mapping/Other/SuperfluousKeysMappingTest.php
+++ b/tests/Integration/Mapping/Other/SuperfluousKeysMappingTest.php
@@ -55,6 +55,19 @@ final class SuperfluousKeysMappingTest extends IntegrationTest
         self::assertSame('bar', $object->bar);
         self::assertSame('fiz', $object->fiz);
     }
+
+    public function test_single_property_node_can_be_mapped_with_superfluous_key(): void
+    {
+        try {
+            $result = $this->mapper->map(SomeFooObject::class, [
+                'foo' => 'foo',
+                'bar' => 'bar',
+            ]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+        self::assertSame('foo', $result->foo);
+    }
 }
 
 // PHP8.1 Readonly properties

--- a/tests/Integration/Mapping/SingleNodeMappingTest.php
+++ b/tests/Integration/Mapping/SingleNodeMappingTest.php
@@ -10,64 +10,92 @@ use CuyZ\Valinor\Tests\Integration\IntegrationTest;
 
 final class SingleNodeMappingTest extends IntegrationTest
 {
-    public function test_single_property_and_constructor_parameter_are_mapped_properly(): void
+    /**
+     * @dataProvider single_property_and_constructor_parameter_data_provider
+     *
+     * @param class-string $className
+     */
+    public function test_single_property_and_constructor_parameter_are_mapped_properly(string $className, mixed $value): void
     {
-        $mapper = (new MapperBuilder())->mapper();
-
-        // Note that the key `value` is missing from the source
-        $scalarSource = 'foo';
-        $arraySource = ['foo', '42.404', '1337'];
-
         try {
-            $singleScalarProperty = $mapper->map(SingleScalarProperty::class, $scalarSource);
-            $singleConstructorScalarParameter = $mapper->map(SingleConstructorScalarParameter::class, $scalarSource);
-            $singleNullableScalarProperty = $mapper->map(SingleNullableScalarProperty::class, null);
-            $singleConstructorNullableScalarParameter = $mapper->map(SingleConstructorNullableScalarParameter::class, null);
-            $singleArrayProperty = $mapper->map(SingleArrayProperty::class, $arraySource);
-            $singleConstructorArrayParameter = $mapper->map(SingleConstructorArrayParameter::class, $arraySource);
-            $singleScalarPropertyWithDefaultValue = $mapper->map(SingleScalarPropertyWithDefaultValue::class, []);
-            $singleConstructorParameterWithDefaultValue = $mapper->map(SingleConstructorParameterWithDefaultValue::class, []);
+            $result = (new MapperBuilder())->mapper()->map($className, $value);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }
 
-        self::assertSame('foo', $singleScalarProperty->value);
-        self::assertSame('foo', $singleConstructorScalarParameter->value);
-        self::assertSame(null, $singleNullableScalarProperty->value);
-        self::assertSame(null, $singleConstructorNullableScalarParameter->value);
-        self::assertSame(['foo', '42.404', '1337'], $singleArrayProperty->value);
-        self::assertSame(['foo', '42.404', '1337'], $singleConstructorArrayParameter->value);
-        self::assertSame('foo', $singleScalarPropertyWithDefaultValue->value);
-        self::assertSame('bar', $singleConstructorParameterWithDefaultValue->value);
+        self::assertSame($value, $result->value); // @phpstan-ignore-line
     }
 
     /**
-     * @dataProvider single_property_and_constructor_parameter_cannot_be_mapped_with_array_with_property_name_data_provider
+     * @dataProvider single_property_and_constructor_parameter_with_default_value_data_provider
      *
      * @param class-string $className
-     * @param mixed $source
      */
-    public function test_single_property_and_constructor_parameter_cannot_be_mapped_with_array_with_property_name(string $className, $source): void
+    public function test_single_property_and_constructor_parameter_with_default_value_are_mapped_properly(string $className): void
     {
         try {
-            (new MapperBuilder())->mapper()->map($className, $source);
-        } catch (MappingError $exception) {
-            $error = $exception->node()->messages()[0];
-
-            self::assertSame('1632903281', $error->code());
+            $result = (new MapperBuilder())->mapper()->map($className, ['foo' => []]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
         }
+
+        self::assertSame('foo', $result['foo']->value); // @phpstan-ignore-line
     }
 
-    public function single_property_and_constructor_parameter_cannot_be_mapped_with_array_with_property_name_data_provider(): iterable
+    /**
+     * @dataProvider single_property_and_constructor_parameter_data_provider
+     *
+     * @param class-string $className
+     */
+    public function test_single_property_and_constructor_parameter_can_be_mapped_with_array_with_property_name(string $className, mixed $value): void
     {
-        yield [SingleScalarProperty::class, ['value' => 'foo']];
-        yield [SingleConstructorScalarParameter::class, ['value' => 'foo']];
-        yield [SingleNullableScalarProperty::class, ['value' => null]];
-        yield [SingleConstructorNullableScalarParameter::class, ['value' => null]];
-        yield [SingleArrayProperty::class, ['value' => ['foo', '42.404', '1337']]];
-        yield [SingleConstructorArrayParameter::class, ['value' => ['foo', '42.404', '1337']]];
-        yield [SingleScalarPropertyWithDefaultValue::class, ['value' => []]];
-        yield [SingleConstructorParameterWithDefaultValue::class, ['value' => []]];
+        try {
+            $result = (new MapperBuilder())->mapper()->map($className, ['value' => $value]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame($value, $result->value); // @phpstan-ignore-line
+    }
+
+    public function single_property_and_constructor_parameter_data_provider(): iterable
+    {
+        yield 'Single scalar property' => [
+            SingleScalarProperty::class, 'foo',
+        ];
+        yield 'Single constructor scalar parameter' => [
+            SingleConstructorScalarParameter::class, 'foo',
+        ];
+        yield 'Single nullable scalar property' => [
+            SingleNullableScalarProperty::class, null,
+        ];
+        yield 'Single constructor nullable scalar property' => [
+            SingleConstructorNullableScalarParameter::class, null,
+        ];
+        yield 'Single array property with empty array' => [
+            SingleArrayProperty::class, [],
+        ];
+        yield 'Single array property with filled array' => [
+            SingleArrayProperty::class, ['foo', '42.404', '1337'],
+        ];
+        yield 'Single array property with array containing entry with same key as property name' => [
+            SingleArrayProperty::class, ['value' => 'foo', 'otherValue' => 'bar'],
+        ];
+        yield 'Single constructor array parameter with empty array' => [
+            SingleConstructorArrayParameter::class, [],
+        ];
+        yield 'Single constructor array parameter with filled array' => [
+            SingleConstructorArrayParameter::class, ['foo', '42.404', '1337'],
+        ];
+        yield 'Single constructor array parameter with array containing entry with same key as parameter name' => [
+            SingleConstructorArrayParameter::class, ['value' => 'foo', 'otherValue' => 'bar'],
+        ];
+    }
+
+    public function single_property_and_constructor_parameter_with_default_value_data_provider(): iterable
+    {
+        yield ['array{foo: ' . SingleScalarPropertyWithDefaultValue::class . '}'];
+        yield ['array{foo: ' . SingleConstructorParameterWithDefaultValue::class . '}'];
     }
 }
 
@@ -101,7 +129,7 @@ class SingleConstructorNullableScalarParameter extends SingleNullableScalarPrope
 class SingleArrayProperty
 {
     /** @var array<string> */
-    public array $value = [];
+    public array $value;
 }
 
 class SingleConstructorArrayParameter extends SingleArrayProperty
@@ -122,7 +150,7 @@ class SingleScalarPropertyWithDefaultValue
 
 class SingleConstructorParameterWithDefaultValue extends SingleScalarPropertyWithDefaultValue
 {
-    public function __construct(string $value = 'bar')
+    public function __construct(string $value = 'foo')
     {
         $this->value = $value;
     }


### PR DESCRIPTION
It is now possible, again, to use an array for a single node (single
class property or single constructor argument), if this array has one
value with a key matching the argument/property name.

This is a revert of a change that was introduced in a previous commit:
see hash 72cba320f582c7cda63865880a1cbf7ea292d2b1

Closes #269