### PR TITLE
Feature: Allow deactivation of flattening of single property objects.

### DIFF
--- a/src/Library/Container.php
+++ b/src/Library/Container.php
@@ -123,7 +123,8 @@ final class Container
                     $this->get(ClassDefinitionRepository::class),
                     $this->get(ObjectBuilderFactory::class),
                     $this->get(ObjectNodeBuilder::class),
-                    $settings->enableFlexibleCasting
+                    $settings->enableFlexibleCasting,
+                    $settings->enableSinglePropertyFlattening
                 );
 
                 $builder = new CasterProxyNodeBuilder($builder);
@@ -144,7 +145,10 @@ final class Container
                 return new ErrorCatcherNodeBuilder($builder, $settings->exceptionFilter);
             },
 
-            ObjectNodeBuilder::class => fn () => new ObjectNodeBuilder($settings->allowSuperfluousKeys),
+            ObjectNodeBuilder::class => fn () => new ObjectNodeBuilder(
+                $settings->allowSuperfluousKeys,
+                $settings->enableSinglePropertyFlattening
+            ),
 
             ObjectImplementations::class => fn () => new ObjectImplementations(
                 new FunctionsContainer(

--- a/src/Library/Settings.php
+++ b/src/Library/Settings.php
@@ -40,6 +40,8 @@ final class Settings
 
     public bool $enableFlexibleCasting = false;
 
+    public bool $enableSinglePropertyFlattening = true;
+
     public bool $allowSuperfluousKeys = false;
 
     public bool $allowPermissiveTypes = false;

--- a/src/Mapper/Object/ArgumentsValues.php
+++ b/src/Mapper/Object/ArgumentsValues.php
@@ -29,15 +29,17 @@ final class ArgumentsValues implements IteratorAggregate
     private bool $forInterface = false;
 
     private bool $hadSingleArgument = false;
+    private bool $enableSinglePropertyFlattening;
 
-    private function __construct(Arguments $arguments)
+    private function __construct(Arguments $arguments, bool $enableSinglePropertyFlattening)
     {
         $this->arguments = $arguments;
+        $this->enableSinglePropertyFlattening = $enableSinglePropertyFlattening;
     }
 
-    public static function forInterface(Arguments $arguments, mixed $value): self
+    public static function forInterface(Arguments $arguments, mixed $value, bool $enableSinglePropertyFlattening): self
     {
-        $self = new self($arguments);
+        $self = new self($arguments, $enableSinglePropertyFlattening);
         $self->forInterface = true;
 
         if (count($arguments) > 0) {
@@ -47,9 +49,9 @@ final class ArgumentsValues implements IteratorAggregate
         return $self;
     }
 
-    public static function forClass(Arguments $arguments, mixed $value): self
+    public static function forClass(Arguments $arguments, mixed $value, bool $enableSinglePropertyFlattening): self
     {
-        $self = new self($arguments);
+        $self = new self($arguments, $enableSinglePropertyFlattening);
         $self = $self->transform($value);
 
         return $self;
@@ -110,7 +112,7 @@ final class ArgumentsValues implements IteratorAggregate
 
     private function transformValueForSingleArgument(mixed $value): mixed
     {
-        if (count($this->arguments) !== 1) {
+        if (count($this->arguments) !== 1 || $this->enableSinglePropertyFlattening === false) {
             return $value;
         }
 

--- a/src/Mapper/Tree/Builder/InterfaceNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/InterfaceNodeBuilder.php
@@ -26,7 +26,8 @@ final class InterfaceNodeBuilder implements NodeBuilder
         private ClassDefinitionRepository $classDefinitionRepository,
         private ObjectBuilderFactory $objectBuilderFactory,
         private ObjectNodeBuilder $objectNodeBuilder,
-        private bool $enableFlexibleCasting
+        private bool $enableFlexibleCasting,
+        private bool $disableSinglePropertyFlattening,
     ) {}
 
     public function build(Shell $shell, RootNodeBuilder $rootBuilder): TreeNode
@@ -116,7 +117,7 @@ final class InterfaceNodeBuilder implements NodeBuilder
      */
     private function children(Shell $shell, Arguments $arguments, RootNodeBuilder $rootBuilder): array
     {
-        $arguments = ArgumentsValues::forInterface($arguments, $shell->value());
+        $arguments = ArgumentsValues::forInterface($arguments, $shell->value(), $this->disableSinglePropertyFlattening);
 
         $children = [];
 

--- a/src/Mapper/Tree/Builder/ObjectNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ObjectNodeBuilder.php
@@ -14,17 +14,20 @@ use function count;
 /** @internal */
 final class ObjectNodeBuilder
 {
-    public function __construct(private bool $allowSuperfluousKeys) {}
+    public function __construct(
+        private bool $allowSuperfluousKeys,
+        private bool $enableSinglePropertyFlattening
+    ) {}
 
     public function build(ObjectBuilder $builder, Shell $shell, RootNodeBuilder $rootBuilder): TreeNode
     {
-        $arguments = ArgumentsValues::forClass($builder->describeArguments(), $shell->value());
+        $arguments = ArgumentsValues::forClass($builder->describeArguments(), $shell->value(), $this->enableSinglePropertyFlattening);
 
         $children = $this->children($shell, $arguments, $rootBuilder);
 
         $object = $this->buildObject($builder, $children);
 
-        $node = $arguments->hadSingleArgument()
+        $node = ($arguments->hadSingleArgument() && $this->enableSinglePropertyFlattening)
             ? TreeNode::flattenedBranch($shell, $object, $children[0])
             : TreeNode::branch($shell, $object, $children);
 

--- a/src/MapperBuilder.php
+++ b/src/MapperBuilder.php
@@ -385,6 +385,48 @@ final class MapperBuilder
     }
 
     /**
+     * Object with only one value (one constructor argument or one property)
+     * will be not be flattened.
+     *
+     * ```php
+     * final class Identifier
+     * {
+     *      public readonly string $value;
+     * }
+     *
+     * final class SomeClass
+     * {
+     *      public readonly Identifier $identifier;
+     *
+     *      public readonly string $description;
+     * }
+     *
+     * $mapper = (new \CuyZ\Valinor\MapperBuilder())->mapper();
+     *
+     * $mapper->map(SomeClass::class, [
+     *      // By default the input has been flattened and is easier to read.
+     *          'identifier' => 'some-identifier',
+     *          'description' => 'Lorem ipsum…',
+     *      ]);
+     *
+     *  $mapper->disableSinglePropertyFlattening()->map(SomeClass::class, [
+     *       'identifier' => [
+     *           // When deactivated the `value` key feels a bit excessive but follows mapped class.
+     *           'value' => 'some-identifier'
+     *       ],
+     *       'description' => 'Lorem ipsum…',
+     *  ]);
+     * ```
+     */
+    public function disableSinglePropertyFlattening(): self
+    {
+        $clone = clone $this;
+        $clone->settings->enableSinglePropertyFlattening = false;
+
+        return $clone;
+    }
+
+    /**
      * Allows permissive types `mixed` and `object` to be used during mapping.
      *
      * ```php

--- a/tests/Integration/Mapping/Other/SinglePropertyFlatteningTest.php
+++ b/tests/Integration/Mapping/Other/SinglePropertyFlatteningTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Mapping\Other;
+
+use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\Mapper\TreeMapper;
+use CuyZ\Valinor\MapperBuilder;
+use CuyZ\Valinor\Tests\Integration\IntegrationTest;
+
+class SinglePropertyFlatteningTest extends IntegrationTest
+{
+    private TreeMapper $mapper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mapper = (new MapperBuilder())->disableSinglePropertyFlattening()->mapper();
+    }
+
+    public function test_single_property_object_flattening_disabled(): void
+    {
+        $source = [
+            'foo' => [
+                'fiz' => 1337.404,
+            ],
+            'bar' => 'bar',
+        ];
+
+        try {
+            $result = $this->mapper->map(SomeFooAndBarObject::class, $source);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertInstanceOf(SomeFooAndBarObject::class, $result);
+        self::assertInstanceOf(SomeFizObject::class, $result->foo);
+    }
+}
+
+final class SomeFizObject
+{
+    public float $fiz;
+}
+
+final class SomeFooAndBarObject
+{
+    public SomeFizObject $foo;
+
+    public string $bar;
+}


### PR DESCRIPTION
This allow to disable the behavior described in the documentation: https://valinor.cuyz.io/1.7/usage/object-construction/#class-with-a-single-value

**Context:**

When using valinor on API payload, json can be return like this:
```
{
    "items" : ["foo", "bar", "baz"]
}
```

Currently this would be flattened.

The issue is that this payload was designed this way to evolve... and could change to:

```
{
    "items" : ["foo", "bar", "baz"],
    "page": 1
}
```

In that case the flattening will not operate and so the mapping will crash.

With this feature used with `allowSuperfluousKeys` alow a greater stability of the code on payload changes that shall be backward compatible.