### PR TITLE
feat: handle non-negative integer type

### DIFF
--- a/docs/pages/usage/type-reference.md
+++ b/docs/pages/usage/type-reference.md
@@ -22,6 +22,9 @@ final class SomeClass
         /** @var negative-int */
         private int $negativeInteger,
 
+        /** @var non-negative-int */
+        private int $nonNegativeInteger,
+
         /** @var int<-42, 1337> */
         private int $integerRange,
 

--- a/src/Definition/Repository/Cache/Compiler/TypeCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/TypeCompiler.php
@@ -28,6 +28,7 @@ use CuyZ\Valinor\Type\Types\NegativeIntegerType;
 use CuyZ\Valinor\Type\Types\NonEmptyArrayType;
 use CuyZ\Valinor\Type\Types\NonEmptyListType;
 use CuyZ\Valinor\Type\Types\NonEmptyStringType;
+use CuyZ\Valinor\Type\Types\NonNegativeIntegerType;
 use CuyZ\Valinor\Type\Types\NullType;
 use CuyZ\Valinor\Type\Types\NumericStringType;
 use CuyZ\Valinor\Type\Types\PositiveIntegerType;
@@ -58,6 +59,7 @@ final class TypeCompiler
             case $type instanceof NativeIntegerType:
             case $type instanceof PositiveIntegerType:
             case $type instanceof NegativeIntegerType:
+            case $type instanceof NonNegativeIntegerType:
             case $type instanceof NativeStringType:
             case $type instanceof NonEmptyStringType:
             case $type instanceof NumericStringType:

--- a/src/Type/Parser/Lexer/Token/NativeToken.php
+++ b/src/Type/Parser/Lexer/Token/NativeToken.php
@@ -14,6 +14,7 @@ use CuyZ\Valinor\Type\Types\NativeFloatType;
 use CuyZ\Valinor\Type\Types\NativeStringType;
 use CuyZ\Valinor\Type\Types\NegativeIntegerType;
 use CuyZ\Valinor\Type\Types\NonEmptyStringType;
+use CuyZ\Valinor\Type\Types\NonNegativeIntegerType;
 use CuyZ\Valinor\Type\Types\NullType;
 use CuyZ\Valinor\Type\Types\NumericStringType;
 use CuyZ\Valinor\Type\Types\PositiveIntegerType;
@@ -67,6 +68,7 @@ final class NativeToken implements TraversingToken
             'float' => NativeFloatType::get(),
             'positive-int' => PositiveIntegerType::get(),
             'negative-int' => NegativeIntegerType::get(),
+            'non-negative-int' => NonNegativeIntegerType::get(),
             'string' => NativeStringType::get(),
             'non-empty-string' => NonEmptyStringType::get(),
             'numeric-string' => NumericStringType::get(),

--- a/src/Type/Types/NonNegativeIntegerType.php
+++ b/src/Type/Types/NonNegativeIntegerType.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Type\Types;
+
+use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
+use CuyZ\Valinor\Mapper\Tree\Message\MessageBuilder;
+use CuyZ\Valinor\Type\IntegerType;
+use CuyZ\Valinor\Type\Type;
+use CuyZ\Valinor\Utility\IsSingleton;
+
+/** @internal */
+final class NonNegativeIntegerType implements IntegerType
+{
+    use IsSingleton;
+
+    public function accepts(mixed $value): bool
+    {
+        return is_int($value) && $value >= 0;
+    }
+
+    public function matches(Type $other): bool
+    {
+        if ($other instanceof UnionType) {
+            return $other->isMatchedBy($this);
+        }
+
+        return $other instanceof self
+            || $other instanceof NativeIntegerType
+            || $other instanceof MixedType;
+    }
+
+    public function canCast(mixed $value): bool
+    {
+        return ! is_bool($value)
+            && filter_var($value, FILTER_VALIDATE_INT) !== false
+            && $value >= 0;
+    }
+
+    public function cast(mixed $value): int
+    {
+        assert($this->canCast($value));
+
+        return (int)$value; // @phpstan-ignore-line
+    }
+
+    public function errorMessage(): ErrorMessage
+    {
+        return MessageBuilder::newError('Value {source_value} is not a valid non-negative integer.')->build();
+    }
+
+    public function toString(): string
+    {
+        return 'non-negative-int';
+    }
+}

--- a/tests/Functional/Definition/Repository/Cache/Compiler/TypeCompilerTest.php
+++ b/tests/Functional/Definition/Repository/Cache/Compiler/TypeCompilerTest.php
@@ -29,6 +29,7 @@ use CuyZ\Valinor\Type\Types\NegativeIntegerType;
 use CuyZ\Valinor\Type\Types\NonEmptyArrayType;
 use CuyZ\Valinor\Type\Types\NonEmptyListType;
 use CuyZ\Valinor\Type\Types\NonEmptyStringType;
