### PR TITLE
test: run the whole integration test suite with & without cache injected

### DIFF
--- a/tests/Integration/Cache/CacheInjectionTest.php
+++ b/tests/Integration/Cache/CacheInjectionTest.php
@@ -7,7 +7,6 @@ namespace CuyZ\Valinor\Tests\Integration\Cache;
 use CuyZ\Valinor\Cache\FileSystemCache;
 use CuyZ\Valinor\Cache\FileWatchingCache;
 use CuyZ\Valinor\Mapper\TreeMapper;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject;
 use org\bovigo\vfs\vfsStream;
@@ -53,7 +52,7 @@ final class CacheInjectionTest extends IntegrationTestCase
      */
     private function createMapper(CacheInterface $cache): TreeMapper
     {
-        return (new MapperBuilder())
+        return $this->mapperBuilder()
             ->withCache($cache)
             // The cache should be able to cache function definitions…
             ->registerConstructor(fn (): stdClass => new stdClass())

--- a/tests/Integration/Cache/CacheWarmupTest.php
+++ b/tests/Integration/Cache/CacheWarmupTest.php
@@ -22,13 +22,13 @@ final class CacheWarmupTest extends IntegrationTestCase
         parent::setUp();
 
         $this->cache = new FakeCache();
-        $this->mapper = (new MapperBuilder())->withCache($this->cache);
+        $this->mapper = $this->mapperBuilder()->withCache($this->cache);
     }
 
     public function test_cache_warmup_is_called_only_once(): void
     {
         $cache = new FakeCacheWithWarmup();
-        $mapper = (new MapperBuilder())->withCache($cache);
+        $mapper = $this->mapperBuilder()->withCache($cache);
 
         $mapper->warmup();
         $mapper->warmup();
@@ -41,7 +41,7 @@ final class CacheWarmupTest extends IntegrationTestCase
      */
     public function test_cache_warmup_does_not_call_delegate_warmup_if_not_handled(): void
     {
-        $mapper = new MapperBuilder(); // no cache registered
+        $mapper = $this->mapperBuilder(); // no cache registered
         $mapper->warmup();
     }
 

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -4,15 +4,67 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Integration;
 
+use CuyZ\Valinor\Cache\FileSystemCache;
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Mapper\Tree\Node;
+use CuyZ\Valinor\MapperBuilder;
+use CuyZ\Valinor\Tests\Integration\Mapping\Namespace\NamespacedInterfaceInferringTest;
 use PHPUnit\Framework\TestCase;
+use Psr\SimpleCache\CacheInterface;
 
+use function bin2hex;
 use function implode;
 use function iterator_to_array;
+use function random_bytes;
+use function sys_get_temp_dir;
 
 abstract class IntegrationTestCase extends TestCase
 {
+    /** @var CacheInterface<mixed> */
+    private CacheInterface $cacheToInject;
+
+    /**
+     * After the test has run, it is run again with the cache injected. This
+     * allows us to test the exact same case and assertions, but with a
+     * completely different code path (as the file cache is used only in one
+     * scenario).
+     */
+    protected function tearDown(): void
+    {
+        // Excluding this test because it cannot run twice in the same process.
+        if (static::class === NamespacedInterfaceInferringTest::class) {
+            return;
+        }
+
+        $cacheDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . bin2hex(random_bytes(16));
+        $this->cacheToInject = new FileSystemCache($cacheDir);
+
+        // First rerun of the test: the cache entries will be injected.
+        parent::runTest();
+
+        // Second rerun of the test: the cache entries will be used and tested.
+        parent::runTest();
+
+        $this->cacheToInject->clear();
+    }
+
+    /**
+     * This method *must* be used by every integration test in replacement of a
+     * direct creation of a MapperBuilder instance. The goal is to ensure that
+     * a test is run twice: once without a cache and once with the internal
+     * filesystem cache injected.
+     */
+    protected function mapperBuilder(): MapperBuilder
+    {
+        $builder = new MapperBuilder();
+
+        if (isset($this->cacheToInject)) {
+            $builder = $builder->withCache($this->cacheToInject);
+        }
+
+        return $builder;
+    }
+
     protected function mappingFail(MappingError $error): never
     {
         $errorFinder = static function (Node $node, callable $errorFinder) {

--- a/tests/Integration/Mapping/AnonymousClassMappingTest.php
+++ b/tests/Integration/Mapping/AnonymousClassMappingTest.php
@@ -2,7 +2,6 @@
 
 namespace CuyZ\Valinor\Tests\Integration\Mapping;
 
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
 final class AnonymousClassMappingTest extends IntegrationTestCase
@@ -14,7 +13,7 @@ final class AnonymousClassMappingTest extends IntegrationTestCase
             public string $bar;
         };
 
-        $res = (new MapperBuilder())
+        $res = $this->mapperBuilder()
             ->mapper()
             ->map('string|' . $class::class, 'foo');
 

--- a/tests/Integration/Mapping/ClassInheritanceInferringMappingTest.php
+++ b/tests/Integration/Mapping/ClassInheritanceInferringMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping;
 
 use CuyZ\Valinor\Mapper\Tree\Exception\CannotInferFinalClass;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use LogicException;
 
@@ -13,7 +12,7 @@ final class ClassInheritanceInferringMappingTest extends IntegrationTestCase
 {
     public function test_infer_abstract_class_works_as_expected(): void
     {
-        $result = (new MapperBuilder())
+        $result = $this->mapperBuilder()
             ->infer(
                 SomeAbstractClass::class,
                 fn () => SomeAbstractChildClass::class
@@ -33,7 +32,7 @@ final class ClassInheritanceInferringMappingTest extends IntegrationTestCase
 
     public function test_infer_abstract_class_with_argument_in_callback_works_as_expected(): void
     {
-        $result = (new MapperBuilder())
+        $result = $this->mapperBuilder()
             ->infer(
                 SomeAbstractClass::class,
                 /** @return class-string<SomeAbstractChildClass> */
@@ -58,7 +57,7 @@ final class ClassInheritanceInferringMappingTest extends IntegrationTestCase
 
     public function test_infer_class_works_as_expected(): void
     {
-        $result = (new MapperBuilder())
+        $result = $this->mapperBuilder()
             ->infer(
                 SomeParentClass::class,
                 fn () => SomeChildClass::class
@@ -78,7 +77,7 @@ final class ClassInheritanceInferringMappingTest extends IntegrationTestCase
 
     public function test_infer_class_with_argument_in_callback_works_as_expected(): void
     {
-        $result = (new MapperBuilder())
+        $result = $this->mapperBuilder()
             ->infer(
                 SomeParentClass::class,
                 /** @return class-string<SomeChildClass> */
@@ -107,7 +106,7 @@ final class ClassInheritanceInferringMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1671468163);
         $this->expectExceptionMessage('Cannot infer final class `' . SomeAbstractChildClass::class . '` with function');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->infer(SomeAbstractChildClass::class, fn () => SomeAbstractChildClass::class)
             ->mapper()
             ->map(SomeAbstractChildClass::class, []);

--- a/tests/Integration/Mapping/ClassNameCollisionTestCollision.php
+++ b/tests/Integration/Mapping/ClassNameCollisionTestCollision.php
@@ -3,7 +3,6 @@
 namespace CuyZ\Valinor\Tests\Integration\Mapping;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\Error;
 
@@ -12,7 +11,7 @@ final class ClassNameCollisionTestCollision extends IntegrationTestCase
     public function test_mapping_to_class_with_same_class_name_as_native_class_works_properly(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->mapper()
                 ->map(ObjectWithErrorsClassNameCollision::class, ['foo', 'bar']);
         } catch (MappingError $error) {

--- a/tests/Integration/Mapping/Closure/ArgumentsMappingTest.php
+++ b/tests/Integration/Mapping/Closure/ArgumentsMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Closure;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
 final class ArgumentsMappingTest extends IntegrationTestCase
@@ -15,7 +14,7 @@ final class ArgumentsMappingTest extends IntegrationTestCase
         $function = fn (string $foo, int $bar): string => "$foo / $bar";
 
         try {
-            $arguments = (new MapperBuilder())->argumentsMapper()->mapArguments($function, [
+            $arguments = $this->mapperBuilder()->argumentsMapper()->mapArguments($function, [
                 'foo' => 'foo',
                 'bar' => 42,
             ]);
@@ -31,7 +30,7 @@ final class ArgumentsMappingTest extends IntegrationTestCase
         $object = new SomeClassWithMethods();
 
         try {
-            $arguments = (new MapperBuilder())->argumentsMapper()->mapArguments($object->somePublicMethod(...), [
+            $arguments = $this->mapperBuilder()->argumentsMapper()->mapArguments($object->somePublicMethod(...), [
                 'foo' => 'foo',
                 'bar' => 42,
             ]);
@@ -45,7 +44,7 @@ final class ArgumentsMappingTest extends IntegrationTestCase
     public function test_can_map_to_class_static_method(): void
     {
         try {
-            $arguments = (new MapperBuilder())->argumentsMapper()->mapArguments(SomeClassWithMethods::somePublicStaticMethod(...), [
+            $arguments = $this->mapperBuilder()->argumentsMapper()->mapArguments(SomeClassWithMethods::somePublicStaticMethod(...), [
                 'foo' => 'foo',
                 'bar' => 42,
             ]);
@@ -61,7 +60,7 @@ final class ArgumentsMappingTest extends IntegrationTestCase
         $function = fn (string $foo): string => $foo;
 
         try {
-            $arguments = (new MapperBuilder())->argumentsMapper()->mapArguments($function, ['foo' => 'foo']);
+            $arguments = $this->mapperBuilder()->argumentsMapper()->mapArguments($function, ['foo' => 'foo']);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }
@@ -74,7 +73,7 @@ final class ArgumentsMappingTest extends IntegrationTestCase
         $function = fn (string $foo, int $bar): string => "$foo / $bar";
 
         try {
-            (new MapperBuilder())->argumentsMapper()->mapArguments($function, [
+            $this->mapperBuilder()->argumentsMapper()->mapArguments($function, [
                 'foo' => false,
                 'bar' => false,
             ]);
@@ -91,7 +90,7 @@ final class ArgumentsMappingTest extends IntegrationTestCase
         $function = fn (string $foo, int $bar): string => "$foo / $bar";
 
         try {
-            (new MapperBuilder())->argumentsMapper()->mapArguments($function, [
+            $this->mapperBuilder()->argumentsMapper()->mapArguments($function, [
                 'foo' => false,
                 'bar' => 42,
             ]);

--- a/tests/Integration/Mapping/ConstructorRegistrationMappingTest.php
+++ b/tests/Integration/Mapping/ConstructorRegistrationMappingTest.php
@@ -12,7 +12,6 @@ use CuyZ\Valinor\Mapper\Object\Exception\InvalidConstructorClassTypeParameter;
 use CuyZ\Valinor\Mapper\Object\Exception\InvalidConstructorReturnType;
 use CuyZ\Valinor\Mapper\Object\Exception\MissingConstructorClassTypeParameter;
 use CuyZ\Valinor\Mapper\Object\Exception\ObjectBuildersCollision;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeErrorMessage;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject;
@@ -29,7 +28,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
         $object = new stdClass();
 
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(fn (): stdClass => $object)
                 ->mapper()
                 ->map(stdClass::class, []);
@@ -45,7 +44,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
         $object = new stdClass();
 
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(static fn (): stdClass => $object)
                 ->mapper()
                 ->map(stdClass::class, []);
@@ -61,7 +60,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
         $object = new stdClass();
 
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(SomeClassProvidingStaticClosure::getConstructor($object))
                 ->mapper()
                 ->map(stdClass::class, []);
@@ -77,7 +76,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
         $object = new stdClass();
 
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(/** @return stdClass */ fn () => $object)
                 ->mapper()
                 ->map(stdClass::class, []);
@@ -91,7 +90,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
     public function test_registered_named_constructor_is_used(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(SomeClassWithNamedConstructors::namedConstructor(...))
                 ->mapper()
                 ->map(SomeClassWithNamedConstructors::class, 'foo');
@@ -115,7 +114,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
         };
 
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor($constructor)
                 ->mapper()
                 ->map(stdClass::class, []);
@@ -139,7 +138,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
         };
 
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor($constructor->build(...))
                 ->mapper()
                 ->map(stdClass::class, []);
@@ -153,7 +152,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
     public function test_class_static_constructor_for_other_class_is_used(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(SomeClassWithStaticConstructorForOtherClass::from(...))
                 ->mapper()
                 ->map(SimpleObject::class, 'foo');
@@ -167,7 +166,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
     public function test_registered_constructor_with_injected_class_name_is_used_for_abstract_class(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(
                     /**
                      * @param class-string<SomeAbstractClassWithStaticConstructor> $className
@@ -193,7 +192,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
     public function test_registered_constructor_with_injected_class_name_is_used_for_interface(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(
                     /**
                      * @param class-string<SomeInterfaceWithStaticConstructor> $className
@@ -221,7 +220,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
         try {
             $object = new stdClass();
 
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(
                     #[DynamicConstructor]
                     fn (string $className, string $foo): stdClass => $object
@@ -240,7 +239,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
         try {
             $object = new stdClass();
 
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(fn (): DateTimeInterface => new DateTime())
                 ->registerConstructor(
                     #[DynamicConstructor]
@@ -258,7 +257,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
     public function test_native_constructor_is_not_called_if_not_registered_but_other_constructors_are_registered(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(SomeClassWithSimilarNativeConstructorAndNamedConstructor::namedConstructor(...))
                 ->mapper()
                 ->map(SomeClassWithSimilarNativeConstructorAndNamedConstructor::class, 'foo');
@@ -272,7 +271,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
     public function test_registered_native_constructor_is_called_if_registered_and_other_constructors_are_registered(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(SomeClassWithDifferentNativeConstructorAndNamedConstructor::class)
                 ->registerConstructor(SomeClassWithDifferentNativeConstructorAndNamedConstructor::namedConstructor(...))
                 ->mapper()
@@ -293,7 +292,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
         $object = new stdClass();
 
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(fn (): DateTime => new DateTime())
                 // This constructor is surrounded by other ones to ensure it is
                 // still used correctly.
@@ -311,7 +310,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
     public function test_registered_constructor_with_one_argument_is_used(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(function (int $int): stdClass {
                     $class = new stdClass();
                     $class->int = $int;
@@ -330,7 +329,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
     public function test_registered_constructor_with_several_arguments_is_used(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(function (string $string, int $int, float $float = 1337.404): stdClass {
                     $class = new stdClass();
                     $class->string = $string;
@@ -355,7 +354,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
 
     public function test_registered_constructors_for_same_class_are_filtered_correctly(): void
     {
-        $mapper = (new MapperBuilder())
+        $mapper = $this->mapperBuilder()
             // Basic constructor
             ->registerConstructor(function (string $foo): stdClass {
                 $class = new stdClass();
@@ -413,7 +412,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
 
     public function test_several_constructors_with_same_arguments_number_are_filtered_correctly(): void
     {
-        $mapper = (new MapperBuilder())
+        $mapper = $this->mapperBuilder()
             ->registerConstructor(function (string $foo, string $bar): stdClass {
                 $class = new stdClass();
                 $class->foo = $foo;
@@ -458,7 +457,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
         })::class;
 
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(SomeAbstractClassWithStaticConstructor::from(...))
                 ->mapper()
                 ->map($class, [
@@ -481,7 +480,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1654955787);
         $this->expectExceptionMessageMatches('/A collision was detected between the following constructors of the class `stdClass`: `Closure .*`, `Closure .*`\./');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->registerConstructor(
                 fn (string $foo): stdClass => new stdClass(),
                 fn (): stdClass => new stdClass(),
@@ -497,7 +496,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1654955787);
         $this->expectExceptionMessageMatches('/A collision was detected between the following constructors of the class `stdClass`: `Closure .*`, `Closure .*`\./');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->registerConstructor(
                 fn (int $int): stdClass => new stdClass(),
                 fn (float $float): stdClass => new stdClass(),
@@ -512,7 +511,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1654955787);
         $this->expectExceptionMessage('A collision was detected between the following constructors of the class `stdClass`: `CuyZ\Valinor\Tests\Integration\Mapping\constructorA()`, `CuyZ\Valinor\Tests\Integration\Mapping\constructorB()`.');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->registerConstructor(
                 constructorA(...),
                 fn (int $other, float $arguments): stdClass => new stdClass(),
@@ -525,7 +524,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
     public function test_source_not_matching_registered_constructors_throws_exception(): void
     {
         try {
-            (new MapperBuilder())
+            $this->mapperBuilder()
                 ->registerConstructor(
                     fn (int $bar, float $baz = 1337.404): stdClass => new stdClass(),
                     fn (string $foo): stdClass => new stdClass(),
@@ -546,7 +545,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1646916477);
         $this->expectExceptionMessage('No available constructor found for class `' . SomeClassWithPrivateNativeConstructor::class . '`');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->mapper()
             ->map(SomeClassWithPrivateNativeConstructor::class, []);
     }
@@ -557,7 +556,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1659446121);
         $this->expectExceptionMessageMatches('/Invalid return type `string` for constructor `.*`\, it must be a valid class name\./');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->registerConstructor(fn (): string => 'foo')
             ->mapper()
             ->map(stdClass::class, []);
@@ -569,7 +568,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1659446121);
         $this->expectExceptionMessageMatches('/The type `.*` for return type of method `.*` could not be resolved: No generic was assigned to the template\(s\) `T` for the class .*/');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->registerConstructor(
                 fn (): SimpleObjectWithGeneric => new SimpleObjectWithGeneric()
             )
@@ -583,7 +582,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1661516853);
         $this->expectExceptionMessageMatches('/Missing first parameter of type `class-string` for the constructor `.*`\./');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->registerConstructor(
                 #[DynamicConstructor]
                 fn (): stdClass => new stdClass()
@@ -598,7 +597,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1661517000);
         $this->expectExceptionMessageMatches('/Invalid type `int` for the first parameter of the constructor `.*`, it should be of type `class-string`\./');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->registerConstructor(
                 #[DynamicConstructor]
                 fn (int $invalidParameterType): stdClass => new stdClass()
@@ -612,7 +611,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
         $default = new DateTime('@1356097062');
         $defaultImmutable = new DateTimeImmutable('@1356097062');
 
-        $mapper = (new MapperBuilder())
+        $mapper = $this->mapperBuilder()
             ->registerConstructor(fn (int $timestamp): DateTime => $default)
             ->registerConstructor(fn (int $timestamp): DateTimeImmutable => $defaultImmutable)
             ->mapper();
@@ -633,7 +632,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
         $default = new DateTime('@1659691266');
         $defaultImmutable = new DateTimeImmutable('@1659691266');
 
-        $mapper = (new MapperBuilder())
+        $mapper = $this->mapperBuilder()
             ->registerConstructor(fn (int $timestamp, string $timezone): DateTime => $default)
             ->registerConstructor(fn (int $timestamp, string $timezone): DateTimeImmutable => $defaultImmutable)
             ->mapper();
@@ -652,7 +651,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
     public function test_registered_datetime_constructor_not_matching_source_uses_default_constructor(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(fn (string $foo, int $bar): DateTimeImmutable => new DateTimeImmutable())
                 ->mapper()
                 ->map(DateTimeInterface::class, 1647781015);
@@ -666,7 +665,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
     public function test_registered_constructor_throwing_exception_fails_mapping_with_message(): void
     {
         try {
-            (new MapperBuilder())
+            $this->mapperBuilder()
                 ->registerConstructor(fn (): stdClass => throw new FakeErrorMessage('some error message', 1656076090))
                 ->mapper()
                 ->map(stdClass::class, []);

--- a/tests/Integration/Mapping/EnumConstructorRegistrationMappingTest.php
+++ b/tests/Integration/Mapping/EnumConstructorRegistrationMappingTest.php
@@ -3,7 +3,6 @@
 namespace CuyZ\Valinor\Tests\Integration\Mapping;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Fixture\Enum\BackedStringEnum;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
@@ -12,7 +11,7 @@ class EnumConstructorRegistrationMappingTest extends IntegrationTestCase
     public function test_constructor_with_no_argument_is_called_when_no_value_is_given(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(
                     BackedStringEnum::class,
                     fn (): BackedStringEnum => BackedStringEnum::FOO
@@ -29,7 +28,7 @@ class EnumConstructorRegistrationMappingTest extends IntegrationTestCase
     public function test_constructor_with_no_argument_is_not_called_when_value_is_given(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(
                     BackedStringEnum::class,
                     fn (): BackedStringEnum => BackedStringEnum::FOO
@@ -46,7 +45,7 @@ class EnumConstructorRegistrationMappingTest extends IntegrationTestCase
     public function test_constructor_with_one_argument_is_called_when_one_value_is_given(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(fn (string $value): BackedStringEnum => BackedStringEnum::from($value))
                 ->mapper()
                 ->map(BackedStringEnum::class, 'foo');
@@ -60,7 +59,7 @@ class EnumConstructorRegistrationMappingTest extends IntegrationTestCase
     public function test_constructor_with_several_arguments_is_called_when_values_are_given(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(fn (string $foo, int $bar): BackedStringEnum => BackedStringEnum::FOO)
                 ->mapper()
                 ->map(BackedStringEnum::class, [
@@ -77,7 +76,7 @@ class EnumConstructorRegistrationMappingTest extends IntegrationTestCase
     public function test_registered_native_constructor_is_called_when_one_argument_is_given(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(
                     BackedStringEnum::class,
                     fn (string $foo, int $bar): BackedStringEnum => BackedStringEnum::BAR
@@ -94,7 +93,7 @@ class EnumConstructorRegistrationMappingTest extends IntegrationTestCase
     public function test_map_to_enum_pattern_fetches_correct_constructor(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(
                     /**
                      * @return BackedStringEnum::BA*
@@ -118,7 +117,7 @@ class EnumConstructorRegistrationMappingTest extends IntegrationTestCase
     public function test_register_internal_from_constructor_is_overridden_by_library_constructor(): void
     {
         try {
-            (new MapperBuilder())
+            $this->mapperBuilder()
                 ->registerConstructor(BackedStringEnum::from(...))
                 ->mapper()
                 ->map(BackedStringEnum::class, 'fiz');
@@ -133,7 +132,7 @@ class EnumConstructorRegistrationMappingTest extends IntegrationTestCase
     public function test_register_internal_try_from_constructor_is_overridden_by_library_constructor(): void
     {
         try {
-            (new MapperBuilder())
+            $this->mapperBuilder()
                 ->registerConstructor(BackedStringEnum::tryFrom(...))
                 ->mapper()
                 ->map(BackedStringEnum::class, 'fiz');

--- a/tests/Integration/Mapping/ExceptionFilteringTest.php
+++ b/tests/Integration/Mapping/ExceptionFilteringTest.php
@@ -6,7 +6,6 @@ namespace CuyZ\Valinor\Tests\Integration\Mapping;
 
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeErrorMessage;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use DomainException;
@@ -20,13 +19,13 @@ final class ExceptionFilteringTest extends IntegrationTestCase
         $this->expectExceptionCode(1657042062);
         $this->expectExceptionMessage('some error message');
 
-        (new MapperBuilder())->mapper()->map(ClassThatThrowsExceptionIfInvalidValue::class, 'bar');
+        $this->mapperBuilder()->mapper()->map(ClassThatThrowsExceptionIfInvalidValue::class, 'bar');
     }
 
     public function test_userland_exception_filtered_is_caught_and_added_to_mapping_errors(): void
     {
         try {
-            (new MapperBuilder())
+            $this->mapperBuilder()
                 ->filterExceptions(function (Throwable $exception): ErrorMessage {
                     if ($exception instanceof DomainException) {
                         return new FakeErrorMessage('some error message', 1657197780);

--- a/tests/Integration/Mapping/InterfaceInferringMappingTest.php
+++ b/tests/Integration/Mapping/InterfaceInferringMappingTest.php
@@ -12,7 +12,6 @@ use CuyZ\Valinor\Mapper\Tree\Exception\MissingObjectImplementationRegistration;
 use CuyZ\Valinor\Mapper\Tree\Exception\ObjectImplementationCallbackError;
 use CuyZ\Valinor\Mapper\Tree\Exception\ObjectImplementationNotRegistered;
 use CuyZ\Valinor\Mapper\Tree\Exception\ResolvedImplementationIsNotAccepted;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeErrorMessage;
 use CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithDifferentNamespaces\A\ClassThatInheritsInterfaceA;
 use CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithDifferentNamespaces\B\ClassThatInheritsInterfaceB;
@@ -32,7 +31,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
     public function test_override_date_time_interface_inferring_overrides_correctly(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->infer(DateTimeInterface::class, fn () => DateTime::class)
                 ->mapper()
                 ->map(DateTimeInterface::class, 1645279176);
@@ -47,7 +46,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
     public function test_single_argument_for_both_infer_and_object_constructor_can_be_used(): void
     {
         try {
-            $mapper = (new MapperBuilder())
+            $mapper = $this->mapperBuilder()
                 ->infer(
                     SomeInterface::class,
                     /** @return class-string<SomeClassThatInheritsInterfaceA>|class-string<SomeClassThatInheritsInterfaceB> */
@@ -72,7 +71,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
     public function test_infer_interface_with_union_of_class_string_works_properly(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->infer(
                     SomeInterface::class,
                     /** @return class-string<SomeClassThatInheritsInterfaceA>|class-string<SomeClassThatInheritsInterfaceB> */
@@ -90,7 +89,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
     public function test_infer_interface_with_class_string_with_union_of_class_names_works_properly(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->infer(
                     SomeInterface::class,
                     /** @return class-string<SomeClassThatInheritsInterfaceA|SomeClassThatInheritsInterfaceB> */
@@ -108,7 +107,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
     public function test_infer_interface_with_single_argument_works_properly(): void
     {
         try {
-            [$resultA, $resultB] = (new MapperBuilder())
+            [$resultA, $resultB] = $this->mapperBuilder()
                 ->infer(
                     SomeInterface::class,
                     /** @return class-string<SomeClassThatInheritsInterfaceA|SomeClassThatInheritsInterfaceB> */
@@ -136,7 +135,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
     public function test_infer_interface_with_several_arguments_works_properly(): void
     {
         try {
-            [$resultA, $resultB] = (new MapperBuilder())
+            [$resultA, $resultB] = $this->mapperBuilder()
                 ->infer(
                     SomeInterface::class,
                     /** @return class-string<SomeClassThatInheritsInterfaceA|SomeClassThatInheritsInterfaceB> */
@@ -176,7 +175,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
     public function test_infer_with_two_functions_with_same_name_works_properly(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->infer(
                     InterfaceA::class,
                     InterfaceAInferer::infer(...)
@@ -210,7 +209,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1618049116);
         $this->expectExceptionMessage('Impossible to resolve an implementation for `' . SomeInterface::class . '`.');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->mapper()
             ->map(SomeInterface::class, []);
     }
@@ -221,7 +220,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1630091260);
         $this->expectExceptionMessage('Invalid value 42, expected a subtype of `DateTimeInterface`.');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->infer(DateTimeInterface::class, fn () => 42)
             ->mapper()
             ->map(DateTimeInterface::class, []);
@@ -233,7 +232,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1618049487);
         $this->expectExceptionMessage('Invalid implementation type `int`, expected a subtype of `DateTimeInterface`.');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->infer(DateTimeInterface::class, fn () => 'int')
             ->mapper()
             ->map(DateTimeInterface::class, []);
@@ -245,7 +244,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1618049487);
         $this->expectExceptionMessage('Invalid implementation type `stdClass`, expected a subtype of `DateTimeInterface`.');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->infer(DateTimeInterface::class, fn () => stdClass::class)
             ->mapper()
             ->map(DateTimeInterface::class, []);
@@ -257,7 +256,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1618049487);
         $this->expectExceptionMessage('Invalid implementation type `DateTimeInterface`, expected a subtype of `DateTimeInterface`.');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->infer(DateTimeInterface::class, fn () => DateTimeInterface::class)
             ->mapper()
             ->map(DateTimeInterface::class, []);
@@ -271,7 +270,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1653983061);
         $this->expectExceptionMessage('Error thrown when trying to get implementation of `DateTimeInterface`: some error message');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->infer(
                 DateTimeInterface::class,
                 fn () => throw $exception
@@ -286,7 +285,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1653990369);
         $this->expectExceptionMessage('Invalid interface or class name `invalid type`.');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->infer('invalid type', fn () => stdClass::class) // @phpstan-ignore-line
             ->mapper()
             ->map(stdClass::class, []);
@@ -298,7 +297,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1653990369);
         $this->expectExceptionMessage('Invalid interface or class name `string`.');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->infer('string', fn () => stdClass::class) // @phpstan-ignore-line
             ->mapper()
             ->map(stdClass::class, []);
@@ -310,7 +309,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1653990549);
         $this->expectExceptionMessage('No implementation of `' . SomeInterface::class . '` found with return type `mixed` of');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->infer(
                 SomeInterface::class,
                 fn (string $type) => SomeClassThatInheritsInterfaceA::class
@@ -325,7 +324,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1653990549);
         $this->expectExceptionMessage('No implementation of `' . SomeInterface::class . '` found with return type `string|int` of');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->infer(
                 SomeInterface::class,
                 fn (string $value): string|int => $value === 'foo' ? 'foo' : 42
@@ -340,7 +339,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1653990549);
         $this->expectExceptionMessage('No implementation of `' . SomeInterface::class . '` found with return type `class-string` of');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->infer(
                 SomeInterface::class,
                 /** @return class-string */
@@ -356,7 +355,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1653990989);
         $this->expectExceptionMessage('Invalid implementation `' . SomeClassThatInheritsInterfaceC::class . '` for `' . SomeInterface::class . '`, it should be one of `' . SomeClassThatInheritsInterfaceA::class . '`, `' . SomeClassThatInheritsInterfaceB::class . '`.');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->infer(
                 SomeInterface::class,
                 /** @return class-string<SomeClassThatInheritsInterfaceA|SomeClassThatInheritsInterfaceB> */
@@ -369,7 +368,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
     public function test_invalid_source_throws_exception(): void
     {
         try {
-            (new MapperBuilder())
+            $this->mapperBuilder()
                 ->infer(
                     SomeInterface::class,
                     /** @return class-string<SomeClassThatInheritsInterfaceA> */
@@ -388,7 +387,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
     public function test_invalid_source_value_throws_exception(): void
     {
         try {
-            (new MapperBuilder())
+            $this->mapperBuilder()
                 ->infer(
                     SomeInterface::class,
                     /** @return class-string<SomeClassThatInheritsInterfaceA> */
@@ -406,7 +405,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
     public function test_exception_thrown_is_caught_and_throws_message_exception(): void
     {
         try {
-            (new MapperBuilder())
+            $this->mapperBuilder()
                 ->infer(
                     DateTimeInterface::class,
                     /** @return class-string<DateTime> */
@@ -425,7 +424,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
     public function test_superfluous_values_throws_exception(): void
     {
         try {
-            (new MapperBuilder())
+            $this->mapperBuilder()
                 ->infer(
                     SomeInterface::class,
                     /** @return class-string<SomeClassThatInheritsInterfaceA> */

--- a/tests/Integration/Mapping/MappingErrorTest.php
+++ b/tests/Integration/Mapping/MappingErrorTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
 final class MappingErrorTest extends IntegrationTestCase
@@ -16,7 +15,7 @@ final class MappingErrorTest extends IntegrationTestCase
         $this->expectExceptionCode(1617193185);
         $this->expectExceptionMessage("Could not map type `string`. An error occurred at path *root*: Value array{0: 'foo'} is not a valid string.");
 
-        (new MapperBuilder())->mapper()->map('string', ['foo']);
+        $this->mapperBuilder()->mapper()->map('string', ['foo']);
     }
 
     public function test_several_tree_mapper_errors_count_are_reported_in_exception_message(): void
@@ -25,7 +24,7 @@ final class MappingErrorTest extends IntegrationTestCase
         $this->expectExceptionCode(1617193185);
         $this->expectExceptionMessage("Could not map type `array{foo: string, bar: int}` with value array{foo: 42, bar: 'some string'}. A total of 2 errors were encountered.");
 
-        (new MapperBuilder())->mapper()->map(
+        $this->mapperBuilder()->mapper()->map(
             'array{foo: string, bar: int}',
             ['foo' => 42, 'bar' => 'some string']
         );
@@ -36,6 +35,6 @@ final class MappingErrorTest extends IntegrationTestCase
         $this->expectException(MappingError::class);
         $this->expectExceptionCode(1671115362);
 
-        (new MapperBuilder())->argumentsMapper()->mapArguments(fn (string $foo) => $foo, 42);
+        $this->mapperBuilder()->argumentsMapper()->mapArguments(fn (string $foo) => $foo, 42);
     }
 }

--- a/tests/Integration/Mapping/Message/MessageFormatterTest.php
+++ b/tests/Integration/Mapping/Message/MessageFormatterTest.php
@@ -9,7 +9,6 @@ use CuyZ\Valinor\Mapper\Tree\Message\Formatter\AggregateMessageFormatter;
 use CuyZ\Valinor\Mapper\Tree\Message\Formatter\LocaleMessageFormatter;
 use CuyZ\Valinor\Mapper\Tree\Message\Formatter\MessageMapFormatter;
 use CuyZ\Valinor\Mapper\Tree\Message\Formatter\TranslationMessageFormatter;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
 final class MessageFormatterTest extends IntegrationTestCase
@@ -17,7 +16,7 @@ final class MessageFormatterTest extends IntegrationTestCase
     public function test_message_is_formatted_correctly(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('int', 'foo');
+            $this->mapperBuilder()->mapper()->map('int', 'foo');
         } catch (MappingError $error) {
             $formatter = new AggregateMessageFormatter(
                 new LocaleMessageFormatter('fr'),

--- a/tests/Integration/Mapping/Namespace/RegisteredStaticConstructorWithReturnTypeInDocBlockTest.php
+++ b/tests/Integration/Mapping/Namespace/RegisteredStaticConstructorWithReturnTypeInDocBlockTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Namespace;
 
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
 final class RegisteredStaticConstructorWithReturnTypeInDocBlockTest extends IntegrationTestCase
@@ -12,7 +11,7 @@ final class RegisteredStaticConstructorWithReturnTypeInDocBlockTest extends Inte
     // @see https://github.com/CuyZ/Valinor/issues/461
     public function test_registered_static_constructor_with_return_type_in_doc_block_works_properly(): void
     {
-        $result = (new MapperBuilder())
+        $result = $this->mapperBuilder()
             ->registerConstructor(
                 SomeClassWithStaticConstructor::staticConstructorWithReturnTypeInDocBlock(...),
             )

--- a/tests/Integration/Mapping/Object/ArrayValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ArrayValuesMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject as SimpleObjectAlias;
@@ -41,7 +40,7 @@ final class ArrayValuesMappingTest extends IntegrationTestCase
 
         foreach ([ArrayValues::class, ArrayValuesWithConstructor::class] as $class) {
             try {
-                $result = (new MapperBuilder())->mapper()->map($class, $source);
+                $result = $this->mapperBuilder()->mapper()->map($class, $source);
             } catch (MappingError $error) {
                 $this->mappingFail($error);
             }
@@ -70,7 +69,7 @@ final class ArrayValuesMappingTest extends IntegrationTestCase
     public function test_empty_array_in_non_empty_array_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map(ArrayValues::class, [
+            $this->mapperBuilder()->mapper()->map(ArrayValues::class, [
                 'nonEmptyArraysOfStrings' => [],
             ]);
         } catch (MappingError $exception) {
@@ -84,7 +83,7 @@ final class ArrayValuesMappingTest extends IntegrationTestCase
     public function test_value_with_invalid_type_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map(ArrayValues::class, [
+            $this->mapperBuilder()->mapper()->map(ArrayValues::class, [
                 'integers' => ['foo'],
             ]);
         } catch (MappingError $exception) {

--- a/tests/Integration/Mapping/Object/ConstantValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ConstantValuesMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Fixture\Enum\BackedIntegerEnum;
 use CuyZ\Valinor\Tests\Fixture\Object\ObjectWithConstants;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
@@ -35,7 +34,7 @@ final class ConstantValuesMappingTest extends IntegrationTestCase
 
         foreach ([ClassWithConstantValues::class, ClassWithConstantValuesWithConstructor::class] as $class) {
             try {
-                $result = (new MapperBuilder())->mapper()->map($class, $source);
+                $result = $this->mapperBuilder()->mapper()->map($class, $source);
             } catch (MappingError $error) {
                 $this->mappingFail($error);
             }
@@ -63,7 +62,7 @@ final class ConstantValuesMappingTest extends IntegrationTestCase
     public function test_private_constant_cannot_be_mapped(): void
     {
         try {
-            (new MapperBuilder())
+            $this->mapperBuilder()
                 ->mapper()
                 ->map(ObjectWithConstants::class . '::CONST_WITH_STRING_*', 'some private string value');
         } catch (MappingError $exception) {
@@ -77,7 +76,7 @@ final class ConstantValuesMappingTest extends IntegrationTestCase
     public function test_constant_not_matching_pattern_cannot_be_mapped(): void
     {
         try {
-            (new MapperBuilder())
+            $this->mapperBuilder()
                 ->mapper()
                 ->map(ObjectWithConstants::class . '::CONST_WITH_STRING_*', 'some prefixed string value');
         } catch (MappingError $exception) {

--- a/tests/Integration/Mapping/Object/DateTimeMappingTest.php
+++ b/tests/Integration/Mapping/Object/DateTimeMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use DateTimeInterface;
 
@@ -14,7 +13,7 @@ final class DateTimeMappingTest extends IntegrationTestCase
     public function test_default_datetime_constructor_cannot_be_used(): void
     {
         try {
-            (new MapperBuilder())
+            $this->mapperBuilder()
                 ->mapper()
                 ->map(DateTimeInterface::class, ['datetime' => '2022/08/05', 'timezone' => 'Europe/Paris']);
         } catch (MappingError $exception) {
@@ -27,7 +26,7 @@ final class DateTimeMappingTest extends IntegrationTestCase
     public function test_default_date_constructor_with_valid_rfc_3339_format_source_returns_datetime(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->mapper()
                 ->map(DateTimeInterface::class, '2022-08-05T08:32:06+00:00');
         } catch (MappingError $error) {
@@ -40,7 +39,7 @@ final class DateTimeMappingTest extends IntegrationTestCase
     public function test_default_date_constructor_with_valid_rfc_3339_and_milliseconds_format_source_returns_datetime(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->mapper()
                 ->map(DateTimeInterface::class, '2022-08-05T08:32:06.123Z');
         } catch (MappingError $error) {
@@ -55,7 +54,7 @@ final class DateTimeMappingTest extends IntegrationTestCase
     public function test_default_date_constructor_with_valid_rfc_3339_and_microseconds_format_source_returns_datetime(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->mapper()
                 ->map(DateTimeInterface::class, '2022-08-05T08:32:06.123456Z');
         } catch (MappingError $error) {
@@ -70,7 +69,7 @@ final class DateTimeMappingTest extends IntegrationTestCase
     public function test_default_date_constructor_with_valid_timestamp_format_source_returns_datetime(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->mapper()
                 ->map(DateTimeInterface::class, 1659688380);
         } catch (MappingError $error) {
@@ -83,7 +82,7 @@ final class DateTimeMappingTest extends IntegrationTestCase
     public function test_default_date_constructor_with_timestamp_at_0_source_returns_datetime(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->mapper()
                 ->map(DateTimeInterface::class, 0);
         } catch (MappingError $error) {
@@ -96,7 +95,7 @@ final class DateTimeMappingTest extends IntegrationTestCase
     public function test_default_date_constructor_with_a_negative_timestamp_source_returns_datetime(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->mapper()
                 ->map(DateTimeInterface::class, -1);
         } catch (MappingError $error) {
@@ -109,7 +108,7 @@ final class DateTimeMappingTest extends IntegrationTestCase
     public function test_registered_date_constructor_with_valid_source_returns_datetime(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->supportDateFormats('d/m/Y', 'Y/m/d')
                 ->mapper()
                 ->map(DateTimeInterface::class, '2022/08/05');
@@ -123,7 +122,7 @@ final class DateTimeMappingTest extends IntegrationTestCase
     public function test_default_date_constructor_with_invalid_source_throws_exception(): void
     {
         try {
-            (new MapperBuilder())
+            $this->mapperBuilder()
                 ->mapper()
                 ->map(DateTimeInterface::class, 'invalid datetime');
         } catch (MappingError $exception) {
@@ -137,7 +136,7 @@ final class DateTimeMappingTest extends IntegrationTestCase
     public function test_registered_date_constructor_with_invalid_source_throws_exception(): void
     {
         try {
-            (new MapperBuilder())
+            $this->mapperBuilder()
                 ->supportDateFormats('Y/m/d')
                 ->mapper()
                 ->map(DateTimeInterface::class, 'invalid datetime');
@@ -152,7 +151,7 @@ final class DateTimeMappingTest extends IntegrationTestCase
     public function test_date_constructor_with_overridden_format_source_throws_exception(): void
     {
         try {
-            (new MapperBuilder())
+            $this->mapperBuilder()
                 ->supportDateFormats('Y/m/d')
                 ->supportDateFormats('d/m/Y')
                 ->mapper()

--- a/tests/Integration/Mapping/Object/DateTimeZoneMappingTest.php
+++ b/tests/Integration/Mapping/Object/DateTimeZoneMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use DateTimeZone;
 
@@ -14,7 +13,7 @@ final class DateTimeZoneMappingTest extends IntegrationTestCase
     public function test_can_map_to_timezone_with_default_constructor(): void
     {
         try {
-            $result = (new MapperBuilder())->mapper()->map(DateTimeZone::class, 'Europe/Paris');
+            $result = $this->mapperBuilder()->mapper()->map(DateTimeZone::class, 'Europe/Paris');
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }
@@ -25,7 +24,7 @@ final class DateTimeZoneMappingTest extends IntegrationTestCase
     public function test_constructor_with_one_argument_replaces_default_constructor(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(
                     fn (string $europeanCity): DateTimeZone => new DateTimeZone("Europe/$europeanCity")
                 )
@@ -40,7 +39,7 @@ final class DateTimeZoneMappingTest extends IntegrationTestCase
 
     public function test_constructor_with_two_arguments_does_not_replaces_default_constructor(): void
     {
-        $mapper = (new MapperBuilder())->registerConstructor(
+        $mapper = $this->mapperBuilder()->registerConstructor(
             fn (string $continent, string $city): DateTimeZone => new DateTimeZone("$continent/$city")
         )->mapper();
 
@@ -67,7 +66,7 @@ final class DateTimeZoneMappingTest extends IntegrationTestCase
     public function test_invalid_timezone_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map(DateTimeZone::class, 'Jupiter/Europa');
+            $this->mapperBuilder()->mapper()->map(DateTimeZone::class, 'Jupiter/Europa');
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 

--- a/tests/Integration/Mapping/Object/EnumValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/EnumValuesMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Fixture\Enum\BackedIntegerEnum;
 use CuyZ\Valinor\Tests\Fixture\Enum\BackedStringEnum;
 use CuyZ\Valinor\Tests\Fixture\Enum\PureEnum;
@@ -28,7 +27,7 @@ final class EnumValuesMappingTest extends IntegrationTestCase
 
         foreach ([EnumValues::class, EnumValuesWithConstructor::class] as $class) {
             try {
-                $result = (new MapperBuilder())->mapper()->map($class, $source);
+                $result = $this->mapperBuilder()->mapper()->map($class, $source);
             } catch (MappingError $error) {
                 $this->mappingFail($error);
             }
@@ -46,7 +45,7 @@ final class EnumValuesMappingTest extends IntegrationTestCase
     public function test_invalid_string_enum_value_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map(BackedStringEnum::class, new StringableObject('fiz'));
+            $this->mapperBuilder()->mapper()->map(BackedStringEnum::class, new StringableObject('fiz'));
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 
@@ -57,7 +56,7 @@ final class EnumValuesMappingTest extends IntegrationTestCase
     public function test_invalid_integer_enum_value_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map(BackedIntegerEnum::class, '512');
+            $this->mapperBuilder()->mapper()->map(BackedIntegerEnum::class, '512');
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 
@@ -68,7 +67,7 @@ final class EnumValuesMappingTest extends IntegrationTestCase
     public function test_value_not_matching_pure_enum_case_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map(PureEnum::class . '::FOO', 'fiz');
+            $this->mapperBuilder()->mapper()->map(PureEnum::class . '::FOO', 'fiz');
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 
@@ -79,7 +78,7 @@ final class EnumValuesMappingTest extends IntegrationTestCase
     public function test_value_not_matching_backed_integer_enum_case_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map(BackedIntegerEnum::class . '::FOO', '512');
+            $this->mapperBuilder()->mapper()->map(BackedIntegerEnum::class . '::FOO', '512');
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 
@@ -90,7 +89,7 @@ final class EnumValuesMappingTest extends IntegrationTestCase
     public function test_value_not_filled_for_pure_enum_case_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('array{foo: ' . PureEnum::class . '::FOO}', []);
+            $this->mapperBuilder()->mapper()->map('array{foo: ' . PureEnum::class . '::FOO}', []);
         } catch (MappingError $exception) {
             $error = $exception->node()->children()['foo']->messages()[0];
 
@@ -101,7 +100,7 @@ final class EnumValuesMappingTest extends IntegrationTestCase
     public function test_value_not_filled_for_backed_integer_enum_case_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('array{foo: ' . BackedIntegerEnum::class . '::FOO}', []);
+            $this->mapperBuilder()->mapper()->map('array{foo: ' . BackedIntegerEnum::class . '::FOO}', []);
         } catch (MappingError $exception) {
             $error = $exception->node()->children()['foo']->messages()[0];
 

--- a/tests/Integration/Mapping/Object/ExtendedDateIntervalMappingTest.php
+++ b/tests/Integration/Mapping/Object/ExtendedDateIntervalMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\DateInterval;
 
@@ -14,7 +13,7 @@ final class ExtendedDateIntervalMappingTest extends IntegrationTestCase
     public function test_extended_date_interval_is_mapped_properly(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->mapper()
                 ->map(DateInterval::class, 'P1Y2M3DT4H5M6S');
         } catch (MappingError $error) {

--- a/tests/Integration/Mapping/Object/GenericInheritanceTest.php
+++ b/tests/Integration/Mapping/Object/GenericInheritanceTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
 final class GenericInheritanceTest extends IntegrationTestCase
@@ -13,7 +12,7 @@ final class GenericInheritanceTest extends IntegrationTestCase
     public function test_generic_types_are_inherited_properly(): void
     {
         try {
-            $object = (new MapperBuilder())
+            $object = $this->mapperBuilder()
                 ->mapper()
                 ->map(ChildClassWithInheritedGenericType::class, [
                     'valueA' => 'foo',

--- a/tests/Integration/Mapping/Object/GenericValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/GenericValuesMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject as SimpleObjectAlias;
@@ -43,7 +42,7 @@ final class GenericValuesMappingTest extends IntegrationTestCase
 
         foreach ([GenericValues::class, GenericValuesWithConstructor::class] as $class) {
             try {
-                $result = (new MapperBuilder())->mapper()->map($class, $source);
+                $result = $this->mapperBuilder()->mapper()->map($class, $source);
             } catch (MappingError $error) {
                 $this->mappingFail($error);
             }

--- a/tests/Integration/Mapping/Object/IterableValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/IterableValuesMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject as SimpleObjectAlias;
@@ -36,7 +35,7 @@ final class IterableValuesMappingTest extends IntegrationTestCase
 
         foreach ([IterableValues::class, IterableValuesWithConstructor::class] as $class) {
             try {
-                $result = (new MapperBuilder())->mapper()->map($class, $source);
+                $result = $this->mapperBuilder()->mapper()->map($class, $source);
             } catch (MappingError $error) {
                 $this->mappingFail($error);
             }

--- a/tests/Integration/Mapping/Object/ListValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ListValuesMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject as SimpleObjectAlias;
@@ -27,7 +26,7 @@ final class ListValuesMappingTest extends IntegrationTestCase
 
         foreach ([ListValues::class, ListValuesWithConstructor::class] as $class) {
             try {
-                $result = (new MapperBuilder())->mapper()->map($class, $source);
+                $result = $this->mapperBuilder()->mapper()->map($class, $source);
             } catch (MappingError $error) {
                 $this->mappingFail($error);
             }
@@ -50,7 +49,7 @@ final class ListValuesMappingTest extends IntegrationTestCase
     public function test_empty_list_in_non_empty_list_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map(ListValues::class, [
+            $this->mapperBuilder()->mapper()->map(ListValues::class, [
                 'nonEmptyListOfStrings' => [],
             ]);
         } catch (MappingError $exception) {
@@ -64,7 +63,7 @@ final class ListValuesMappingTest extends IntegrationTestCase
     public function test_map_array_with_non_sequential_keys_to_list_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('list<string>', [
+            $this->mapperBuilder()->mapper()->map('list<string>', [
                 0 => 'foo',
                 2 => 'bar',
             ]);
@@ -79,7 +78,7 @@ final class ListValuesMappingTest extends IntegrationTestCase
     public function test_value_with_invalid_type_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map(ListValues::class, [
+            $this->mapperBuilder()->mapper()->map(ListValues::class, [
                 'integers' => ['foo'],
             ]);
         } catch (MappingError $exception) {

--- a/tests/Integration/Mapping/Object/LocalTypeAliasMappingTest.php
+++ b/tests/Integration/Mapping/Object/LocalTypeAliasMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
 final class LocalTypeAliasMappingTest extends IntegrationTestCase
@@ -28,7 +27,7 @@ final class LocalTypeAliasMappingTest extends IntegrationTestCase
 
         foreach ([PhpStanLocalAliases::class, PsalmLocalAliases::class] as $class) {
             try {
-                $result = (new MapperBuilder())
+                $result = $this->mapperBuilder()
                     ->mapper()
                     ->map($class, $source);
 
@@ -47,7 +46,7 @@ final class LocalTypeAliasMappingTest extends IntegrationTestCase
     {
         foreach ([PhpStanAliasImport::class, PsalmAliasImport::class] as $class) {
             try {
-                $result = (new MapperBuilder())
+                $result = $this->mapperBuilder()
                     ->mapper()
                     ->map($class, [
                         'firstImportedType' => 42,

--- a/tests/Integration/Mapping/Object/NullableMappingTest.php
+++ b/tests/Integration/Mapping/Object/NullableMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
 final class NullableMappingTest extends IntegrationTestCase
@@ -13,7 +12,7 @@ final class NullableMappingTest extends IntegrationTestCase
     public function test_nullable_properties_default_value_are_handled_properly(): void
     {
         try {
-            $result = (new MapperBuilder())->mapper()->map(NullablePropertyWithNullDefaultValue::class, []);
+            $result = $this->mapperBuilder()->mapper()->map(NullablePropertyWithNullDefaultValue::class, []);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }

--- a/tests/Integration/Mapping/Object/ObjectValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ObjectValuesMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject;
 use stdClass;
@@ -21,7 +20,7 @@ final class ObjectValuesMappingTest extends IntegrationTestCase
 
         foreach ([ObjectValues::class, ObjectValuesWithConstructor::class] as $class) {
             try {
-                $result = (new MapperBuilder())->mapper()->map($class, $source);
+                $result = $this->mapperBuilder()->mapper()->map($class, $source);
             } catch (MappingError $error) {
                 $this->mappingFail($error);
             }
@@ -36,7 +35,7 @@ final class ObjectValuesMappingTest extends IntegrationTestCase
 
         foreach ([ObjectValues::class, ObjectValuesWithConstructor::class] as $class) {
             try {
-                (new MapperBuilder())->mapper()->map($class, $source);
+                $this->mapperBuilder()->mapper()->map($class, $source);
             } catch (MappingError $exception) {
                 $error = $exception->node()->messages()[0];
 
@@ -49,7 +48,7 @@ final class ObjectValuesMappingTest extends IntegrationTestCase
     public function test_superfluous_values_throws_exception_and_keeps_nested_errors(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map(ObjectWithTwoProperties::class, [
+            $this->mapperBuilder()->mapper()->map(ObjectWithTwoProperties::class, [
                 'stringA' => 42,
                 'stringB' => 'fooB',
                 'unexpectedValueA' => 'foo',
@@ -69,7 +68,7 @@ final class ObjectValuesMappingTest extends IntegrationTestCase
     public function test_object_with_no_argument_build_with_non_array_source_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map(stdClass::class, 'foo');
+            $this->mapperBuilder()->mapper()->map(stdClass::class, 'foo');
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 

--- a/tests/Integration/Mapping/Object/ScalarValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ScalarValuesMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject;
 use DateTime;
@@ -50,7 +49,7 @@ final class ScalarValuesMappingTest extends IntegrationTestCase
 
         foreach ([ScalarValues::class, ScalarValuesWithConstructor::class] as $class) {
             try {
-                $result = (new MapperBuilder())->mapper()->map($class, $source);
+                $result = $this->mapperBuilder()->mapper()->map($class, $source);
             } catch (MappingError $error) {
                 $this->mappingFail($error);
             }
@@ -88,7 +87,7 @@ final class ScalarValuesMappingTest extends IntegrationTestCase
     public function test_value_with_invalid_type_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map(SimpleObject::class, new stdClass());
+            $this->mapperBuilder()->mapper()->map(SimpleObject::class, new stdClass());
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 

--- a/tests/Integration/Mapping/Object/ShapedArrayValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ShapedArrayValuesMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject;
 use stdClass;
@@ -66,7 +65,7 @@ final class ShapedArrayValuesMappingTest extends IntegrationTestCase
 
         foreach ([ShapedArrayValues::class, ShapedArrayValuesWithConstructor::class] as $class) {
             try {
-                $result = (new MapperBuilder())->mapper()->map($class, $source);
+                $result = $this->mapperBuilder()->mapper()->map($class, $source);
             } catch (MappingError $error) {
                 $this->mappingFail($error);
             }
@@ -92,7 +91,7 @@ final class ShapedArrayValuesMappingTest extends IntegrationTestCase
     public function test_value_with_invalid_type_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map(ShapedArrayValues::class, [
+            $this->mapperBuilder()->mapper()->map(ShapedArrayValues::class, [
                 'basicShapedArrayWithStringKeys' => [
                     'foo' => new stdClass(),
                     'bar' => 42,

--- a/tests/Integration/Mapping/Object/SimpleNamespacedObjectMappingTest.php
+++ b/tests/Integration/Mapping/Object/SimpleNamespacedObjectMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use SimpleNamespace\SimpleNamespacedObject;
 
@@ -16,7 +15,7 @@ final class SimpleNamespacedObjectMappingTest extends IntegrationTestCase
         require_once(__DIR__ . '/../Fixture/SimpleNamespacedObject.php');
 
         try {
-            $object = (new MapperBuilder())->mapper()->map(SimpleNamespacedObject::class, ['foo']);
+            $object = $this->mapperBuilder()->mapper()->map(SimpleNamespacedObject::class, ['foo']);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }

--- a/tests/Integration/Mapping/Object/UnionOfObjectsMappingTest.php
+++ b/tests/Integration/Mapping/Object/UnionOfObjectsMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -14,7 +13,7 @@ final class UnionOfObjectsMappingTest extends IntegrationTestCase
     public function test_objects_sharing_one_property_are_resolved_correctly(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->registerConstructor(SomeFooAndBarObject::constructorA(...))
                 ->registerConstructor(SomeFooAndBarObject::constructorB(...))
                 ->mapper()
@@ -33,7 +32,7 @@ final class UnionOfObjectsMappingTest extends IntegrationTestCase
     public function test_mapping_to_union_of_null_and_objects_can_infer_object(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->mapper()
                 ->map(
                     'null|' . SomeObjectWithFooAndBar::class . '|' . SomeObjectWithBazAndFiz::class,
@@ -60,7 +59,7 @@ final class UnionOfObjectsMappingTest extends IntegrationTestCase
     public function test_mapping_error_when_cannot_resolve_union(string $className, array $source): void
     {
         try {
-            (new MapperBuilder())->mapper()->map($className, $source);
+            $this->mapperBuilder()->mapper()->map($className, $source);
 
             self::fail('No mapping error when one was expected');
         } catch (MappingError $exception) {

--- a/tests/Integration/Mapping/Object/UnionValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/UnionValuesMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Fixture\Object\ObjectWithConstants;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use DateTimeImmutable;
@@ -39,7 +38,7 @@ final class UnionValuesMappingTest extends IntegrationTestCase
 
         foreach ($classes as $class) {
             try {
-                $result = (new MapperBuilder())->mapper()->map($class, $source);
+                $result = $this->mapperBuilder()->mapper()->map($class, $source);
             } catch (MappingError $error) {
                 $this->mappingFail($error);
             }
@@ -71,7 +70,7 @@ final class UnionValuesMappingTest extends IntegrationTestCase
 
         foreach ([UnionOfFixedValues::class, UnionOfFixedValuesWithConstructor::class] as $class) {
             try {
-                $result = (new MapperBuilder())->mapper()->map($class, $source);
+                $result = $this->mapperBuilder()->mapper()->map($class, $source);
             } catch (MappingError $error) {
                 $this->mappingFail($error);
             }
@@ -88,7 +87,7 @@ final class UnionValuesMappingTest extends IntegrationTestCase
     public function test_invalid_value_is_not_casted_when_casting_mode_is_disabled(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('string|int', 42.404);
+            $this->mapperBuilder()->mapper()->map('string|int', 42.404);
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 

--- a/tests/Integration/Mapping/Other/ArrayMappingTest.php
+++ b/tests/Integration/Mapping/Other/ArrayMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Other;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use stdClass;
 
@@ -16,7 +15,7 @@ final class ArrayMappingTest extends IntegrationTestCase
         $source = ['foo', 'bar', 'baz'];
 
         try {
-            $result = (new MapperBuilder())->mapper()->map('string[]', $source);
+            $result = $this->mapperBuilder()->mapper()->map('string[]', $source);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }
@@ -29,7 +28,7 @@ final class ArrayMappingTest extends IntegrationTestCase
         $source = ['foo' => 'foo', 'bar' => 'bar'];
 
         try {
-            $result = (new MapperBuilder())->mapper()->map("array<'foo'|'bar', string>", $source);
+            $result = $this->mapperBuilder()->mapper()->map("array<'foo'|'bar', string>", $source);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }
@@ -42,7 +41,7 @@ final class ArrayMappingTest extends IntegrationTestCase
         $source = [42 => 'foo', 1337 => 'bar'];
 
         try {
-            $result = (new MapperBuilder())->mapper()->map('array<42|1337, string>', $source);
+            $result = $this->mapperBuilder()->mapper()->map('array<42|1337, string>', $source);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }
@@ -55,7 +54,7 @@ final class ArrayMappingTest extends IntegrationTestCase
         $source = [42 => 'foo', 1337 => 'bar'];
 
         try {
-            $result = (new MapperBuilder())->mapper()->map('array<positive-int, string>', $source);
+            $result = $this->mapperBuilder()->mapper()->map('array<positive-int, string>', $source);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }
@@ -68,7 +67,7 @@ final class ArrayMappingTest extends IntegrationTestCase
         $source = [-42 => 'foo', -1337 => 'bar'];
 
         try {
-            $result = (new MapperBuilder())->mapper()->map('array<negative-int, string>', $source);
+            $result = $this->mapperBuilder()->mapper()->map('array<negative-int, string>', $source);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }
@@ -81,7 +80,7 @@ final class ArrayMappingTest extends IntegrationTestCase
         $source = [-42 => 'foo', 42 => 'foo', 1337 => 'bar'];
 
         try {
-            $result = (new MapperBuilder())->mapper()->map('array<int<-42, 1337>, string>', $source);
+            $result = $this->mapperBuilder()->mapper()->map('array<int<-42, 1337>, string>', $source);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }
@@ -94,7 +93,7 @@ final class ArrayMappingTest extends IntegrationTestCase
         $source = ['foo' => 'foo', 'bar' => 'bar'];
 
         try {
-            $result = (new MapperBuilder())->mapper()->map('array<non-empty-string, string>', $source);
+            $result = $this->mapperBuilder()->mapper()->map('array<non-empty-string, string>', $source);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }
@@ -107,7 +106,7 @@ final class ArrayMappingTest extends IntegrationTestCase
         $source = [stdClass::class => 'foo'];
 
         try {
-            $result = (new MapperBuilder())->mapper()->map('array<class-string, string>', $source);
+            $result = $this->mapperBuilder()->mapper()->map('array<class-string, string>', $source);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }
@@ -118,7 +117,7 @@ final class ArrayMappingTest extends IntegrationTestCase
     public function test_value_with_invalid_integer_key_type_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('array<int, string>', ['foo' => 'foo']);
+            $this->mapperBuilder()->mapper()->map('array<int, string>', ['foo' => 'foo']);
         } catch (MappingError $exception) {
             $error = $exception->node()->children()['foo']->messages()[0];
 
@@ -129,7 +128,7 @@ final class ArrayMappingTest extends IntegrationTestCase
     public function test_value_with_invalid_positive_integer_key_type_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('array<positive-int, string>', [-42 => 'foo']);
+            $this->mapperBuilder()->mapper()->map('array<positive-int, string>', [-42 => 'foo']);
         } catch (MappingError $exception) {
             $error = $exception->node()->children()[-42]->messages()[0];
 
@@ -140,7 +139,7 @@ final class ArrayMappingTest extends IntegrationTestCase
     public function test_value_with_invalid_negative_integer_key_type_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('array<negative-int, string>', [42 => 'foo']);
+            $this->mapperBuilder()->mapper()->map('array<negative-int, string>', [42 => 'foo']);
         } catch (MappingError $exception) {
             $error = $exception->node()->children()[42]->messages()[0];
 
@@ -151,7 +150,7 @@ final class ArrayMappingTest extends IntegrationTestCase
     public function test_value_with_invalid_integer_range_key_type_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('array<int<-42, 1337>, string>', [-404 => 'foo']);
+            $this->mapperBuilder()->mapper()->map('array<int<-42, 1337>, string>', [-404 => 'foo']);
         } catch (MappingError $exception) {
             $error = $exception->node()->children()[-404]->messages()[0];
 
@@ -162,7 +161,7 @@ final class ArrayMappingTest extends IntegrationTestCase
     public function test_value_with_invalid_union_string_key_type_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map("array<'foo'|'bar', string>", ['baz' => 'baz']);
+            $this->mapperBuilder()->mapper()->map("array<'foo'|'bar', string>", ['baz' => 'baz']);
         } catch (MappingError $exception) {
             $error = $exception->node()->children()['baz']->messages()[0];
 
@@ -173,7 +172,7 @@ final class ArrayMappingTest extends IntegrationTestCase
     public function test_value_with_invalid_union_integer_key_type_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('array<42|1337, string>', [404 => 'baz']);
+            $this->mapperBuilder()->mapper()->map('array<42|1337, string>', [404 => 'baz']);
         } catch (MappingError $exception) {
             $error = $exception->node()->children()[404]->messages()[0];
 
@@ -184,7 +183,7 @@ final class ArrayMappingTest extends IntegrationTestCase
     public function test_value_with_invalid_non_empty_string_key_type_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('array<non-empty-string, string>', ['' => 'foo']);
+            $this->mapperBuilder()->mapper()->map('array<non-empty-string, string>', ['' => 'foo']);
         } catch (MappingError $exception) {
             $error = $exception->node()->children()['']->messages()[0];
 
@@ -195,7 +194,7 @@ final class ArrayMappingTest extends IntegrationTestCase
     public function test_value_with_invalid_class_string_key_type_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('array<class-string, string>', ['foo bar' => 'foo']);
+            $this->mapperBuilder()->mapper()->map('array<class-string, string>', ['foo bar' => 'foo']);
         } catch (MappingError $exception) {
             $error = $exception->node()->children()['foo bar']->messages()[0];
 

--- a/tests/Integration/Mapping/Other/FlexibleCastingMappingTest.php
+++ b/tests/Integration/Mapping/Other/FlexibleCastingMappingTest.php
@@ -6,7 +6,6 @@ namespace CuyZ\Valinor\Tests\Integration\Mapping\Other;
 
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Mapper\TreeMapper;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Fixture\Enum\BackedIntegerEnum;
 use CuyZ\Valinor\Tests\Fixture\Enum\BackedStringEnum;
 use CuyZ\Valinor\Tests\Fixture\Object\StringableObject;
@@ -21,7 +20,7 @@ final class FlexibleCastingMappingTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        $this->mapper = (new MapperBuilder())->enableFlexibleCasting()->mapper();
+        $this->mapper = $this->mapperBuilder()->enableFlexibleCasting()->mapper();
     }
 
     public function test_leading_zero_in_numeric_is_mapped_properly(): void
@@ -172,7 +171,7 @@ final class FlexibleCastingMappingTest extends IntegrationTestCase
     public function test_null_value_for_interface_with_no_properties_needed_fills_it_with_empty_array(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->infer(SomeInterfaceForClassWithNoProperties::class, fn () => SomeClassWithNoProperties::class)
                 ->enableFlexibleCasting()
                 ->mapper()
@@ -187,7 +186,7 @@ final class FlexibleCastingMappingTest extends IntegrationTestCase
     public function test_interface_is_inferred_and_mapped_properly_in_flexible_casting_mode(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->infer(SomeInterfaceForClassWithProperties::class, fn () => SomeClassWithProperties::class)
                 ->enableFlexibleCasting()
                 ->mapper()

--- a/tests/Integration/Mapping/Other/PermissiveTypesMappingTest.php
+++ b/tests/Integration/Mapping/Other/PermissiveTypesMappingTest.php
@@ -6,7 +6,6 @@ namespace CuyZ\Valinor\Tests\Integration\Mapping\Other;
 
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Mapper\TreeMapper;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use DateTime;
 use stdClass;
@@ -19,7 +18,7 @@ final class PermissiveTypesMappingTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        $this->mapper = (new MapperBuilder())->allowPermissiveTypes()->mapper();
+        $this->mapper = $this->mapperBuilder()->allowPermissiveTypes()->mapper();
     }
 
     public function test_can_map_to_mixed_type(): void

--- a/tests/Integration/Mapping/Other/ShapedArrayMappingTest.php
+++ b/tests/Integration/Mapping/Other/ShapedArrayMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Other;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
 final class ShapedArrayMappingTest extends IntegrationTestCase
@@ -19,7 +18,7 @@ final class ShapedArrayMappingTest extends IntegrationTestCase
         ];
 
         try {
-            $result = (new MapperBuilder())->mapper()->map('array{foo: string, bar: int, fiz: float}', $source);
+            $result = $this->mapperBuilder()->mapper()->map('array{foo: string, bar: int, fiz: float}', $source);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }
@@ -38,7 +37,7 @@ final class ShapedArrayMappingTest extends IntegrationTestCase
         })();
 
         try {
-            $result = (new MapperBuilder())->mapper()->map('array{foo: string, bar: int, fiz: float}', $iterator);
+            $result = $this->mapperBuilder()->mapper()->map('array{foo: string, bar: int, fiz: float}', $iterator);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }
@@ -51,7 +50,7 @@ final class ShapedArrayMappingTest extends IntegrationTestCase
     public function test_missing_element_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('array{foo: string, bar: int}', ['foo' => 'foo']);
+            $this->mapperBuilder()->mapper()->map('array{foo: string, bar: int}', ['foo' => 'foo']);
         } catch (MappingError $exception) {
             $error = $exception->node()->children()['bar']->messages()[0];
 
@@ -69,7 +68,7 @@ final class ShapedArrayMappingTest extends IntegrationTestCase
         ];
 
         try {
-            (new MapperBuilder())->mapper()->map('array{foo: string, bar: int}', $source);
+            $this->mapperBuilder()->mapper()->map('array{foo: string, bar: int}', $source);
         } catch (MappingError $exception) {
             $rootError = $exception->node()->messages()[0];
             $nestedError = $exception->node()->children()['foo']->messages()[0];

--- a/tests/Integration/Mapping/Other/StrictMappingTest.php
+++ b/tests/Integration/Mapping/Other/StrictMappingTest.php
@@ -6,7 +6,6 @@ namespace CuyZ\Valinor\Tests\Integration\Mapping\Other;
 
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Mapper\Object\Exception\PermissiveTypeNotAllowed;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Fixture\Enum\BackedIntegerEnum;
 use CuyZ\Valinor\Tests\Fixture\Enum\BackedStringEnum;
 use CuyZ\Valinor\Tests\Fixture\Enum\PureEnum;
@@ -25,7 +24,7 @@ final class StrictMappingTest extends IntegrationTestCase
         };
 
         try {
-            (new MapperBuilder())->mapper()->map($class::class, [
+            $this->mapperBuilder()->mapper()->map($class::class, [
                 'foo' => 'foo',
             ]);
         } catch (MappingError $exception) {
@@ -42,7 +41,7 @@ final class StrictMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1655231817);
         $this->expectExceptionMessage('Type `object` is too permissive.');
 
-        (new MapperBuilder())->mapper()->map('object', new stdClass());
+        $this->mapperBuilder()->mapper()->map('object', new stdClass());
     }
 
     public function test_map_to_object_containing_undefined_object_type_throws_exception(): void
@@ -51,7 +50,7 @@ final class StrictMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1655389255);
         $this->expectExceptionMessage('Error for `value` in `' . ObjectContainingUndefinedObjectType::class . ' (properties)`: Type `object` is too permissive.');
 
-        (new MapperBuilder())->mapper()->map(ObjectContainingUndefinedObjectType::class, ['value' => new stdClass()]);
+        $this->mapperBuilder()->mapper()->map(ObjectContainingUndefinedObjectType::class, ['value' => new stdClass()]);
     }
 
     public function test_map_to_type_containing_mixed_type_throws_exception(): void
@@ -60,7 +59,7 @@ final class StrictMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1655231817);
         $this->expectExceptionMessage('Type `mixed` in `array{foo: string, bar: mixed}` is too permissive.');
 
-        (new MapperBuilder())->mapper()->map('array{foo: string, bar: mixed}', ['foo' => 'foo', 'bar' => 42]);
+        $this->mapperBuilder()->mapper()->map('array{foo: string, bar: mixed}', ['foo' => 'foo', 'bar' => 42]);
     }
 
     public function test_map_to_object_containing_mixed_type_throws_exception(): void
@@ -69,13 +68,13 @@ final class StrictMappingTest extends IntegrationTestCase
         $this->expectExceptionCode(1655389255);
         $this->expectExceptionMessage('Error for `value` in `' . ObjectContainingMixedType::class . ' (properties)`: Type `mixed` in `array{foo: string, bar: mixed}` is too permissive.');
 
-        (new MapperBuilder())->mapper()->map(ObjectContainingMixedType::class, ['value' => 'foo']);
+        $this->mapperBuilder()->mapper()->map(ObjectContainingMixedType::class, ['value' => 'foo']);
     }
 
     public function test_null_that_cannot_be_cast_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('int', null);
+            $this->mapperBuilder()->mapper()->map('int', null);
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 
@@ -86,7 +85,7 @@ final class StrictMappingTest extends IntegrationTestCase
     public function test_invalid_float_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('float', 'foo');
+            $this->mapperBuilder()->mapper()->map('float', 'foo');
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 
@@ -97,7 +96,7 @@ final class StrictMappingTest extends IntegrationTestCase
     public function test_invalid_float_value_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('42.404', 1337);
+            $this->mapperBuilder()->mapper()->map('42.404', 1337);
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 
@@ -108,7 +107,7 @@ final class StrictMappingTest extends IntegrationTestCase
     public function test_invalid_integer_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('int', 'foo');
+            $this->mapperBuilder()->mapper()->map('int', 'foo');
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 
@@ -119,7 +118,7 @@ final class StrictMappingTest extends IntegrationTestCase
     public function test_invalid_integer_value_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('42', 1337);
+            $this->mapperBuilder()->mapper()->map('42', 1337);
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 
@@ -130,7 +129,7 @@ final class StrictMappingTest extends IntegrationTestCase
     public function test_invalid_integer_range_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('int<42, 1337>', 'foo');
+            $this->mapperBuilder()->mapper()->map('int<42, 1337>', 'foo');
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 
@@ -141,7 +140,7 @@ final class StrictMappingTest extends IntegrationTestCase
     public function test_invalid_enum_value_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map(PureEnum::class, 'foo');
+            $this->mapperBuilder()->mapper()->map(PureEnum::class, 'foo');
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 
@@ -152,7 +151,7 @@ final class StrictMappingTest extends IntegrationTestCase
     public function test_invalid_string_enum_value_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map(BackedStringEnum::class, new stdClass());
+            $this->mapperBuilder()->mapper()->map(BackedStringEnum::class, new stdClass());
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 
@@ -163,7 +162,7 @@ final class StrictMappingTest extends IntegrationTestCase
     public function test_invalid_integer_enum_value_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map(BackedIntegerEnum::class, false);
+            $this->mapperBuilder()->mapper()->map(BackedIntegerEnum::class, false);
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 
@@ -174,7 +173,7 @@ final class StrictMappingTest extends IntegrationTestCase
     public function test_invalid_union_value_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('bool|int|float', 'foo');
+            $this->mapperBuilder()->mapper()->map('bool|int|float', 'foo');
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 
@@ -186,7 +185,7 @@ final class StrictMappingTest extends IntegrationTestCase
     public function test_invalid_utf8_union_value_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('bool|int|float', '🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄');
+            $this->mapperBuilder()->mapper()->map('bool|int|float', '🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄');
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 
@@ -198,7 +197,7 @@ final class StrictMappingTest extends IntegrationTestCase
     public function test_null_in_union_value_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('bool|int|float', null);
+            $this->mapperBuilder()->mapper()->map('bool|int|float', null);
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 
@@ -210,7 +209,7 @@ final class StrictMappingTest extends IntegrationTestCase
     public function test_invalid_array_value_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('array<float>', 'foo');
+            $this->mapperBuilder()->mapper()->map('array<float>', 'foo');
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 
@@ -222,7 +221,7 @@ final class StrictMappingTest extends IntegrationTestCase
     public function test_invalid_list_value_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('list<float>', 'foo');
+            $this->mapperBuilder()->mapper()->map('list<float>', 'foo');
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 
@@ -234,7 +233,7 @@ final class StrictMappingTest extends IntegrationTestCase
     public function test_invalid_shaped_array_value_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('array{foo: string}', 'foo');
+            $this->mapperBuilder()->mapper()->map('array{foo: string}', 'foo');
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 
@@ -246,7 +245,7 @@ final class StrictMappingTest extends IntegrationTestCase
     public function test_invalid_shaped_array_with_object_value_throws_exception(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map('array{foo: stdClass}', 'foo');
+            $this->mapperBuilder()->mapper()->map('array{foo: stdClass}', 'foo');
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 

--- a/tests/Integration/Mapping/Other/SuperfluousKeysMappingTest.php
+++ b/tests/Integration/Mapping/Other/SuperfluousKeysMappingTest.php
@@ -6,7 +6,6 @@ namespace CuyZ\Valinor\Tests\Integration\Mapping\Other;
 
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Mapper\TreeMapper;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
 final class SuperfluousKeysMappingTest extends IntegrationTestCase
@@ -17,7 +16,7 @@ final class SuperfluousKeysMappingTest extends IntegrationTestCase
     {
         parent::setUp();
 
-        $this->mapper = (new MapperBuilder())->allowSuperfluousKeys()->mapper();
+        $this->mapper = $this->mapperBuilder()->allowSuperfluousKeys()->mapper();
     }
 
     public function test_superfluous_shaped_array_values_are_mapped_properly(): void

--- a/tests/Integration/Mapping/ReadonlyMappingTest.php
+++ b/tests/Integration/Mapping/ReadonlyMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
 final class ReadonlyMappingTest extends IntegrationTestCase
@@ -17,7 +16,7 @@ final class ReadonlyMappingTest extends IntegrationTestCase
         };
 
         try {
-            $object = (new MapperBuilder())->mapper()->map($class::class, 'foo');
+            $object = $this->mapperBuilder()->mapper()->map($class::class, 'foo');
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }

--- a/tests/Integration/Mapping/SingleNodeMappingTest.php
+++ b/tests/Integration/Mapping/SingleNodeMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -19,7 +18,7 @@ final class SingleNodeMappingTest extends IntegrationTestCase
     public function test_single_property_and_constructor_parameter_are_mapped_properly(string $className, mixed $value): void
     {
         try {
-            $result = (new MapperBuilder())->mapper()->map($className, $value);
+            $result = $this->mapperBuilder()->mapper()->map($className, $value);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }
@@ -34,7 +33,7 @@ final class SingleNodeMappingTest extends IntegrationTestCase
     public function test_single_property_and_constructor_parameter_with_default_value_are_mapped_properly(string $className): void
     {
         try {
-            $result = (new MapperBuilder())->mapper()->map($className, ['foo' => []]);
+            $result = $this->mapperBuilder()->mapper()->map($className, ['foo' => []]);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }
@@ -49,7 +48,7 @@ final class SingleNodeMappingTest extends IntegrationTestCase
     public function test_single_property_and_constructor_parameter_can_be_mapped_with_array_with_property_name(string $className, mixed $value): void
     {
         try {
-            $result = (new MapperBuilder())->mapper()->map($className, ['value' => $value]);
+            $result = $this->mapperBuilder()->mapper()->map($className, ['value' => $value]);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }
@@ -60,7 +59,7 @@ final class SingleNodeMappingTest extends IntegrationTestCase
     public function test_single_argument_invalid_value_with_key_present_in_source_keeps_path_in_error_nodes(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map(SimpleObject::class, ['value' => 42]);
+            $this->mapperBuilder()->mapper()->map(SimpleObject::class, ['value' => 42]);
         } catch (MappingError $exception) {
             $error = $exception->node()->children()['value']->messages()[0];
 
@@ -71,7 +70,7 @@ final class SingleNodeMappingTest extends IntegrationTestCase
     public function test_single_argument_invalid_value_with_key_not_present_in_source_does_not_keep_path_in_error_nodes(): void
     {
         try {
-            (new MapperBuilder())->mapper()->map(SimpleObject::class, 42);
+            $this->mapperBuilder()->mapper()->map(SimpleObject::class, 42);
         } catch (MappingError $exception) {
             $error = $exception->node()->messages()[0];
 

--- a/tests/Integration/Mapping/Source/JsonSourceMappingTest.php
+++ b/tests/Integration/Mapping/Source/JsonSourceMappingTest.php
@@ -6,7 +6,6 @@ namespace CuyZ\Valinor\Tests\Integration\Mapping\Source;
 
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Mapper\Source\JsonSource;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
 final class JsonSourceMappingTest extends IntegrationTestCase
@@ -20,7 +19,7 @@ final class JsonSourceMappingTest extends IntegrationTestCase
         };
 
         try {
-            $object = (new MapperBuilder())->mapper()->map(
+            $object = $this->mapperBuilder()->mapper()->map(
                 $class::class,
                 new JsonSource('{"foo": "foo", "bar": "bar"}')
             );

--- a/tests/Integration/Mapping/Source/Modifier/CamelCaseKeysMappingTest.php
+++ b/tests/Integration/Mapping/Source/Modifier/CamelCaseKeysMappingTest.php
@@ -6,7 +6,6 @@ namespace CuyZ\Valinor\Tests\Integration\Mapping\Source\Modifier;
 
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Mapper\Source\Modifier\CamelCaseKeys;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\ObjectWithSubProperties;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -20,7 +19,7 @@ final class CamelCaseKeysMappingTest extends IntegrationTestCase
     public function test_sources_are_mapped_properly(iterable $source): void
     {
         try {
-            $object = (new MapperBuilder())->mapper()->map(ObjectWithSubProperties::class, $source);
+            $object = $this->mapperBuilder()->mapper()->map(ObjectWithSubProperties::class, $source);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }

--- a/tests/Integration/Mapping/Source/Modifier/PathMappingTest.php
+++ b/tests/Integration/Mapping/Source/Modifier/PathMappingTest.php
@@ -6,7 +6,6 @@ namespace CuyZ\Valinor\Tests\Integration\Mapping\Source\Modifier;
 
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Mapper\Source\Modifier\PathMapping;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\Country;
 
@@ -47,7 +46,7 @@ final class PathMappingTest extends IntegrationTestCase
         ]);
 
         try {
-            $countries = (new MapperBuilder())->mapper()->map('list<' . Country::class . '>', $source);
+            $countries = $this->mapperBuilder()->mapper()->map('list<' . Country::class . '>', $source);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }

--- a/tests/Integration/Mapping/Source/SourceTest.php
+++ b/tests/Integration/Mapping/Source/SourceTest.php
@@ -6,7 +6,6 @@ namespace CuyZ\Valinor\Tests\Integration\Mapping\Source;
 
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Mapper\Source\Source;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\ObjectWithSubProperties;
 use IteratorAggregate;
@@ -22,7 +21,7 @@ final class SourceTest extends IntegrationTestCase
     public function test_sources_are_mapped_properly(iterable $source): void
     {
         try {
-            $object = (new MapperBuilder())->mapper()->map(ObjectWithSubProperties::class, $source);
+            $object = $this->mapperBuilder()->mapper()->map(ObjectWithSubProperties::class, $source);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }

--- a/tests/Integration/Mapping/Source/YamlSourceMappingTest.php
+++ b/tests/Integration/Mapping/Source/YamlSourceMappingTest.php
@@ -6,7 +6,6 @@ namespace CuyZ\Valinor\Tests\Integration\Mapping\Source;
 
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Mapper\Source\YamlSource;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 
@@ -22,7 +21,7 @@ final class YamlSourceMappingTest extends IntegrationTestCase
         };
 
         try {
-            $object = (new MapperBuilder())->mapper()->map(
+            $object = $this->mapperBuilder()->mapper()->map(
                 $class::class,
                 new YamlSource("foo: foo\nbar: bar")
             );

--- a/tests/Integration/Mapping/UnionMappingTest.php
+++ b/tests/Integration/Mapping/UnionMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\City;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject;
@@ -15,7 +14,7 @@ final class UnionMappingTest extends IntegrationTestCase
     public function test_union_with_int_or_object(): void
     {
         try {
-            $array = (new MapperBuilder())->mapper()->map("list<int|" . SimpleObject::class . ">", [123, "foo"]);
+            $array = $this->mapperBuilder()->mapper()->map("list<int|" . SimpleObject::class . ">", [123, "foo"]);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }
@@ -27,7 +26,7 @@ final class UnionMappingTest extends IntegrationTestCase
     public function test_union_with_string_or_object_prioritizes_string(): void
     {
         try {
-            $array = (new MapperBuilder())
+            $array = $this->mapperBuilder()
                 ->mapper()
                 ->map("list<string|" . SimpleObject::class . ">", ["foo", "bar", "baz"]);
         } catch (MappingError $error) {
@@ -40,7 +39,7 @@ final class UnionMappingTest extends IntegrationTestCase
     public function test_union_with_string_literal_or_object_prioritizes_string_literal(): void
     {
         try {
-            $array = (new MapperBuilder())
+            $array = $this->mapperBuilder()
                 ->mapper()
                 ->map("list<'foo'|" . SimpleObject::class . "|'bar'>", ["foo", "bar", "baz"]);
         } catch (MappingError $error) {
@@ -55,7 +54,7 @@ final class UnionMappingTest extends IntegrationTestCase
     public function test_union_of_objects(): void
     {
         try {
-            $array = (new MapperBuilder())
+            $array = $this->mapperBuilder()
                 ->mapper()
                 ->map(
                     "list<" . SimpleObject::class . "|" . City::class . ">",

--- a/tests/Integration/Mapping/ValueAlteringMappingTest.php
+++ b/tests/Integration/Mapping/ValueAlteringMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject;
 
@@ -17,7 +16,7 @@ final class ValueAlteringMappingTest extends IntegrationTestCase
     public function test_alter_string_alters_value(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->alter(fn () => 'bar')
                 ->alter(fn (string $value) => strtolower($value))
                 ->alter(fn (string $value) => strtoupper($value))
@@ -35,7 +34,7 @@ final class ValueAlteringMappingTest extends IntegrationTestCase
     public function test_value_not_accepted_by_value_altering_callback_is_not_used(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->alter(fn (string $value) => $value)
                 ->mapper()
                 ->map('string|null', null);
@@ -49,7 +48,7 @@ final class ValueAlteringMappingTest extends IntegrationTestCase
     public function test_alter_function_is_called_when_not_the_first_nor_the_last_one(): void
     {
         try {
-            $result = (new MapperBuilder())
+            $result = $this->mapperBuilder()
                 ->alter(fn (int $value) => 404)
                 ->alter(fn (string $value) => $value . '!')
                 ->alter(fn (float $value) => 42.1337)

--- a/tests/Integration/Mapping/VariadicParameterMappingTest.php
+++ b/tests/Integration/Mapping/VariadicParameterMappingTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
 final class VariadicParameterMappingTest extends IntegrationTestCase
@@ -13,7 +12,7 @@ final class VariadicParameterMappingTest extends IntegrationTestCase
     public function test_only_variadic_parameters_are_mapped_properly(): void
     {
         try {
-            $object = (new MapperBuilder())->mapper()->map(SomeClassWithOnlyVariadicParameters::class, ['foo', 'bar', 'baz']);
+            $object = $this->mapperBuilder()->mapper()->map(SomeClassWithOnlyVariadicParameters::class, ['foo', 'bar', 'baz']);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }
@@ -24,7 +23,7 @@ final class VariadicParameterMappingTest extends IntegrationTestCase
     public function test_variadic_parameters_are_mapped_properly_when_string_keys_are_given(): void
     {
         try {
-            $object = (new MapperBuilder())->mapper()->map(SomeClassWithOnlyVariadicParameters::class, [
+            $object = $this->mapperBuilder()->mapper()->map(SomeClassWithOnlyVariadicParameters::class, [
                 'foo' => 'foo',
                 'bar' => 'bar',
                 'baz' => 'baz',
@@ -39,7 +38,7 @@ final class VariadicParameterMappingTest extends IntegrationTestCase
     public function test_constructor_with_variadic_parameters_with_dots_in_dot_blocks_are_defined_properly(): void
     {
         try {
-            (new MapperBuilder())
+            $this->mapperBuilder()
                 ->mapper()
                 ->map(SomeClassWithVariadicParametersInDocBlock::class, ['']);
         } catch (MappingError $exception) {
@@ -52,7 +51,7 @@ final class VariadicParameterMappingTest extends IntegrationTestCase
     public function test_non_variadic_and_variadic_parameters_are_mapped_properly(): void
     {
         try {
-            $object = (new MapperBuilder())->mapper()->map(SomeClassWithNonVariadicAndVariadicParameters::class, [
+            $object = $this->mapperBuilder()->mapper()->map(SomeClassWithNonVariadicAndVariadicParameters::class, [
                 'int' => 42,
                 'values' => ['foo', 'bar', 'baz'],
             ]);
@@ -67,7 +66,7 @@ final class VariadicParameterMappingTest extends IntegrationTestCase
     public function test_named_constructor_with_non_variadic_and_variadic_parameters_are_mapped_properly(): void
     {
         try {
-            $object = (new MapperBuilder())
+            $object = $this->mapperBuilder()
                 ->registerConstructor(SomeClassWithNamedConstructorWithNonVariadicAndVariadicParameters::new(...))
                 ->mapper()
                 ->map(SomeClassWithNamedConstructorWithNonVariadicAndVariadicParameters::class, [

--- a/tests/Integration/Normalizer/CommonExamples/CustomObjectNormalizationTest.php
+++ b/tests/Integration/Normalizer/CommonExamples/CustomObjectNormalizationTest.php
@@ -4,17 +4,16 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Integration\Normalizer\CommonExamples;
 
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Normalizer\Format;
-use PHPUnit\Framework\TestCase;
+use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
 use function dechex;
 
-final class CustomObjectNormalizationTest extends TestCase
+final class CustomObjectNormalizationTest extends IntegrationTestCase
 {
     public function test_custom_object_normalization_works_properly(): void
     {
-        $result = (new MapperBuilder())
+        $result = $this->mapperBuilder()
             ->registerTransformer(
                 fn (HasCustomNormalization $object) => $object->normalize(),
             )

--- a/tests/Integration/Normalizer/CommonExamples/DateFormatFromAttributeTest.php
+++ b/tests/Integration/Normalizer/CommonExamples/DateFormatFromAttributeTest.php
@@ -5,17 +5,16 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Normalizer\CommonExamples;
 
 use Attribute;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Normalizer\Format;
+use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use DateTimeImmutable;
 use DateTimeInterface;
-use PHPUnit\Framework\TestCase;
 
-final class DateFormatFromAttributeTest extends TestCase
+final class DateFormatFromAttributeTest extends IntegrationTestCase
 {
     public function test_date_format_attribute_works_properly(): void
     {
-        $result = (new MapperBuilder())
+        $result = $this->mapperBuilder()
             ->registerTransformer(DateTimeFormat::class)
             ->normalizer(Format::array())
             ->normalize(new class (

--- a/tests/Integration/Normalizer/CommonExamples/DateFormatFromGlobalTransformerTest.php
+++ b/tests/Integration/Normalizer/CommonExamples/DateFormatFromGlobalTransformerTest.php
@@ -4,17 +4,16 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Integration\Normalizer\CommonExamples;
 
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Normalizer\Format;
+use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use DateTimeImmutable;
 use DateTimeInterface;
-use PHPUnit\Framework\TestCase;
 
-final class DateFormatFromGlobalTransformerTest extends TestCase
+final class DateFormatFromGlobalTransformerTest extends IntegrationTestCase
 {
     public function test_date_format_from_global_transformer_works_properly(): void
     {
-        $result = (new MapperBuilder())
+        $result = $this->mapperBuilder()
             ->registerTransformer(
                 fn (DateTimeInterface $date) => $date->format('Y/m/d'),
             )

--- a/tests/Integration/Normalizer/CommonExamples/IgnoreAttributeTest.php
+++ b/tests/Integration/Normalizer/CommonExamples/IgnoreAttributeTest.php
@@ -5,15 +5,14 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Normalizer\CommonExamples;
 
 use Attribute;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Normalizer\Format;
-use PHPUnit\Framework\TestCase;
+use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
-final class IgnoreAttributeTest extends TestCase
+final class IgnoreAttributeTest extends IntegrationTestCase
 {
     public function test_ignore_attribute_works_properly(): void
     {
-        $result = (new MapperBuilder())
+        $result = $this->mapperBuilder()
             ->registerTransformer(
                 fn (object $value, callable $next) => array_filter(
                     $next(),

--- a/tests/Integration/Normalizer/CommonExamples/ObjectKeysToSnakeCaseFromAttributeTest.php
+++ b/tests/Integration/Normalizer/CommonExamples/ObjectKeysToSnakeCaseFromAttributeTest.php
@@ -5,15 +5,14 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Normalizer\CommonExamples;
 
 use Attribute;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Normalizer\Format;
-use PHPUnit\Framework\TestCase;
+use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
-final class ObjectKeysToSnakeCaseFromAttributeTest extends TestCase
+final class ObjectKeysToSnakeCaseFromAttributeTest extends IntegrationTestCase
 {
     public function test_object_keys_are_converted_to_snake_case(): void
     {
-        $result = (new MapperBuilder())
+        $result = $this->mapperBuilder()
             ->registerTransformer(SnakeCaseProperties::class)
             ->normalizer(Format::array())
             ->normalize(new #[SnakeCaseProperties] class () {

--- a/tests/Integration/Normalizer/CommonExamples/ObjectKeysToSnakeCaseTest.php
+++ b/tests/Integration/Normalizer/CommonExamples/ObjectKeysToSnakeCaseTest.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Integration\Normalizer\CommonExamples;
 
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Normalizer\Format;
-use PHPUnit\Framework\TestCase;
+use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
-final class ObjectKeysToSnakeCaseTest extends TestCase
+final class ObjectKeysToSnakeCaseTest extends IntegrationTestCase
 {
     public function test_object_keys_are_converted_to_snake_case(): void
     {
-        $result = (new MapperBuilder())
+        $result = $this->mapperBuilder()
             ->registerTransformer(
                 function (object $object, callable $next) {
                     $result = [];

--- a/tests/Integration/Normalizer/CommonExamples/RenamePropertyFromAttributeTest.php
+++ b/tests/Integration/Normalizer/CommonExamples/RenamePropertyFromAttributeTest.php
@@ -5,15 +5,14 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Normalizer\CommonExamples;
 
 use Attribute;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Normalizer\Format;
-use PHPUnit\Framework\TestCase;
+use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
-final class RenamePropertyFromAttributeTest extends TestCase
+final class RenamePropertyFromAttributeTest extends IntegrationTestCase
 {
     public function test_rename_attribute_works_properly(): void
     {
-        $result = (new MapperBuilder())
+        $result = $this->mapperBuilder()
             ->registerTransformer(Rename::class)
             ->normalizer(Format::array())
             ->normalize(new class () {

--- a/tests/Integration/Normalizer/CommonExamples/UppercaseFromAttributeTest.php
+++ b/tests/Integration/Normalizer/CommonExamples/UppercaseFromAttributeTest.php
@@ -5,15 +5,14 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Normalizer\CommonExamples;
 
 use Attribute;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Normalizer\Format;
-use PHPUnit\Framework\TestCase;
+use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
-final class UppercaseFromAttributeTest extends TestCase
+final class UppercaseFromAttributeTest extends IntegrationTestCase
 {
     public function test_uppercase_attribute_works_properly(): void
     {
-        $result = (new MapperBuilder())
+        $result = $this->mapperBuilder()
             ->registerTransformer(Uppercase::class)
             ->normalizer(Format::array())
             ->normalize(new class () {

--- a/tests/Integration/Normalizer/CommonExamples/VersionTransformerTest.php
+++ b/tests/Integration/Normalizer/CommonExamples/VersionTransformerTest.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Integration\Normalizer\CommonExamples;
 
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Normalizer\Format;
-use PHPUnit\Framework\TestCase;
+use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
-final class VersionTransformerTest extends TestCase
+final class VersionTransformerTest extends IntegrationTestCase
 {
     public function test_version_transformer_works_properly(): void
     {
-        $normalizeWithVersion = fn (string $version) => (new MapperBuilder())
+        $normalizeWithVersion = fn (string $version) => $this->mapperBuilder()
             ->registerTransformer(
                 fn (HasVersionedNormalization $object, callable $next) => $object->normalizeWithVersion($version, $next),
             )

--- a/tests/Integration/Normalizer/StreamNormalizerTest.php
+++ b/tests/Integration/Normalizer/StreamNormalizerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Integration\Normalizer;
 
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Normalizer\Format;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 
@@ -18,7 +17,7 @@ final class StreamNormalizerTest extends IntegrationTestCase
         /** @var resource $resource */
         $resource = fopen('php://memory', 'r+');
 
-        (new MapperBuilder())
+        $this->mapperBuilder()
             ->normalizer(Format::json())
             ->streamTo($resource)
             ->normalize(['foo' => 'bar']);


### PR DESCRIPTION
This allows us to test the exact same test cases and assertions, but with a completely different code path (as the file cache is used only in one scenario).