### PR TITLE
Avoid using unserialize when caching NULL default values

### DIFF
--- a/src/Definition/Repository/Cache/Compiler/ParameterDefinitionCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/ParameterDefinitionCompiler.php
@@ -42,7 +42,7 @@ final class ParameterDefinitionCompiler
     {
         $defaultValue = $parameter->defaultValue();
 
-        return is_scalar($defaultValue)
+        return !is_object($defaultValue)
             ? var_export($parameter->defaultValue(), true)
             : 'unserialize(' . var_export(serialize($defaultValue), true) . ')';
     }

--- a/src/Definition/Repository/Cache/Compiler/ParameterDefinitionCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/ParameterDefinitionCompiler.php
@@ -42,8 +42,8 @@ final class ParameterDefinitionCompiler
     {
         $defaultValue = $parameter->defaultValue();
 
-        return !is_object($defaultValue)
-            ? var_export($parameter->defaultValue(), true)
-            : 'unserialize(' . var_export(serialize($defaultValue), true) . ')';
+        return is_object($defaultValue)
+            ? 'unserialize(' . var_export(serialize($defaultValue), true) . ')'
+            : var_export($parameter->defaultValue(), true);
     }
 }

--- a/src/Definition/Repository/Cache/Compiler/ParameterDefinitionCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/ParameterDefinitionCompiler.php
@@ -6,8 +6,6 @@ namespace CuyZ\Valinor\Definition\Repository\Cache\Compiler;
 
 use CuyZ\Valinor\Definition\ParameterDefinition;
 
-use function is_scalar;
-
 /** @internal */
 final class ParameterDefinitionCompiler
 {
@@ -44,6 +42,6 @@ final class ParameterDefinitionCompiler
 
         return is_object($defaultValue)
             ? 'unserialize(' . var_export(serialize($defaultValue), true) . ')'
-            : var_export($parameter->defaultValue(), true);
+            : var_export($defaultValue, true);
     }
 }


### PR DESCRIPTION
`is_scalar` should just be an inverted `is_object` check, instead.