+use CuyZ\Valinor\Type\Types\NonNegativeIntegerType;
 use CuyZ\Valinor\Type\Types\NullType;
 use CuyZ\Valinor\Type\Types\NumericStringType;
 use CuyZ\Valinor\Type\Types\PositiveIntegerType;
@@ -84,6 +85,7 @@ final class TypeCompilerTest extends TestCase
         yield [NativeIntegerType::get()];
         yield [PositiveIntegerType::get()];
         yield [NegativeIntegerType::get()];
+        yield [NonNegativeIntegerType::get()];
         yield [new IntegerValueType(1337)];
         yield [new IntegerValueType(-1337)];
         yield [new IntegerRangeType(42, 1337)];

--- a/tests/Functional/Type/Parser/Lexer/NativeLexerTest.php
+++ b/tests/Functional/Type/Parser/Lexer/NativeLexerTest.php
@@ -61,11 +61,15 @@ use CuyZ\Valinor\Type\Types\MixedType;
 use CuyZ\Valinor\Type\Types\NativeBooleanType;
 use CuyZ\Valinor\Type\Types\EnumType;
 use CuyZ\Valinor\Type\Types\NativeFloatType;
+use CuyZ\Valinor\Type\Types\NativeIntegerType;
+use CuyZ\Valinor\Type\Types\NegativeIntegerType;
 use CuyZ\Valinor\Type\Types\NonEmptyArrayType;
 use CuyZ\Valinor\Type\Types\NonEmptyListType;
 use CuyZ\Valinor\Type\Types\NonEmptyStringType;
+use CuyZ\Valinor\Type\Types\NonNegativeIntegerType;
 use CuyZ\Valinor\Type\Types\NullType;
 use CuyZ\Valinor\Type\Types\NumericStringType;
+use CuyZ\Valinor\Type\Types\PositiveIntegerType;
 use CuyZ\Valinor\Type\Types\ShapedArrayType;
 use CuyZ\Valinor\Type\Types\StringValueType;
 use CuyZ\Valinor\Type\Types\UndefinedObjectType;
