### PR TITLE
Move QA from autoload-dev to autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,13 +33,13 @@
     },
     "autoload": {
         "psr-4": {
-            "CuyZ\\Valinor\\": "src"
+            "CuyZ\\Valinor\\": "src",
+            "CuyZ\\Valinor\\QA\\": "qa"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "CuyZ\\Valinor\\Tests\\": "tests",
-            "CuyZ\\Valinor\\QA\\": "qa"
+            "CuyZ\\Valinor\\Tests\\": "tests"
         }
     },
     "scripts": {


### PR DESCRIPTION
Attempting to use the Psalm plugin yields the following error:

> CuyZ\Valinor\QA\Psalm\ValinorPsalmPlugin is not a known class

This is because classes registered as `autoload-dev` are only included in the autoloader when running composer in dev mode **on the Valinor project**, not when Valinor is a project dependency.

Moving it to `autoload` will make it available everywhere.