### PR TITLE
fix: handle integer key in path mapping modifier

### DIFF
--- a/src/Mapper/Source/Modifier/Mapping.php
+++ b/src/Mapper/Source/Modifier/Mapping.php
@@ -28,7 +28,7 @@ final class Mapping
     {
         $from = $this->keys[$atDepth] ?? null;
 
-        return $from === $key || $from === '*';
+        return $from === (string)$key || $from === '*';
     }
 
     public function findMappedKey(int|string $key, int $atDepth): ?string

--- a/src/Mapper/Source/Modifier/PathMapping.php
+++ b/src/Mapper/Source/Modifier/PathMapping.php
@@ -22,7 +22,7 @@ final class PathMapping implements IteratorAggregate
 
     /**
      * @param iterable<mixed> $source
-     * @param array<string, string> $map
+     * @param array<string> $map
      */
     public function __construct(iterable $source, array $map)
     {
@@ -62,7 +62,7 @@ final class PathMapping implements IteratorAggregate
     }
 
     /**
-     * @param array<string, string> $map
+     * @param array<string> $map
      * @return array<Mapping>
      */
     private function prepareMappings(array $map): array
@@ -70,7 +70,7 @@ final class PathMapping implements IteratorAggregate
         $mappings = [];
 
         foreach ($map as $from => $to) {
-            $mappings[] = new Mapping(explode('.', $from), $to);
+            $mappings[] = new Mapping(explode('.', (string)$from), $to);
         }
 
         return $mappings;

--- a/src/Mapper/Source/Source.php
+++ b/src/Mapper/Source/Source.php
@@ -66,7 +66,7 @@ final class Source implements IteratorAggregate
     }
 
     /**
-     * @param array<string, string> $map
+     * @param array<string> $map
      */
     public function map(array $map): Source
     {

--- a/tests/Unit/Mapper/Source/Modifier/PathMappingTest.php
+++ b/tests/Unit/Mapper/Source/Modifier/PathMappingTest.php
@@ -19,6 +19,16 @@ final class PathMappingTest extends TestCase
         self::assertSame(['new_A' => 'bar'], iterator_to_array($source));
     }
 
+    public function test_root_integer_path_is_mapped(): void
+    {
+        $source = new PathMapping(
+            [0 => 'bar'],
+            [0 => 'new_A']
+        );
+
+        self::assertSame(['new_A' => 'bar'], iterator_to_array($source));
+    }
+
     public function test_sub_path_is_mapped(): void
     {
         $source = new PathMapping(
@@ -37,6 +47,24 @@ final class PathMappingTest extends TestCase
         ], iterator_to_array($source));
     }
 
+    public function test_sub_path_with_integer_is_mapped(): void
+    {
+        $source = new PathMapping(
+            [
+                'A' => [
+                    1 => 'foo',
+                ],
+            ],
+            ['A.1' => 'new_B']
+        );
+
+        self::assertSame([
+            'A' => [
+                'new_B' => 'foo',
+            ],
+        ], iterator_to_array($source));
+    }
+
     public function test_root_iterable_path_is_mapped(): void
     {
         $source = new PathMapping(
@@ -45,6 +73,22 @@ final class PathMappingTest extends TestCase
                 ['A' => 'buz'],
             ],
             ['*.A' => 'new_A']
+        );
+
+        self::assertSame([
+            ['new_A' => 'bar'],
+            ['new_A' => 'buz'],
+        ], iterator_to_array($source));
+    }
+
+    public function test_root_iterable_path_with_integer_is_mapped(): void
+    {
+        $source = new PathMapping(
+            [
+                [2 => 'bar'],
+                [2 => 'buz'],
+            ],
+            ['*.2' => 'new_A']
         );
 
         self::assertSame([


### PR DESCRIPTION
The following now works properly:

```php
\CuyZ\Valinor\Mapper\Source\Source::array([0 => 'foo'])
    ->map([
        '0' => 'some_key'
    ]);
```

Fixes #430