### PR TITLE
qa: Remove MixedTypeRector exception in rector.php

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -32,7 +32,6 @@ return static function (RectorConfig $config): void {
         AddLiteralSeparatorToNumberRector::class,
         ClassPropertyAssignToConstructorPromotionRector::class,
         MixedTypeRector::class => [
-            __DIR__ . '/tests/Integration/Mapping/Object/UnionValuesMappingTest.php',
             __DIR__ . '/tests/Unit/Definition/Repository/Reflection/ReflectionClassDefinitionRepositoryTest',
         ],
         RestoreDefaultNullToNullableTypePropertyRector::class => [


### PR DESCRIPTION
This no longer triggers and thus is not required to be skipped.