### PR TITLE
feat: introduce method to get date formats supported during mapping

### DIFF
--- a/src/MapperBuilder.php
+++ b/src/MapperBuilder.php
@@ -12,6 +12,7 @@ use CuyZ\Valinor\Mapper\TreeMapper;
 use Psr\SimpleCache\CacheInterface;
 use Throwable;
 
+use function array_unique;
 use function is_callable;
 
 /** @api */
@@ -235,9 +236,22 @@ final class MapperBuilder
     public function supportDateFormats(string $format, string ...$formats): self
     {
         $clone = clone $this;
-        $clone->settings->supportedDateFormats = [$format, ...$formats];
+        $clone->settings->supportedDateFormats = array_unique([$format, ...$formats]);
 
         return $clone;
+    }
+
+    /**
+     * Returns the date formats supported during mapping.
+     *
+     * By default, any valid timestamp or ATOM-formatted value are accepted.
+     * Custom formats can be set using method `supportDateFormats()`.
+     *
+     * @return non-empty-array<non-empty-string>
+     */
+    public function supportedDateFormats(): array
+    {
+        return $this->settings->supportedDateFormats;
     }
 
     /**

--- a/tests/Unit/MapperBuilderTest.php
+++ b/tests/Unit/MapperBuilderTest.php
@@ -51,4 +51,32 @@ final class MapperBuilderTest extends TestCase
     {
         self::assertSame($this->mapperBuilder->mapper(), $this->mapperBuilder->mapper());
     }
+
+    public function test_get_supported_date_formats_returns_defaults_formats_when_not_overridden(): void
+    {
+        self::assertSame([DATE_ATOM, 'U'], $this->mapperBuilder->supportedDateFormats());
+    }
+
+    public function test_get_supported_date_formats_returns_configured_values(): void
+    {
+        $mapperBuilder = $this->mapperBuilder->supportDateFormats('Y-m-d', 'd/m/Y');
+
+        self::assertSame(['Y-m-d', 'd/m/Y'], $mapperBuilder->supportedDateFormats());
+    }
+
+    public function test_get_supported_date_formats_returns_last_values(): void
+    {
+        $mapperBuilder = $this->mapperBuilder
+            ->supportDateFormats('Y-m-d')
+            ->supportDateFormats('d/m/Y');
+
+        self::assertSame(['d/m/Y'], $mapperBuilder->supportedDateFormats());
+    }
+
+    public function test_supported_date_formats_are_unique(): void
+    {
+        $mapperBuilder = $this->mapperBuilder->supportDateFormats('Y-m-d', 'd/m/Y', 'Y-m-d');
+
+        self::assertSame(['Y-m-d', 'd/m/Y'], $mapperBuilder->supportedDateFormats());
+    }
 }


### PR DESCRIPTION
The new method `MapperBuilder::supportedDateFormats()` can be used to get date formats supported during mapping.