### PR TITLE
qa: Use less-specific exception message assertion in StringFormatterTest

### DIFF
--- a/tests/Unit/Utility/String/StringFormatterTest.php
+++ b/tests/Unit/Utility/String/StringFormatterTest.php
@@ -17,7 +17,7 @@ final class StringFormatterTest extends TestCase
     public function test_wrong_intl_format_throws_exception(): void
     {
         $this->expectException(StringFormatterError::class);
-        $this->expectExceptionMessage('Message formatter error using `some {wrong.format}`: pattern syntax error (parse error at offset 6, after "some {", before or at "wrong.format}"): U_PATTERN_SYNTAX_ERROR.');
+        $this->expectExceptionMessage('Message formatter error using `some {wrong.format}`');
         $this->expectExceptionCode(1652901203);
 
         StringFormatter::format('en', 'some {wrong.format}', []);
@@ -26,7 +26,7 @@ final class StringFormatterTest extends TestCase
     public function test_wrong_message_body_format_throws_exception(): void
     {
         $this->expectException(StringFormatterError::class);
-        $this->expectExceptionMessage('Message formatter error using `some message with {invalid format}`: pattern syntax error (parse error at offset 19, after " message with {", before or at "invalid format}"): U_PATTERN_SYNTAX_ERROR.');
+        $this->expectExceptionMessage('Message formatter error using `some message with {invalid format}`');
         $this->expectExceptionCode(1652901203);
 
         StringFormatter::format('en', 'some message with {invalid format}');


### PR DESCRIPTION
The actual error message is emitted by ICU / PHP which we do not have control over.  We should not test that the upstream dependency returns stable error messages, especially since error messages are for human consumption and thus not part of the backwards compatibility contract.

see php/php-src#12020