### PR TITLE
fix: detect circular references linearly through objects

### DIFF
--- a/src/Normalizer/Transformer/RecursiveTransformer.php
+++ b/src/Normalizer/Transformer/RecursiveTransformer.php
@@ -60,6 +60,8 @@ final class RecursiveTransformer
                 throw new CircularReferenceFoundDuringNormalization($value);
             }
 
+            $references = clone $references;
+
             // @infection-ignore-all
             $references[$value] = true;
         }


### PR DESCRIPTION
The same object can now exist several times in an array, an iterable or in several properties of a class.

The normalizer will not detect it as a circular reference anymore.

Fixes #472 