### PR TITLE
fix: improve cache warmup by creating required directories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,7 @@
             "rector"
         ],
         "mutation": [
+            "@putenv XDEBUG_MODE=off",
             "infection --threads=max --git-diff-lines"
         ],
         "doc": [

--- a/src/Cache/ChainCache.php
+++ b/src/Cache/ChainCache.php
@@ -11,9 +11,9 @@ use Traversable;
  * @internal
  *
  * @template EntryType
- * @implements CacheInterface<EntryType>
+ * @implements WarmupCache<EntryType>
  */
-final class ChainCache implements CacheInterface
+final class ChainCache implements WarmupCache
 {
     /** @var array<CacheInterface<EntryType>> */
     private array $delegates;
@@ -27,6 +27,15 @@ final class ChainCache implements CacheInterface
     {
         $this->delegates = $delegates;
         $this->count = count($delegates);
+    }
+
+    public function warmup(): void
+    {
+        foreach ($this->delegates as $delegate) {
+            if ($delegate instanceof WarmupCache) {
+                $delegate->warmup();
+            }
+        }
     }
 
     public function get($key, $default = null): mixed

--- a/src/Cache/Compiled/CompiledPhpFileCache.php
+++ b/src/Cache/Compiled/CompiledPhpFileCache.php
@@ -7,11 +7,11 @@ namespace CuyZ\Valinor\Cache\Compiled;
 use CuyZ\Valinor\Cache\Exception\CacheDirectoryNotWritable;
 use CuyZ\Valinor\Cache\Exception\CompiledPhpCacheFileNotWritten;
 use CuyZ\Valinor\Cache\Exception\CorruptedCompiledPhpCacheFile;
+use CuyZ\Valinor\Cache\WarmupCache;
 use DateInterval;
 use DateTime;
 use Error;
 use FilesystemIterator;
-use Psr\SimpleCache\CacheInterface;
 use Traversable;
 
 use function bin2hex;
@@ -30,9 +30,9 @@ use function unlink;
  * @internal
  *
  * @template EntryType
- * @implements CacheInterface<EntryType>
+ * @implements WarmupCache<EntryType>
  */
-final class CompiledPhpFileCache implements CacheInterface
+final class CompiledPhpFileCache implements WarmupCache
 {
     private const TEMPORARY_DIR_PERMISSION = 510;
 
@@ -45,6 +45,11 @@ final class CompiledPhpFileCache implements CacheInterface
         private string $cacheDir,
         private CacheCompiler $compiler
     ) {}
+
+    public function warmup(): void
+    {
+        $this->createTemporaryDir();
+    }
 
     public function has($key): bool
     {
@@ -74,11 +79,7 @@ final class CompiledPhpFileCache implements CacheInterface
 
         $code = $this->compile($value, $ttl);
 
-        $tmpDir = $this->cacheDir . DIRECTORY_SEPARATOR . '.valinor.tmp';
-
-        if (! is_dir($tmpDir) && ! @mkdir($tmpDir, self::TEMPORARY_DIR_PERMISSION, true)) {
-            throw new CacheDirectoryNotWritable($this->cacheDir);
-        }
+        $tmpDir = $this->createTemporaryDir();
 
         /** @infection-ignore-all */
         $tmpFilename = $tmpDir . DIRECTORY_SEPARATOR . bin2hex(random_bytes(16));
@@ -226,6 +227,17 @@ final class CompiledPhpFileCache implements CacheInterface
         }
 
         return $this->files[$filename];
+    }
+
+    private function createTemporaryDir(): string
+    {
+        $tmpDir = $this->cacheDir . DIRECTORY_SEPARATOR . '.valinor.tmp';
+
+        if (! is_dir($tmpDir) && ! @mkdir($tmpDir, self::TEMPORARY_DIR_PERMISSION, true)) {
+            throw new CacheDirectoryNotWritable($this->cacheDir);
+        }
+
+        return $tmpDir;
     }
 
     private function path(string $key): string

--- a/src/Cache/FileSystemCache.php
+++ b/src/Cache/FileSystemCache.php
@@ -20,9 +20,9 @@ use function sys_get_temp_dir;
  * @api
  *
  * @template EntryType
- * @implements CacheInterface<EntryType>
+ * @implements WarmupCache<EntryType>
  */
-final class FileSystemCache implements CacheInterface
+final class FileSystemCache implements WarmupCache
 {
     /** @var array<string, CacheInterface<EntryType>> */
     private array $delegates;
@@ -37,6 +37,15 @@ final class FileSystemCache implements CacheInterface
             ClassDefinition::class => new CompiledPhpFileCache($cacheDir . DIRECTORY_SEPARATOR . 'classes', new ClassDefinitionCompiler()),
             FunctionDefinition::class => new CompiledPhpFileCache($cacheDir . DIRECTORY_SEPARATOR . 'functions', new FunctionDefinitionCompiler()),
         ];
+    }
+
+    public function warmup(): void
+    {
+        foreach ($this->delegates as $delegate) {
+            if ($delegate instanceof WarmupCache) {
+                $delegate->warmup();
+            }
+        }
     }
 
     public function has($key): bool

