### PR TITLE
Add failing test for local alias shaped array multi line

### DIFF
--- a/src/Definition/Exception/InvalidTypeAliasImportClass.php
+++ b/src/Definition/Exception/InvalidTypeAliasImportClass.php
@@ -10,9 +10,6 @@ use LogicException;
 /** @internal */
 final class InvalidTypeAliasImportClass extends LogicException
 {
-    /**
-     * @param class-string $className
-     */
     public function __construct(ClassType $type, string $className)
     {
         parent::__construct(

--- a/src/Utility/Reflection/DocParser.php
+++ b/src/Utility/Reflection/DocParser.php
@@ -8,7 +8,9 @@ use ReflectionFunctionAbstract;
 use ReflectionParameter;
 use ReflectionProperty;
 
+use function array_merge;
 use function end;
+use function explode;
 use function preg_match;
 use function preg_match_all;
 use function str_replace;
@@ -68,13 +70,16 @@ final class DocParser
             return [];
         }
 
+        $cases = self::splitStringBy($doc, '@phpstan-type', '@psalm-type');
+
         $types = [];
 
-        preg_match_all('/@(phpstan|psalm)-type\s+(?<name>[a-zA-Z]\w*)\s*=?\s*(?<type>.*)/', $doc, $matches);
+        foreach ($cases as $case) {
+            if (! preg_match('/\s*(?<name>[a-zA-Z]\w*)\s*=?\s*(?<type>.*)/s', $case, $matches)) {
+                continue;
+            }
 
-        foreach ($matches['name'] as $key => $name) {
-            /** @var string $name */
-            $types[$name] = self::findType($matches['type'][$key]);
+            $types[$matches['name']] = self::findType($matches['type']);
         }
 
         return $types;
@@ -82,7 +87,7 @@ final class DocParser
 
     /**
      * @param ReflectionClass<object> $reflection
-     * @return array<class-string, string[]>
+     * @return array<string, string[]>
      */
     public static function importedTypeAliases(ReflectionClass $reflection): array
     {
@@ -92,15 +97,16 @@ final class DocParser
             return [];
         }
 
+        $cases = self::splitStringBy($doc, '@phpstan-import-type', '@psalm-import-type');
+
         $types = [];
 
-        preg_match_all('/@(phpstan|psalm)-import-type\s+(?<name>[a-zA-Z]\w*)\s*from\s*(?<class>\w+)/', $doc, $matches);
+        foreach ($cases as $case) {
+            if (! preg_match('/\s*(?<name>[a-zA-Z]\w*)\s*from\s*(?<class>\w+)/', $case, $matches)) {
+                continue;
+            }
 
-        foreach ($matches['name'] as $key => $name) {
-            /** @var class-string $class */
-            $class = $matches['class'][$key];
-
-            $types[$class][] = $name;
+            $types[$matches['class']][] = $matches['name'];
         }
 
         return $types;
@@ -213,5 +219,22 @@ final class DocParser
         $doc = preg_replace('#^\s*/\*\*([^/]+)\*/\s*$#', '$1', $doc);
 
         return preg_replace('/^\s*\*\s*(\S*)/m', '$1', $doc); // @phpstan-ignore-line
+    }
+
+    /**
+     * @param non-empty-string ...$cases
+     * @return list<string>
+     */
+    private static function splitStringBy(string $string, string ...$cases): array
+    {
+        $result = [$string];
+
+        foreach ($cases as $case) {
+            foreach ($result as $value) {
+                $result = array_merge($result, explode($case, $value));
+            }
+        }
+
+        return $result;
     }
 }

--- a/tests/Integration/Mapping/Object/LocalTypeAliasMappingTest.php
+++ b/tests/Integration/Mapping/Object/LocalTypeAliasMappingTest.php
@@ -19,6 +19,10 @@ final class LocalTypeAliasMappingTest extends IntegrationTest
                 'foo' => 'foo',
                 'bar' => 1337,
             ],
+            'aliasShapedArrayMultiline' => [
+                'foo' => 'foo',
+                'bar' => 1337,
+            ],
             'aliasGeneric' => [42, 1337],
         ];
 
@@ -31,6 +35,7 @@ final class LocalTypeAliasMappingTest extends IntegrationTest
                 self::assertSame(42, $result->aliasWithEqualsSign);
                 self::assertSame(42, $result->aliasWithoutEqualsSign);
                 self::assertSame($source['aliasShapedArray'], $result->aliasShapedArray);
+                self::assertSame($source['aliasShapedArrayMultiline'], $result->aliasShapedArrayMultiline);
                 self::assertSame($source['aliasGeneric'], $result->aliasGeneric->aliasArray);
             } catch (MappingError $error) {
                 $this->mappingFail($error);
@@ -72,6 +77,10 @@ class GenericObjectWithPhpStanLocalAlias
  * @phpstan-type AliasWithEqualsSign = int
  * @phpstan-type AliasWithoutEqualsSign int
  * @phpstan-type AliasShapedArray = array{foo: string, bar: int}
+ * @phpstan-type AliasShapedArrayMultiline = array{
+ *   foo: string,
+ *   bar: int
+ * }
  * @phpstan-type AliasGeneric = GenericObjectWithPhpStanLocalAlias<int>
  */
 class PhpStanLocalAliases
@@ -84,6 +93,9 @@ class PhpStanLocalAliases
 
     /** @var AliasShapedArray */
     public array $aliasShapedArray;
+
+    /** @var AliasShapedArrayMultiline */
+    public array $aliasShapedArrayMultiline;
 
     /** @var AliasGeneric */
     public GenericObjectWithPhpStanLocalAlias $aliasGeneric;
@@ -125,6 +137,10 @@ class GenericObjectWithPsalmLocalAlias
  * @psalm-type AliasWithEqualsSign = int
  * @psalm-type AliasWithoutEqualsSign int
  * @psalm-type AliasShapedArray = array{foo: string, bar: int}
+ * @psalm-type AliasShapedArrayMultiline = array{
+ *   foo: string,
+ *   bar: int
+ * }
  * @psalm-type AliasGeneric = GenericObjectWithPsalmLocalAlias<int>
  */
 class PsalmLocalAliases
@@ -137,6 +153,9 @@ class PsalmLocalAliases
 
     /** @var AliasShapedArray */
     public array $aliasShapedArray;
+
+    /** @var AliasShapedArrayMultiline */
+    public array $aliasShapedArrayMultiline;
 
     /** @var AliasGeneric */
     public GenericObjectWithPsalmLocalAlias $aliasGeneric;


### PR DESCRIPTION
Hi, this used to work in `1.5.0`, looks like multi line local alias shaped array is not parsed properly.