### PR TITLE
fix: remove previous exception from UnresolvableType

### DIFF
--- a/src/Definition/NativeAttributes.php
+++ b/src/Definition/NativeAttributes.php
@@ -20,16 +20,14 @@ final class NativeAttributes implements Attributes
 {
     private AttributesContainer $delegate;
 
-    /** @var array<ReflectionAttribute<object>> */
-    private array $reflectionAttributes;
+    /** @var array<class-string, array<mixed>> */
+    private array $definition = [];
 
     /**
      * @param ReflectionClass<object>|ReflectionProperty|ReflectionMethod|ReflectionFunction|ReflectionParameter $reflection
      */
     public function __construct(ReflectionClass|ReflectionProperty|ReflectionMethod|ReflectionFunction|ReflectionParameter $reflection)
     {
-        $this->reflectionAttributes = $reflection->getAttributes();
-
         $attributes = array_filter(
             array_map(
                 static function (ReflectionAttribute $attribute) {
@@ -45,9 +43,13 @@ final class NativeAttributes implements Attributes
                         return null;
                     }
                 },
-                $this->reflectionAttributes,
+                $reflection->getAttributes(),
             ),
         );
+
+        foreach ($reflection->getAttributes() as $attribute) {
+            $this->definition[$attribute->getName()] = $attribute->getArguments();
+        }
 
         $this->delegate = new AttributesContainer(...$attributes);
     }
@@ -73,10 +75,10 @@ final class NativeAttributes implements Attributes
     }
 
     /**
-     * @return array<ReflectionAttribute<object>>
+     * @return array<class-string, array<mixed>>
      */
-    public function reflectionAttributes(): array
+    public function definition(): array
     {
-        return $this->reflectionAttributes;
+        return $this->definition;
     }
 }

--- a/src/Mapper/Object/Exception/InvalidConstructorReturnType.php
+++ b/src/Mapper/Object/Exception/InvalidConstructorReturnType.php
@@ -17,12 +17,10 @@ final class InvalidConstructorReturnType extends LogicException
 
         if ($returnType instanceof UnresolvableType) {
             $message = $returnType->message();
-            $previous = $returnType->previous();
         } else {
             $message = "Invalid return type `{$returnType->toString()}` for constructor `{$function->signature()}`, it must be a valid class name.";
-            $previous = null;
         }
 
-        parent::__construct($message, 1659446121, $previous);
+        parent::__construct($message, 1659446121);
     }
 }

--- a/src/Type/Types/UnresolvableType.php
+++ b/src/Type/Types/UnresolvableType.php
@@ -9,7 +9,6 @@ use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Utility\ValueDumper;
 use LogicException;
-use Throwable;
 
 /** @internal */
 final class UnresolvableType implements Type
@@ -17,15 +16,13 @@ final class UnresolvableType implements Type
     public function __construct(
         private string $rawType,
         private string $message,
-        private ?Throwable $previous = null
     ) {}
 
     public static function forProperty(string $raw, string $signature, InvalidType $exception): self
     {
         return new self(
             $raw,
-            "The type `$raw` for property `$signature` could not be resolved: {$exception->getMessage()}",
-            $exception
+            "The type `$raw` for property `$signature` could not be resolved: {$exception->getMessage()}"
         );
     }
 
@@ -33,8 +30,7 @@ final class UnresolvableType implements Type
     {
         return new self(
             $raw,
-            "The type `$raw` for parameter `$signature` could not be resolved: {$exception->getMessage()}",
-            $exception
+            "The type `$raw` for parameter `$signature` could not be resolved: {$exception->getMessage()}"
         );
     }
 
@@ -42,8 +38,7 @@ final class UnresolvableType implements Type
     {
         return new self(
             $raw,
-            "The type `$raw` for return type of method `$signature` could not be resolved: {$exception->getMessage()}",
-            $exception
+            "The type `$raw` for return type of method `$signature` could not be resolved: {$exception->getMessage()}"
         );
     }
 
@@ -71,19 +66,13 @@ final class UnresolvableType implements Type
     {
         return new self(
             $raw,
-            "The type `$raw` for local alias `$name` of the class `{$type->className()}` could not be resolved: {$exception->getMessage()}",
-            $exception
+            "The type `$raw` for local alias `$name` of the class `{$type->className()}` could not be resolved: {$exception->getMessage()}"
         );
     }
 
     public function message(): string
     {
         return $this->message;
-    }
-
-    public function previous(): ?Throwable
-    {
-        return $this->previous;
     }
 
     public function accepts(mixed $value): bool


### PR DESCRIPTION
Following up eaa1283, fixes an issue where cache mechanism could break
when relying on serialization.