@@ -208,67 +212,85 @@ final class NativeLexerTest extends TestCase
         yield 'Integer type' => [
             'raw' => 'int',
             'transformed' => 'int',
-            'type' => IntegerType::class,
+            'type' => NativeIntegerType::class,
         ];
 
         yield 'Integer type - uppercase' => [
             'raw' => 'INT',
             'transformed' => 'int',
-            'type' => IntegerType::class,
+            'type' => NativeIntegerType::class,
         ];
 
         yield 'Integer type followed by description' => [
             'raw' => 'int lorem ipsum',
             'transformed' => 'int',
-            'type' => IntegerType::class,
+            'type' => NativeIntegerType::class,
         ];
 
         yield 'Integer type (longer version)' => [
             'raw' => 'integer',
             'transformed' => 'int',
-            'type' => IntegerType::class,
+            'type' => NativeIntegerType::class,
         ];
 
         yield 'Integer type (longer version) - uppercase' => [
             'raw' => 'INTEGER',
             'transformed' => 'int',
-            'type' => IntegerType::class,
+            'type' => NativeIntegerType::class,
         ];
 
         yield 'Positive integer type' => [
             'raw' => 'positive-int',
             'transformed' => 'positive-int',
-            'type' => IntegerType::class,
+            'type' => PositiveIntegerType::class,
         ];
 
         yield 'Positive integer type - uppercase' => [
             'raw' => 'POSITIVE-INT',
             'transformed' => 'positive-int',
-            'type' => IntegerType::class,
+            'type' => PositiveIntegerType::class,
         ];
 
         yield 'Positive integer type followed by description' => [
             'raw' => 'positive-int lorem ipsum',
             'transformed' => 'positive-int',
-            'type' => IntegerType::class,
+            'type' => PositiveIntegerType::class,
         ];
 
         yield 'Negative integer type' => [
             'raw' => 'negative-int',
             'transformed' => 'negative-int',
-            'type' => IntegerType::class,
+            'type' => NegativeIntegerType::class,
         ];
 
         yield 'Negative integer type - uppercase' => [
             'raw' => 'NEGATIVE-INT',
             'transformed' => 'negative-int',
-            'type' => IntegerType::class,
+            'type' => NegativeIntegerType::class,
         ];
 
         yield 'Negative integer type followed by description' => [
             'raw' => 'negative-int lorem ipsum',
             'transformed' => 'negative-int',
-            'type' => IntegerType::class,
+            'type' => NegativeIntegerType::class,
+        ];
+
+        yield 'Non-negative integer type' => [
+            'raw' => 'non-negative-int',
+            'transformed' => 'non-negative-int',
+            'type' => NonNegativeIntegerType::class,
+        ];
+
+        yield 'Non-negative integer type - uppercase' => [
+            'raw' => 'NON-NEGATIVE-INT',
+            'transformed' => 'non-negative-int',
+            'type' => NonNegativeIntegerType::class,
+        ];
+
+        yield 'Non-negative integer type followed by description' => [
+            'raw' => 'non-negative-int lorem ipsum',
+            'transformed' => 'non-negative-int',
+            'type' => NonNegativeIntegerType::class,
         ];
 
         yield 'Positive integer value' => [

--- a/tests/Integration/Mapping/Object/ScalarValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ScalarValuesMappingTest.php
@@ -27,6 +27,7 @@ final class ScalarValuesMappingTest extends IntegrationTest
             'integer' => 1337,
             'positiveInteger' => 1337,
             'negativeInteger' => -1337,
+            'nonNegativeInteger' => 1337,
             'integerRangeWithPositiveValue' => 1337,
             'integerRangeWithNegativeValue' => -1337,
             'integerRangeWithMinAndMax' => 42,
@@ -61,6 +62,7 @@ final class ScalarValuesMappingTest extends IntegrationTest
             self::assertSame(1337, $result->integer);
             self::assertSame(1337, $result->positiveInteger);
             self::assertSame(-1337, $result->negativeInteger);
+            self::assertSame(1337, $result->nonNegativeInteger);
             self::assertSame(1337, $result->integerRangeWithPositiveValue);
             self::assertSame(-1337, $result->integerRangeWithNegativeValue);
             self::assertSame(42, $result->integerRangeWithMinAndMax);
@@ -114,6 +116,9 @@ class ScalarValues
 
     /** @var negative-int */
     public int $negativeInteger = -1;
+
+    /** @var non-negative-int */
+    public int $nonNegativeInteger = 1;
 
     /** @var int<-1337, 1337> */
     public int $integerRangeWithPositiveValue = -1;
@@ -173,6 +178,7 @@ class ScalarValuesWithConstructor extends ScalarValues
      * @param -42.404 $negativeFloatValue
      * @param positive-int $positiveInteger
      * @param negative-int $negativeInteger
+     * @param non-negative-int $nonNegativeInteger
      * @param int<-1337, 1337> $integerRangeWithPositiveValue
      * @param int<-1337, 1337> $integerRangeWithNegativeValue
      * @param int<min, max> $integerRangeWithMinAndMax
@@ -199,6 +205,7 @@ class ScalarValuesWithConstructor extends ScalarValues
         int $integer,
         int $positiveInteger,
         int $negativeInteger,
+        int $nonNegativeInteger,
         int $integerRangeWithPositiveValue,
         int $integerRangeWithNegativeValue,
         int $integerRangeWithMinAndMax,
@@ -225,6 +232,7 @@ class ScalarValuesWithConstructor extends ScalarValues
         $this->integer = $integer;
         $this->positiveInteger = $positiveInteger;
         $this->negativeInteger = $negativeInteger;
+        $this->nonNegativeInteger = $nonNegativeInteger;
         $this->integerRangeWithPositiveValue = $integerRangeWithPositiveValue;
         $this->integerRangeWithNegativeValue = $integerRangeWithNegativeValue;
         $this->integerRangeWithMinAndMax = $integerRangeWithMinAndMax;

--- a/tests/Unit/Type/Types/NonNegativeIntegerTypeTest.php
+++ b/tests/Unit/Type/Types/NonNegativeIntegerTypeTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Unit\Type\Types;
+
+use AssertionError;
+use CuyZ\Valinor\Tests\Fake\Type\FakeType;
+use CuyZ\Valinor\Tests\Traits\TestIsSingleton;
+use CuyZ\Valinor\Type\Types\MixedType;
+use CuyZ\Valinor\Type\Types\NativeIntegerType;
+use CuyZ\Valinor\Type\Types\NonNegativeIntegerType;
+use CuyZ\Valinor\Type\Types\PositiveIntegerType;
+use CuyZ\Valinor\Type\Types\UnionType;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class NonNegativeIntegerTypeTest extends TestCase
+{
+    use TestIsSingleton;
+
+    private NonNegativeIntegerType $nonNegativeIntegerType;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->nonNegativeIntegerType = new NonNegativeIntegerType();
+    }
+
+    public function test_accepts_correct_values(): void
+    {
+        self::assertTrue($this->nonNegativeIntegerType->accepts(0));
+        self::assertTrue($this->nonNegativeIntegerType->accepts(404));
+    }
+
+    public function test_does_not_accept_incorrect_values(): void
+    {
+        self::assertFalse($this->nonNegativeIntegerType->accepts(null));
+        self::assertFalse($this->nonNegativeIntegerType->accepts('Schwifty!'));
+        self::assertFalse($this->nonNegativeIntegerType->accepts(-404));
+        self::assertFalse($this->nonNegativeIntegerType->accepts(42.1337));
+        self::assertFalse($this->nonNegativeIntegerType->accepts(['foo' => 'bar']));
+        self::assertFalse($this->nonNegativeIntegerType->accepts(false));
+        self::assertFalse($this->nonNegativeIntegerType->accepts(new stdClass()));
+    }
+
+    public function test_can_cast_integer_value(): void
+    {
+        self::assertTrue($this->nonNegativeIntegerType->canCast(0));
+        self::assertTrue($this->nonNegativeIntegerType->canCast(404));
+        self::assertTrue($this->nonNegativeIntegerType->canCast('404'));
+        self::assertTrue($this->nonNegativeIntegerType->canCast(404.00));
+    }
+
+    public function test_cannot_cast_other_types(): void
+    {
+        self::assertFalse($this->nonNegativeIntegerType->canCast(null));
+        self::assertFalse($this->nonNegativeIntegerType->canCast(-42));
+        self::assertFalse($this->nonNegativeIntegerType->canCast(-42.1337));
+        self::assertFalse($this->nonNegativeIntegerType->canCast(42.1337));
+        self::assertFalse($this->nonNegativeIntegerType->canCast(['foo' => 'bar']));
+        self::assertFalse($this->nonNegativeIntegerType->canCast('Schwifty!'));
+        self::assertFalse($this->nonNegativeIntegerType->canCast(false));
+        self::assertFalse($this->nonNegativeIntegerType->canCast(new stdClass()));
+    }
+
+    /**
+     * @dataProvider cast_value_returns_correct_result_data_provider
+     */
+    public function test_cast_value_returns_correct_result(mixed $value, int $expected): void
+    {
+        self::assertSame($expected, $this->nonNegativeIntegerType->cast($value));
+    }
+
+    public function cast_value_returns_correct_result_data_provider(): array
+    {
+        return [
+            'Integer from float' => [
+                'value' => 404.00,
+                'expected' => 404,
+            ],
+            'Integer from string' => [
+                'value' => '42',
+                'expected' => 42,
+            ],
+            'Integer from integer' => [
+                'value' => 1337,
+                'expected' => 1337,
+            ],
+            'Zero from string' => [
+                'value' => '0',
+                'expected' => 0,
+            ],
+        ];
+    }
+
+    public function test_cast_invalid_value_throws_exception(): void
+    {
+        $this->expectException(AssertionError::class);
+
+        $this->nonNegativeIntegerType->cast('foo');
+    }
+
+    public function test_cast_invalid_positive_value_throws_exception(): void
+    {
+        $this->expectException(AssertionError::class);
+
+        $this->nonNegativeIntegerType->cast(-1337);
+    }
+
+    public function test_string_value_is_correct(): void
+    {
+        self::assertSame('non-negative-int', $this->nonNegativeIntegerType->toString());
+    }
+
+    public function test_matches_valid_integer_type(): void
+    {
+        self::assertTrue($this->nonNegativeIntegerType->matches(new NativeIntegerType()));
+        self::assertTrue($this->nonNegativeIntegerType->matches($this->nonNegativeIntegerType));
+        self::assertFalse($this->nonNegativeIntegerType->matches(new PositiveIntegerType()));
+    }
+
+    public function test_does_not_match_other_type(): void
+    {
+        self::assertFalse($this->nonNegativeIntegerType->matches(new FakeType()));
+    }
+
+    public function test_matches_mixed_type(): void
+    {
+        self::assertTrue($this->nonNegativeIntegerType->matches(new MixedType()));
+    }
+
+    public function test_matches_union_type_containing_integer_type(): void
+    {
+        $union = new UnionType(new FakeType(), new NativeIntegerType(), new FakeType());
+        $unionWithSelf = new UnionType(new FakeType(), new NonNegativeIntegerType(), new FakeType());
+
+        self::assertTrue($this->nonNegativeIntegerType->matches($union));
+        self::assertTrue($this->nonNegativeIntegerType->matches($unionWithSelf));
+    }
+
+    public function test_does_not_match_union_type_not_containing_integer_type(): void
+    {
+        $unionType = new UnionType(new FakeType(), new FakeType());
+
+        self::assertFalse($this->nonNegativeIntegerType->matches($unionType));
+    }
+}


### PR DESCRIPTION
Non-negative integer can be used as below. It will accept any value equal to or greater than zero.

```php
final class SomeClass
{
    /** @var non-negative-int */
    public int $nonNegativeInteger;
}
```

Closes #434