### PR TITLE
fix: load attributes lazily during runtime and cache access

### DIFF
--- a/src/Definition/NativeAttributes.php
+++ b/src/Definition/NativeAttributes.php
@@ -32,7 +32,12 @@ final class NativeAttributes implements Attributes
             array_map(
                 static function (ReflectionAttribute $attribute) {
                     try {
-                        return $attribute->newInstance();
+                        $instance = $attribute->newInstance();
+
+                        return [
+                            'class' => $attribute->getName(),
+                            'callback' => fn () => $instance
+                        ];
                     } catch (Error) {
                         // Race condition when the attribute is affected to a property/parameter
                         // that was PROMOTED, in this case the attribute will be applied to both

--- a/src/Definition/Repository/Cache/Compiler/AttributesCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/AttributesCompiler.php
@@ -34,21 +34,15 @@ final class AttributesCompiler
 
     private function compileNativeAttributes(NativeAttributes $attributes): string
     {
-        $attributes = $attributes->definition();
-
-        if (count($attributes) === 0) {
-            return '[]';
-        }
-
         $attributesListCode = [];
 
-        foreach ($attributes as $className => $arguments) {
+        foreach ($attributes->definition() as $className => $arguments) {
             $argumentsCode = $this->compileAttributeArguments($arguments);
 
-            $attributesListCode[] = "new $className($argumentsCode)";
+            $attributesListCode[] = "['class' => '$className', 'callback' => fn () => new $className($argumentsCode)]";
         }
 
-        return '...[' . implode(",\n", $attributesListCode) . ']';
+        return implode(', ', $attributesListCode);
     }
 
     /**

--- a/tests/Unit/Definition/AttributesContainerTest.php
+++ b/tests/Unit/Definition/AttributesContainerTest.php
@@ -11,6 +11,9 @@ use DateTimeInterface;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+/**
+ * @phpstan-import-type AttributeParam from AttributesContainer
+ */
 final class AttributesContainerTest extends TestCase
 {
     public function test_empty_attributes_is_empty_and_remains_the_same_instance(): void
@@ -25,22 +28,34 @@ final class AttributesContainerTest extends TestCase
 
     public function test_attributes_are_countable(): void
     {
-        $attributes = new AttributesContainer(new stdClass(), new stdClass(), new stdClass());
+        $attributes = [
+            $this->attribute(new stdClass()),
+            $this->attribute(new stdClass()),
+            $this->attribute(new stdClass()),
+        ];
 
-        self::assertCount(3, $attributes);
+        $container = new AttributesContainer(...$attributes);
+
+        self::assertCount(3, $container);
     }
 
     public function test_attributes_are_traversable(): void
     {
-        $attributes = [new stdClass(), new stdClass(), new stdClass()];
+        $objects = [new stdClass(), new stdClass(), new stdClass()];
+        $attributes = [
+            $this->attribute($objects[0]),
+            $this->attribute($objects[1]),
+            $this->attribute($objects[2]),
+        ];
+
         $container = new AttributesContainer(...$attributes);
 
-        self::assertSame($attributes, iterator_to_array($container));
+        self::assertSame($objects, iterator_to_array($container));
     }
 
     public function test_attributes_has_type_checks_all_attributes(): void
     {
-        $attributes = new AttributesContainer(new stdClass());
+        $attributes = new AttributesContainer($this->attribute(new stdClass()));
 
         self::assertTrue($attributes->has(stdClass::class));
         self::assertFalse($attributes->has(DateTimeInterface::class));
@@ -51,11 +66,22 @@ final class AttributesContainerTest extends TestCase
         $object = new stdClass();
         $date = new DateTime();
 
-        $attributes = new AttributesContainer($object, $date);
+        $attributes = new AttributesContainer($this->attribute($object), $this->attribute($date));
         $filteredAttributes = $attributes->ofType(DateTimeInterface::class);
 
         self::assertContainsEquals($date, $filteredAttributes);
         self::assertNotContains($object, $filteredAttributes);
         self::assertSame($date, $filteredAttributes[0]);
+    }
+
+    /**
+     * @return AttributeParam
+     */
+    private function attribute(object $object): array
+    {
+        return [
+            'class'=> $object::class,
+            'callback' => fn () => $object
+        ];
     }
 }


### PR DESCRIPTION
Attributes are now loaded in a lazy way, preventing an error from happening when attributes were compiled in the cache, but not present when using the mapper during the runtime.

This could happen for instance with attributes used to generate documentation of an API: they are loaded as a development dependency, then the cache is warmed up during deployment, so they are present in the mapper compiled cache; but these attributes are missing from the live version of the application, so they cannot be accessed.

This commit helps to prevent a fatal error from happening in this kind of situation.

Fixes #393