### PR TITLE
Support generic constructors

### DIFF
--- a/src/Mapper/Object/FunctionObjectBuilder.php
+++ b/src/Mapper/Object/FunctionObjectBuilder.php
@@ -43,7 +43,7 @@ final class FunctionObjectBuilder implements ObjectBuilder
         );
 
         $this->isDynamicConstructor = $definition->attributes()->has(DynamicConstructor::class);
-        $this->isGenericConstructor = $type instanceof GenericType && count($type->generics()) > 0;
+        $this->isGenericConstructor = $definition->returnType() instanceof GenericType && count($definition->returnType()->generics()) > 0;
 
         if ($this->isDynamicConstructor || $this->isGenericConstructor) {
             array_shift($arguments);


### PR DESCRIPTION
This was just an experiment to solve #149. Though it it impossible to specify generic constructors today. You will get the following exception.  (See issue for complete code example for reproduction)

```
PHP Fatal error:  Uncaught CuyZ\Valinor\Mapper\Object\Exception\InvalidConstructorReturnType: The type `Bar<T>` for return type of method `Closure (lines 44 to 47 of /home/einar/projects/Valinor/test.php)` could not be resolved: Cannot parse unknown symbol `T`. in /home/einar/projects/Valinor/src/Mapper/Object/Factory/ConstructorObjectBuilderFactory.php:153
Stack trace:
#0 /home/einar/projects/Valinor/src/Mapper/Object/Factory/ConstructorObjectBuilderFactory.php(70): CuyZ\Valinor\Mapper\Object\Factory\ConstructorObjectBuilderFactory->filteredConstructors()
#1 /home/einar/projects/Valinor/src/Mapper/Object/Factory/ConstructorObjectBuilderFactory.php(46): CuyZ\Valinor\Mapper\Object\Factory\ConstructorObjectBuilderFactory->builders()
#2 /home/einar/projects/Valinor/src/Mapper/Object/Factory/DateTimeZoneObjectBuilderFactory.php(36): CuyZ\Valinor\Mapper\Object\Factory\ConstructorObjectBuilderFactory->for()
#3 /home/einar/projects/Valinor/src/Mapper/Object/Factory/DateTimeObjectBuilderFactory.php(34): CuyZ\Valinor\Mapper\Object\Factory\DateTimeZoneObjectBuilderFactory->for()
#4 /home/einar/projects/Valinor/src/Mapper/Object/Factory/CollisionObjectBuilderFactory.php(24): CuyZ\Valinor\Mapper\Object\Factory\DateTimeObjectBuilderFactory->for()
#5 /home/einar/projects/Valinor/src/Mapper/Object/Factory/StrictTypesObjectBuilderFactory.php(21): CuyZ\Valinor\Mapper\Object\Factory\CollisionObjectBuilderFactory->for()
#6 /home/einar/projects/Valinor/src/Mapper/Object/Factory/CacheObjectBuilderFactory.php(31): CuyZ\Valinor\Mapper\Object\Factory\StrictTypesObjectBuilderFactory->for()
#7 /home/einar/projects/Valinor/src/Mapper/Tree/Builder/NativeClassNodeBuilder.php(38): CuyZ\Valinor\Mapper\Object\Factory\CacheObjectBuilderFactory->for()
#8 /home/einar/projects/Valinor/src/Mapper/Tree/Builder/CasterNodeBuilder.php(25): CuyZ\Valinor\Mapper\Tree\Builder\NativeClassNodeBuilder->build()
#9 /home/einar/projects/Valinor/src/Mapper/Tree/Builder/UnionNodeBuilder.php(38): CuyZ\Valinor\Mapper\Tree\Builder\CasterNodeBuilder->build()
#10 /home/einar/projects/Valinor/src/Mapper/Tree/Builder/InterfaceNodeBuilder.php(52): CuyZ\Valinor\Mapper\Tree\Builder\UnionNodeBuilder->build()
#11 /home/einar/projects/Valinor/src/Mapper/Tree/Builder/CasterProxyNodeBuilder.php(26): CuyZ\Valinor\Mapper\Tree\Builder\InterfaceNodeBuilder->build()
#12 /home/einar/projects/Valinor/src/Mapper/Tree/Builder/IterableNodeBuilder.php(28): CuyZ\Valinor\Mapper\Tree\Builder\CasterProxyNodeBuilder->build()
#13 /home/einar/projects/Valinor/src/Mapper/Tree/Builder/StrictNodeBuilder.php(37): CuyZ\Valinor\Mapper\Tree\Builder\IterableNodeBuilder->build()
#14 /home/einar/projects/Valinor/src/Mapper/Tree/Builder/ErrorCatcherNodeBuilder.php(33): CuyZ\Valinor\Mapper\Tree\Builder\StrictNodeBuilder->build()
#15 /home/einar/projects/Valinor/src/Mapper/Tree/Builder/RootNodeBuilder.php(18): CuyZ\Valinor\Mapper\Tree\Builder\ErrorCatcherNodeBuilder->build()
#16 /home/einar/projects/Valinor/src/Mapper/TypeTreeMapper.php(45): CuyZ\Valinor\Mapper\Tree\Builder\RootNodeBuilder->build()
#17 /home/einar/projects/Valinor/src/Mapper/TypeTreeMapper.php(26): CuyZ\Valinor\Mapper\TypeTreeMapper->node()
#18 /home/einar/projects/Valinor/test.php(51): CuyZ\Valinor\Mapper\TypeTreeMapper->map()
#19 {main}
  thrown in /home/einar/projects/Valinor/src/Mapper/Object/Factory/ConstructorObjectBuilderFactory.php on line 153
```


Using something weird like `@return Bar<1>` as return type for the constuctor works though, eh.. :)  

