### PR TITLE
qa: Fix SourceTest without YAML extension

### DIFF
--- a/tests/Integration/Mapping/Source/SourceTest.php
+++ b/tests/Integration/Mapping/Source/SourceTest.php
@@ -70,9 +70,11 @@ final class SourceTest extends IntegrationTest
             Source::json('{"someValue": {"someNestedValue": "foo", "someOtherNestedValue": "bar"}, "someOtherValue": {"someNestedValue": "foo2", "someOtherNestedValue": "bar2"}}'),
         ];
 
-        yield 'YAML' => [
-            Source::yaml("someValue:\n someNestedValue: foo\n someOtherNestedValue: bar\nsomeOtherValue:\n someNestedValue: foo2\n someOtherNestedValue: bar2"),
-        ];
+        if (extension_loaded('yaml')) {
+            yield 'YAML' => [
+                Source::yaml("someValue:\n someNestedValue: foo\n someOtherNestedValue: bar\nsomeOtherValue:\n someNestedValue: foo2\n someOtherNestedValue: bar2"),
+            ];
+        }
 
         yield 'Camel case' => [
             Source::array([


### PR DESCRIPTION
Previously when the YAML extension was not installed, the test was skipped /
errored entirely, as the data provider is invalid:

> 1) Error
> The data provider specified for CuyZ\Valinor\Tests\Integration\Mapping\Source\SourceTest::test_sources_are_mapped_properly is invalid.
> CuyZ\Valinor\Mapper\Source\Exception\YamlExtensionNotEnabled: The PHP YAML extension is not enabled.
> /pwd/src/Mapper/Source/YamlSource.php:38
> /pwd/src/Mapper/Source/Source.php:55
> /pwd/tests/Integration/Mapping/Source/SourceTest.php:74

Now the YAML source will simply not be provided.