### PR TITLE
test: Add `@requires` to NodeMessageTest::test_custom_locale_is_used()

### DIFF
--- a/tests/Unit/Mapper/Tree/Message/NodeMessageTest.php
+++ b/tests/Unit/Mapper/Tree/Message/NodeMessageTest.php
@@ -102,6 +102,9 @@ final class NodeMessageTest extends TestCase
         self::assertNotSame($messageA, $messageB);
     }
 
+    /**
+     * @requires extension intl
+     */
     public function test_custom_locale_is_used(): void
     {
         $originalMessage = (new FakeMessage('un message: {value, spellout}'))->withParameters(['value' => '42']);


### PR DESCRIPTION
This test requires the intl extension instead of the shim to work.