### PR TITLE
fix: Fix the handling of invalid formats if `intl.use_exceptions=1`

### DIFF
--- a/src/Utility/String/StringFormatter.php
+++ b/src/Utility/String/StringFormatter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Utility\String;
 
 use CuyZ\Valinor\Mapper\Tree\Message\HasParameters;
+use IntlException;
 use MessageFormatter;
 
 use function class_exists;
@@ -37,8 +38,17 @@ final class StringFormatter
      */
     private static function formatWithIntl(string $locale, string $body, array $parameters): string
     {
-        return MessageFormatter::formatMessage($locale, $body, $parameters)
-            ?: throw new StringFormatterError($body, intl_get_error_message());
+        try {
+            $formatted = MessageFormatter::formatMessage($locale, $body, $parameters);
+
+            if ($formatted === false) {
+                throw new StringFormatterError($body, intl_get_error_message());
+            }
+
+            return $formatted;
+        } catch (IntlException $e) {
+            throw new StringFormatterError($body, $e->getMessage(), $e);
+        }
     }
 
     /**

--- a/src/Utility/String/StringFormatterError.php
+++ b/src/Utility/String/StringFormatterError.php
@@ -9,11 +9,11 @@ use RuntimeException;
 /** @internal */
 final class StringFormatterError extends RuntimeException
 {
-    public function __construct(string $body, string $message = '')
+    public function __construct(string $body, string $message = '', ?\Throwable $previous = null)
     {
         if ($message !== '') {
             $message = ": $message";
         }
-        parent::__construct("Message formatter error using `$body`$message.", 1652901203);
+        parent::__construct("Message formatter error using `$body`$message.", 1652901203, $previous);
     }
 }

--- a/tests/Unit/Utility/String/StringFormatterTest.php
+++ b/tests/Unit/Utility/String/StringFormatterTest.php
@@ -23,6 +23,24 @@ final class StringFormatterTest extends TestCase
         StringFormatter::format('en', 'some {wrong.format}', []);
     }
 
+    /**
+     * @requires extension intl
+     */
+    public function test_wrong_intl_format_throws_exception_with_intl_exception(): void
+    {
+        $oldIni = ini_get('intl.use_exceptions');
+        try {
+            ini_set('intl.use_exceptions', '1');
+            $this->expectException(StringFormatterError::class);
+            $this->expectExceptionMessage('Message formatter error using `some {wrong.format}`');
+            $this->expectExceptionCode(1652901203);
+
+            StringFormatter::format('en', 'some {wrong.format}', []);
+        } finally {
+            ini_set('intl.use_exceptions', $oldIni);
+        }
+    }
+
     public function test_wrong_message_body_format_throws_exception(): void
     {
         $this->expectException(StringFormatterError::class);


### PR DESCRIPTION
If `intl.use_exceptions=1`, ext/intl will throw an `\IntlException` that was not yet handled and caused `StringFormatter::format()` to violate its contract to throw `StringFormatterError` in case of errors.