### PR TITLE
misc: catch `json_encode` exception to help identifying parsing errors

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -36,9 +36,6 @@ return static function (RectorConfig $config): void {
         UnionTypesRector::class => [
             __DIR__ . '/tests/Unit/Definition/Repository/Reflection/ReflectionClassDefinitionRepositoryTest',
         ],
-        JsonThrowOnErrorRector::class => [
-            __DIR__ . '/src/Mapper/Source/JsonSource.php',
-        ],
         MixedTypeRector::class => [
             __DIR__ . '/tests/Integration/Mapping/Object/UnionValuesMappingTest.php',
             __DIR__ . '/tests/Unit/Definition/Repository/Reflection/ReflectionClassDefinitionRepositoryTest',

--- a/src/Mapper/Source/Exception/InvalidJson.php
+++ b/src/Mapper/Source/Exception/InvalidJson.php
@@ -4,16 +4,18 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper\Source\Exception;
 
+use JsonException;
 use RuntimeException;
 
 /** @internal */
 final class InvalidJson extends RuntimeException implements InvalidSource
 {
-    public function __construct(private string $source)
+    public function __construct(private string $source, ?JsonException $previous = null)
     {
         parent::__construct(
             'Invalid JSON source.',
-            1566307185
+            1566307185,
+            $previous
         );
     }
 

--- a/src/Mapper/Source/JsonSource.php
+++ b/src/Mapper/Source/JsonSource.php
@@ -9,10 +9,13 @@ use CuyZ\Valinor\Mapper\Source\Exception\InvalidSource;
 use CuyZ\Valinor\Mapper\Source\Exception\SourceNotIterable;
 use Iterator;
 use IteratorAggregate;
+use JsonException;
 use Traversable;
 
 use function is_iterable;
 use function json_decode;
+
+use const JSON_THROW_ON_ERROR;
 
 /**
  * @api
@@ -29,10 +32,10 @@ final class JsonSource implements IteratorAggregate
      */
     public function __construct(string $jsonSource)
     {
-        $source = json_decode($jsonSource, true);
-
-        if ($source === null) {
-            throw new InvalidJson($jsonSource);
+        try {
+            $source = json_decode($jsonSource, true, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new InvalidJson($jsonSource, $e);
         }
 
         if (! is_iterable($source)) {

--- a/src/Mapper/Source/JsonSource.php
+++ b/src/Mapper/Source/JsonSource.php
@@ -33,7 +33,7 @@ final class JsonSource implements IteratorAggregate
     public function __construct(string $jsonSource)
     {
         try {
-            $source = json_decode($jsonSource, true, flags: JSON_THROW_ON_ERROR);
+            $source = json_decode($jsonSource, associative: true, flags: JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {
             throw new InvalidJson($jsonSource, $e);
         }


### PR DESCRIPTION
This brings two improvements:

- The reason for the JSON parsing failure is visible in the stack trace / $previous exception, allowing the developer to determine whether the parsing failure was caused by a syntax error, invalid UTF-8 sequence or something else.
- The JSON string `null` (which decodes to `null`) is no longer erroneously rejected as invalid. Instead it is rejected, because it is not iterable, slightly improving the error reporting.