--- a/src/Cache/FileWatchingCache.php
+++ b/src/Cache/FileWatchingCache.php
@@ -29,9 +29,9 @@ use function is_string;
  *
  * @phpstan-type TimestampsArray = array<string, int>
  * @template EntryType
- * @implements CacheInterface<EntryType|TimestampsArray>
+ * @implements WarmupCache<EntryType|TimestampsArray>
  */
-final class FileWatchingCache implements CacheInterface
+final class FileWatchingCache implements WarmupCache
 {
     /** @var array<string, TimestampsArray> */
     private array $timestamps = [];
@@ -40,6 +40,13 @@ final class FileWatchingCache implements CacheInterface
         /** @var CacheInterface<EntryType|TimestampsArray> */
         private CacheInterface $delegate
     ) {}
+
+    public function warmup(): void
+    {
+        if ($this->delegate instanceof WarmupCache) {
+            $this->delegate->warmup();
+        }
+    }
 
     public function has($key): bool
     {

--- a/src/Cache/KeySanitizerCache.php
+++ b/src/Cache/KeySanitizerCache.php
@@ -15,9 +15,9 @@ use function sha1;
  * @internal
  *
  * @template EntryType
- * @implements CacheInterface<EntryType>
+ * @implements WarmupCache<EntryType>
  */
-final class KeySanitizerCache implements CacheInterface
+final class KeySanitizerCache implements WarmupCache
 {
     private static string $version;
 
@@ -36,6 +36,13 @@ final class KeySanitizerCache implements CacheInterface
         //    @see https://www.php-fig.org/psr/psr-16/#12-definitions
         // @infection-ignore-all
         $this->sanitize = static fn (string $key) => sha1("$key." . self::$version ??= PHP_VERSION . '/' . Package::version());
+    }
+
+    public function warmup(): void
+    {
+        if ($this->delegate instanceof WarmupCache) {
+            $this->delegate->warmup();
+        }
     }
 
     public function get($key, $default = null): mixed

--- a/src/Cache/Warmup/RecursiveCacheWarmupService.php
+++ b/src/Cache/Warmup/RecursiveCacheWarmupService.php
@@ -5,15 +5,17 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Cache\Warmup;
 
 use CuyZ\Valinor\Cache\Exception\InvalidSignatureToWarmup;
+use CuyZ\Valinor\Cache\WarmupCache;
 use CuyZ\Valinor\Definition\Repository\ClassDefinitionRepository;
 use CuyZ\Valinor\Mapper\Object\Factory\ObjectBuilderFactory;
 use CuyZ\Valinor\Mapper\Tree\Builder\ObjectImplementations;
+use CuyZ\Valinor\Type\ClassType;
 use CuyZ\Valinor\Type\CompositeType;
 use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use CuyZ\Valinor\Type\Parser\TypeParser;
 use CuyZ\Valinor\Type\Type;
-use CuyZ\Valinor\Type\ClassType;
 use CuyZ\Valinor\Type\Types\InterfaceType;
+use Psr\SimpleCache\CacheInterface;
 
 use function in_array;
 
@@ -23,8 +25,12 @@ final class RecursiveCacheWarmupService
     /** @var list<class-string> */
     private array $classesWarmedUp = [];
 
+    private bool $warmupWasDone = false;
+
     public function __construct(
         private TypeParser $parser,
+        /** @var CacheInterface<mixed> */
+        private CacheInterface $cache,
         private ObjectImplementations $implementations,
         private ClassDefinitionRepository $classDefinitionRepository,
         private ObjectBuilderFactory $objectBuilderFactory
@@ -32,6 +38,14 @@ final class RecursiveCacheWarmupService
 
     public function warmup(string ...$signatures): void
     {
+        if (! $this->warmupWasDone) {
+            $this->warmupWasDone = true;
+
+            if ($this->cache instanceof WarmupCache) {
+                $this->cache->warmup();
+            }
+        }
+
         foreach ($signatures as $signature) {
             try {
                 $this->warmupType($this->parser->parse($signature));

--- a/src/Cache/WarmupCache.php
+++ b/src/Cache/WarmupCache.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace CuyZ\Valinor\Cache;
+
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * @internal
+ *
+ * @template T
+ * @extends CacheInterface<T>
+ */
+interface WarmupCache extends CacheInterface
+{
+    public function warmup(): void;
+}

--- a/src/Library/Container.php
+++ b/src/Library/Container.php
@@ -200,6 +200,7 @@ final class Container
 
             RecursiveCacheWarmupService::class => fn () => new RecursiveCacheWarmupService(
                 $this->get(TypeParser::class),
+                $this->get(CacheInterface::class),
                 $this->get(ObjectImplementations::class),
                 $this->get(ClassDefinitionRepository::class),
                 $this->get(ObjectBuilderFactory::class)

--- a/tests/Fake/Cache/FakeCacheWithWarmup.php
+++ b/tests/Fake/Cache/FakeCacheWithWarmup.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Fake\Cache;
+
+use CuyZ\Valinor\Cache\WarmupCache;
+
+/**
+ * @implements WarmupCache<mixed>
+ */
+final class FakeCacheWithWarmup implements WarmupCache
+{
+    private int $warmupCount = 0;
+
+    public function timesWarmupWasCalled(): int
+    {
+        return $this->warmupCount;
+    }
+
+    public function warmup(): void
+    {
+        $this->warmupCount++;
+    }
+
+    public function get($key, $default = null): mixed
+    {
+        return null;
+    }
+
+    public function set($key, $value, $ttl = null): bool
+    {
+        return false;
+    }
+
+    public function delete($key): bool
+    {
+        return false;
+    }
+
+    public function clear(): bool
+    {
+        return false;
+    }
+
+    public function getMultiple($keys, $default = null): iterable
+    {
+        return [];
+    }
+
+    public function setMultiple($values, $ttl = null): bool
+    {
+        return false;
+    }
+
+    public function deleteMultiple($keys): bool
+    {
+        return false;
+    }
+
+    public function has($key): bool
+    {
+        return false;
+    }
+}

--- a/tests/Integration/Cache/CacheWarmupTest.php
+++ b/tests/Integration/Cache/CacheWarmupTest.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Tests\Integration\Cache;
 use CuyZ\Valinor\Cache\Exception\InvalidSignatureToWarmup;
 use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Fake\Cache\FakeCache;
+use CuyZ\Valinor\Tests\Fake\Cache\FakeCacheWithWarmup;
 use CuyZ\Valinor\Tests\Integration\IntegrationTest;
 use DateTimeInterface;
 
@@ -22,6 +23,26 @@ final class CacheWarmupTest extends IntegrationTest
 
         $this->cache = new FakeCache();
         $this->mapper = (new MapperBuilder())->withCache($this->cache);
+    }
+
+    public function test_cache_warmup_is_called_only_once(): void
+    {
+        $cache = new FakeCacheWithWarmup();
+        $mapper = (new MapperBuilder())->withCache($cache);
+
+        $mapper->warmup();
+        $mapper->warmup();
+
+        self::assertSame(1, $cache->timesWarmupWasCalled());
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function test_cache_warmup_does_not_call_delegate_warmup_if_not_handled(): void
+    {
+        $mapper = new MapperBuilder(); // no cache registered
+        $mapper->warmup();
     }
 
     public function test_will_warmup_type_parser_cache_for_object_with_properties(): void

--- a/tests/Unit/Cache/Compiled/CompiledPhpFileCacheTest.php
+++ b/tests/Unit/Cache/Compiled/CompiledPhpFileCacheTest.php
@@ -35,6 +35,15 @@ final class CompiledPhpFileCacheTest extends TestCase
         $this->cache = new CompiledPhpFileCache(vfsStream::url('cache-dir'), new FakeCacheCompiler());
     }
 
+    public function test_warmup_creates_temporary_dir(): void
+    {
+        self::assertFalse($this->files->hasChild('.valinor.tmp'));
+
+        $this->cache->warmup();
+
+        self::assertTrue($this->files->hasChild('.valinor.tmp'));
+    }
+
     public function test_set_cache_sets_cache(): void
     {
         self::assertFalse($this->cache->has('foo'));

--- a/tests/Unit/Cache/Compiled/FileWatchingCacheTest.php
+++ b/tests/Unit/Cache/Compiled/FileWatchingCacheTest.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Tests\Unit\Cache\Compiled;
 
 use CuyZ\Valinor\Cache\FileWatchingCache;
 use CuyZ\Valinor\Tests\Fake\Cache\FakeCache;
+use CuyZ\Valinor\Tests\Fake\Cache\FakeCacheWithWarmup;
 use CuyZ\Valinor\Tests\Fake\Definition\FakeClassDefinition;
 use CuyZ\Valinor\Tests\Fake\Definition\FakeFunctionDefinition;
 use org\bovigo\vfs\vfsStream;
@@ -34,6 +35,27 @@ final class FileWatchingCacheTest extends TestCase
 
         $this->delegateCache = new FakeCache();
         $this->cache = new FileWatchingCache($this->delegateCache);
+    }
+
+    public function test_cache_warmup_calls_delegate_warmup(): void
+    {
+        $delegate = new FakeCacheWithWarmup();
+        $cache = new FileWatchingCache($delegate);
+
+        $cache->warmup();
+
+        self::assertSame(1, $delegate->timesWarmupWasCalled());
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function test_cache_warmup_does_not_call_delegate_warmup_if_not_handled(): void
+    {
+        $delegate = new FakeCache();
+        $cache = new FileWatchingCache($delegate);
+
+        $cache->warmup();
     }
 
     public function test_value_can_be_fetched_and_deleted(): void


### PR DESCRIPTION
Calling the mapper warmup will now go through all caches layers and run a warmup process. When using `FileSystemCache` that is provided by the library, the directories required by this cache will be created.

This should fix an issue that could occur when race conditions happened in an app with a lot of traffic.

Fixes #401 