### PR TITLE
Fix union scalar with object not supported

### DIFF
--- a/src/Mapper/Tree/Builder/UnionNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/UnionNodeBuilder.php
@@ -79,18 +79,13 @@ final class UnionNodeBuilder implements NodeBuilder
 
     private function tryToBuildClassNode(UnionType $type, Shell $shell, RootNodeBuilder $rootBuilder): ?TreeNode
     {
-        $classTypes = [];
+        $classTypes = array_filter(
+            $type->types(),
+            fn (Type $type) => $type instanceof ClassType,
+        );
 
-        foreach ($type->types() as $subType) {
-            if ($subType instanceof NullType) {
-                continue;
-            }
-
-            if (! $subType instanceof ClassType) {
-                return null;
-            }
-
-            $classTypes[] = $subType;
+        if (count($classTypes) === 0) {
+            return null;
         }
 
         $objectBuilder = $this->objectBuilder($shell->value(), ...$classTypes);

--- a/tests/Integration/Mapping/Object/UnionOfObjectsMappingTest.php
+++ b/tests/Integration/Mapping/Object/UnionOfObjectsMappingTest.php
@@ -51,6 +51,27 @@ final class UnionOfObjectsMappingTest extends IntegrationTest
         self::assertSame('fiz', $result->fiz);
     }
 
+    public function test_mapping_to_union_of_string_and_object_can_infer_object(): void
+    {
+        try {
+            $result = (new MapperBuilder())
+                ->mapper()
+                ->map(
+                    'string|' . SomeObjectWithBazAndFiz::class,
+                    [
+                        'baz' => 'baz',
+                        'fiz' => 'fiz',
+                    ]
+                );
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertInstanceOf(SomeObjectWithBazAndFiz::class, $result);
+        self::assertSame('baz', $result->baz);
+        self::assertSame('fiz', $result->fiz);
+    }
+
     /**
      *
      * @dataProvider mapping_error_when_cannot_resolve_union_data_provider


### PR DESCRIPTION
This fix aims to solve this case which is not currently supported:

```
class Foo {
    public string|Bar $value;
} 

class Bar {}
```

Without this a `CannotResolveTypeFromUnion` is throwed.