### PR TITLE
feat: introduce `Constructor` attribute

### DIFF
--- a/docs/pages/serialization/extending-normalizer.md
+++ b/docs/pages/serialization/extending-normalizer.md
@@ -9,7 +9,7 @@ A transformer can be a callable (function, closure or a class implementing the
 
 !!! note
     You can find common examples of transformers in the [next
-    chapter](common-examples.md).
+    chapter](common-transformers-examples.md).
 
 ## Callable transformers
 

--- a/src/Definition/MethodDefinition.php
+++ b/src/Definition/MethodDefinition.php
@@ -14,6 +14,7 @@ final class MethodDefinition
         public readonly string $name,
         /** @var non-empty-string */
         public readonly string $signature,
+        public readonly Attributes $attributes,
         public readonly Parameters $parameters,
         public readonly bool $isStatic,
         public readonly bool $isPublic,

--- a/src/Definition/Repository/Cache/Compiler/MethodDefinitionCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/MethodDefinitionCompiler.php
@@ -14,16 +14,21 @@ final class MethodDefinitionCompiler
 {
     private TypeCompiler $typeCompiler;
 
+    private AttributesCompiler $attributesCompiler;
+
     private ParameterDefinitionCompiler $parameterCompiler;
 
     public function __construct(TypeCompiler $typeCompiler, AttributesCompiler $attributesCompiler)
     {
         $this->typeCompiler = $typeCompiler;
+        $this->attributesCompiler = $attributesCompiler;
         $this->parameterCompiler = new ParameterDefinitionCompiler($typeCompiler, $attributesCompiler);
     }
 
     public function compile(MethodDefinition $method): string
     {
+        $attributes = $this->attributesCompiler->compile($method->attributes);
+
         $parameters = array_map(
             fn (ParameterDefinition $parameter) => $this->parameterCompiler->compile($parameter),
             iterator_to_array($method->parameters)
@@ -38,6 +43,7 @@ final class MethodDefinitionCompiler
             new \CuyZ\Valinor\Definition\MethodDefinition(
                 '{$method->name}',
                 '{$method->signature}',
+                $attributes,
                 new \CuyZ\Valinor\Definition\Parameters($parameters),
                 $isStatic,
                 $isPublic,

--- a/src/Definition/Repository/Reflection/ReflectionMethodDefinitionBuilder.php
+++ b/src/Definition/Repository/Reflection/ReflectionMethodDefinitionBuilder.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Definition\Repository\Reflection;
 
+use CuyZ\Valinor\Definition\Attributes;
 use CuyZ\Valinor\Definition\MethodDefinition;
 use CuyZ\Valinor\Definition\Parameters;
 use CuyZ\Valinor\Definition\Repository\AttributesRepository;
 use CuyZ\Valinor\Utility\Reflection\Reflection;
+use ReflectionAttribute;
 use ReflectionMethod;
 use ReflectionParameter;
 
@@ -16,10 +18,13 @@ use function array_map;
 /** @internal */
 final class ReflectionMethodDefinitionBuilder
 {
+    private AttributesRepository $attributesRepository;
+
     private ReflectionParameterDefinitionBuilder $parameterBuilder;
 
     public function __construct(AttributesRepository $attributesRepository)
     {
+        $this->attributesRepository = $attributesRepository;
         $this->parameterBuilder = new ReflectionParameterDefinitionBuilder($attributesRepository);
     }
 
@@ -27,6 +32,11 @@ final class ReflectionMethodDefinitionBuilder
     {
         /** @var non-empty-string $name */
         $name = $reflection->name;
+
+        $attributes = array_map(
+            fn (ReflectionAttribute $attribute) => $this->attributesRepository->for($attribute),
+            Reflection::attributes($reflection)
+        );
 
         $parameters = array_map(
             fn (ReflectionParameter $parameter) => $this->parameterBuilder->for($parameter, $typeResolver),
@@ -38,6 +48,7 @@ final class ReflectionMethodDefinitionBuilder
         return new MethodDefinition(
             $name,
             Reflection::signature($reflection),
+            new Attributes(...$attributes),
             new Parameters(...$parameters),
             $reflection->isStatic(),
             $reflection->isPublic(),

--- a/src/Mapper/Object/Constructor.php
+++ b/src/Mapper/Object/Constructor.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Object;
+
+use Attribute;
+
+/**
+ * This attribute allows a static method inside a class to be marked as a
+ * constructor, that can be used by the mapper to instantiate the object. The
+ * method must be public, static and return an instance of the class it is part
+ * of.
+ *
+ * This attribute is a convenient replacement to the usage of the constructor
+ * registration method: @see \CuyZ\Valinor\MapperBuilder::registerConstructor()
+ *
+ * ```php
+ * final readonly class Email
+ * {
+ *     // When another constructor is registered for the class, the native
+ *     // constructor is disabled. To enable it again, it is mandatory to
+ *     // explicitly register it again.
+ *     #[\CuyZ\Valinor\Mapper\Object\Constructor]
+ *     public function __construct(public string $value) {}
+ *
+ *     #[\CuyZ\Valinor\Mapper\Object\Constructor]
+ *     public static function createFrom(string $user, string $domainName): self
+ *     {
+ *         return new self($user . '@' . $domainName);
+ *     }
+ * }
+ *
+ * (new \CuyZ\Valinor\MapperBuilder())
+ *     ->mapper()
+ *     ->map(Email::class, [
+ *         'userName' => 'john.doe',
+ *         'domainName' => 'example.com',
+ *     ]); // john.doe@example.com
+ * ```
+ *
+ * @api
+ */
+#[Attribute(Attribute::TARGET_METHOD)]
+final class Constructor {}

--- a/src/Mapper/Object/Exception/InvalidConstructorMethodWithAttributeReturnType.php
+++ b/src/Mapper/Object/Exception/InvalidConstructorMethodWithAttributeReturnType.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Object\Exception;
+
+use CuyZ\Valinor\Definition\MethodDefinition;
+use CuyZ\Valinor\Type\Types\UnresolvableType;
+use LogicException;
+
+/** @internal */
+final class InvalidConstructorMethodWithAttributeReturnType extends LogicException
+{
+    /**
+     * @param class-string $expectedClassName
+     */
+    public function __construct(string $expectedClassName, MethodDefinition $method)
+    {
+        if ($method->returnType instanceof UnresolvableType) {
+            $message = $method->returnType->message();
+        } else {
+            $message = "Invalid return type `{$method->returnType->toString()}` for constructor `{$method->signature}`, it must be `$expectedClassName`.";
+        }
+
+        parent::__construct($message, 1708104783);
+    }
+}

--- a/src/Mapper/Object/FilteredObjectBuilder.php
+++ b/src/Mapper/Object/FilteredObjectBuilder.php
@@ -9,6 +9,7 @@ use CuyZ\Valinor\Mapper\Object\Exception\SeveralObjectBuildersFound;
 
 use function count;
 use function is_array;
+use function reset;
 
 /** @internal */
 final class FilteredObjectBuilder implements ObjectBuilder
@@ -41,7 +42,7 @@ final class FilteredObjectBuilder implements ObjectBuilder
     private function filterBuilder(mixed $source, ObjectBuilder ...$builders): ObjectBuilder
     {
         if (count($builders) === 1) {
-            return $builders[0];
+            return reset($builders);
         }
 
         /** @var non-empty-list<ObjectBuilder> $builders */

--- a/tests/Fake/Definition/FakeMethodDefinition.php
+++ b/tests/Fake/Definition/FakeMethodDefinition.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Fake\Definition;
 
+use CuyZ\Valinor\Definition\Attributes;
 use CuyZ\Valinor\Definition\MethodDefinition;
 use CuyZ\Valinor\Definition\Parameters;
 use CuyZ\Valinor\Tests\Fake\Type\FakeType;
@@ -25,6 +26,7 @@ final class FakeMethodDefinition
         return new MethodDefinition(
             $name,
             $name,
+            new Attributes(),
             new Parameters(),
             false,
             true,
@@ -55,6 +57,7 @@ final class FakeMethodDefinition
         return new MethodDefinition(
             $name,
             'Signature::' . $reflection->name,
+            new Attributes(),
             new Parameters(...$parameters),
             $reflection->isStatic(),
             $reflection->isPublic(),

--- a/tests/Integration/Mapping/ConstructorAttributeMappingTest.php
+++ b/tests/Integration/Mapping/ConstructorAttributeMappingTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Mapping;
+
+use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\Mapper\Object\Constructor;
+use CuyZ\Valinor\Mapper\Object\Exception\InvalidConstructorMethodWithAttributeReturnType;
+use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
+use stdClass;
+
+final class ConstructorAttributeMappingTest extends IntegrationTestCase
+{
+    public function test_can_map_class_with_constructor_method_with_attribute(): void
+    {
+        try {
+            $result = $this->mapperBuilder()
+                ->mapper()
+                ->map(SomeClassWithConstructorAttribute::class, 'foo');
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame('foo', $result->value());
+    }
+
+    public function test_can_map_class_with_inherited_constructor_method_with_attribute(): void
+    {
+        try {
+            $result = $this->mapperBuilder()
+                ->mapper()
+                ->map(SomeClassWithInheritedConstructorAttribute::class, 'foo');
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame('foo', $result->value());
+    }
+
+    public function test_can_map_class_with_attribute_on_native_constructor_and_static_factory(): void
+    {
+        try {
+            $result = $this->mapperBuilder()
+                ->mapper()
+                ->map(SomeClassWithConstructorAttributeOnNativeConstructorAndStaticFactory::class, 'foo');
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame('foo', $result->valueA());
+    }
+
+    public function test_constructor_registered_both_with_attribute_and_explicit_registration_does_not_provoke_collision(): void
+    {
+        try {
+            $result = $this->mapperBuilder()
+                ->registerConstructor(SomeClassWithConstructorAttribute::someConstructor(...))
+                ->mapper()
+                ->map(SomeClassWithConstructorAttribute::class, 'foo');
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame('foo', $result->value());
+    }
+
+    public function test_map_class_with_constructor_with_attribute_with_invalid_return_type_throws_exception(): void
+    {
+        $className = SomeClassWithConstructorAttributeWithInvalidReturnType::class;
+
+        $this->expectException(InvalidConstructorMethodWithAttributeReturnType::class);
+        $this->expectExceptionCode(1708104783);
+        $this->expectExceptionMessage("Invalid return type `string` for constructor `$className::someConstructor()`, it must be `$className`.");
+
+        $this->mapperBuilder()
+            ->mapper()
+            ->map($className, 'foo');
+    }
+
+    public function test_map_class_with_constructor_with_attribute_with_invalid_return_class_name_throws_exception(): void
+    {
+        $className = SomeClassWithConstructorAttributeWithInvalidReturnClassName::class;
+
+        $this->expectException(InvalidConstructorMethodWithAttributeReturnType::class);
+        $this->expectExceptionCode(1708104783);
+        $this->expectExceptionMessage("Invalid return type `stdClass` for constructor `$className::someConstructor()`, it must be `$className`.");
+
+        $this->mapperBuilder()
+            ->mapper()
+            ->map($className, 'foo');
+    }
+
+    public function test_map_class_with_constructor_with_attribute_with_unresolvable_return_type_throws_exception(): void
+    {
+        $className = SomeClassWithConstructorAttributeWithUnresolvableReturnClassName::class;
+
+        $this->expectException(InvalidConstructorMethodWithAttributeReturnType::class);
+        $this->expectExceptionCode(1708104783);
+        $this->expectExceptionMessage("The type `Unresolvable-Type` for return type of method `$className::someConstructor()` could not be resolved: Cannot parse unknown symbol `Unresolvable-Type`.");
+
+        $this->mapperBuilder()
+            ->mapper()
+            ->map($className, 'foo');
+    }
+}
+
+class SomeClassWithConstructorAttribute
+{
+    final private function __construct(private string $value) {}
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    public static function someUnrelatedStaticMethod(): void {}
+
+    #[Constructor]
+    public static function someConstructor(string $value): self
+    {
+        return new static($value);
+    }
+}
+
+final class SomeClassWithInheritedConstructorAttribute extends SomeClassWithConstructorAttribute {}
+
+final class SomeClassWithConstructorAttributeOnNativeConstructorAndStaticFactory
+{
+    private string $valueA;
+
+    private string $valueB;
+
+    #[Constructor]
+    public function __construct(string $value)
+    {
+        $this->valueA = $value;
+        $this->valueB = 'default';
+    }
+
+    #[Constructor]
+    public static function from(string $valueA, string $valueB): self
+    {
+        $instance = new self($valueA);
+        $instance->valueB = $valueB;
+
+        return $instance;
+    }
+
+    public function valueA(): string
+    {
+        return $this->valueA;
+    }
+
+    public function valueB(): string
+    {
+        return $this->valueB;
+    }
+}
+
+final class SomeClassWithConstructorAttributeWithInvalidReturnType
+{
+    #[Constructor]
+    public static function someConstructor(): string
+    {
+        return 'foo';
+    }
+}
+
+final class SomeClassWithConstructorAttributeWithInvalidReturnClassName
+{
+    #[Constructor]
+    public static function someConstructor(): stdClass
+    {
+        return new stdClass();
+    }
+}
+
+final class SomeClassWithConstructorAttributeWithUnresolvableReturnClassName
+{
+    /**
+     * @phpstan-ignore-next-line
+     * @return Unresolvable-Type
+     */
+    #[Constructor]
+    public static function someConstructor() {}
+}

--- a/tests/Integration/Mapping/EnumConstructorAttributeMappingTest.php
+++ b/tests/Integration/Mapping/EnumConstructorAttributeMappingTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Mapping;
+
+use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\Mapper\Object\Constructor;
+use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
+
+final class EnumConstructorAttributeMappingTest extends IntegrationTestCase
+{
+    public function test_can_map_enum_with_native_constructor_when_other_constructors_with_attributes_have_patterns(): void
+    {
+        try {
+            $result = $this->mapperBuilder()
+                ->mapper()
+                ->map(SomeEnumWithConstructorAttribute::class, 'FOO');
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame(SomeEnumWithConstructorAttribute::FOO, $result);
+    }
+
+    public function test_can_map_enum_with_constructor_method_with_attribute_and_pattern(): void
+    {
+        try {
+            $result = $this->mapperBuilder()
+                ->mapper()
+                ->map(SomeEnumWithConstructorAttribute::class . '::BA*', 'Z');
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame(SomeEnumWithConstructorAttribute::BAZ, $result);
+    }
+}
+
+enum SomeEnumWithConstructorAttribute: string
+{
+    case FOO = 'FOO';
+    case FOZ = 'FOZ';
+    case BAR = 'BAR';
+    case BAZ = 'BAZ';
+
+    /**
+     * @return self::FO*
+     */
+    #[Constructor]
+    public static function someConstructorWithFoPattern(string $value): self
+    {
+        /** @var self::FO* */
+        return self::from('FO' . $value);
+    }
+
+    /**
+     * @return self::BA*
+     */
+    #[Constructor]
+    public static function someConstructorWithBaPattern(string $value): self
+    {
+        /** @var self::BA* */
+        return self::from('BA' . $value);
+    }
+}

--- a/tests/Unit/Definition/MethodDefinitionTest.php
+++ b/tests/Unit/Definition/MethodDefinitionTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Unit\Definition;
 
+use CuyZ\Valinor\Definition\Attributes;
 use CuyZ\Valinor\Definition\MethodDefinition;
 use CuyZ\Valinor\Definition\Parameters;
+use CuyZ\Valinor\Tests\Fake\Definition\FakeAttributeDefinition;
 use CuyZ\Valinor\Tests\Fake\Definition\FakeParameterDefinition;
 use CuyZ\Valinor\Tests\Fake\Type\FakeType;
 use PHPUnit\Framework\TestCase;
@@ -16,6 +18,7 @@ final class MethodDefinitionTest extends TestCase
     {
         $name = 'someMethod';
         $signature = 'someMethodSignature';
+        $attributes = new Attributes(FakeAttributeDefinition::new());
         $parameters = new Parameters(FakeParameterDefinition::new());
         $isStatic = false;
         $isPublic = true;
@@ -24,6 +27,7 @@ final class MethodDefinitionTest extends TestCase
         $method = new MethodDefinition(
             $name,
             $signature,
+            $attributes,
             $parameters,
             $isStatic,
             $isPublic,
@@ -32,6 +36,7 @@ final class MethodDefinitionTest extends TestCase
 
         self::assertSame($name, $method->name);
         self::assertSame($signature, $method->signature);
+        self::assertSame($attributes, $method->attributes);
         self::assertSame($parameters, $method->parameters);
         self::assertSame($isStatic, $method->isStatic);
         self::assertSame($isPublic, $method->isPublic);


### PR DESCRIPTION
This attribute can be assigned to any method inside an object, to automatically mark the method as a constructor for the class. This is a more convenient way of registering constructors than using the `MapperBuilder::registerConstructor` method, although it does not replace it.

The method targeted by a `Constructor` attribute must be public, static and return an instance of the class it is part of.

```php
final readonly class Email
{
    // When another constructor is registered for the class, the native
    // constructor is disabled. To enable it again, it is mandatory to
    // explicitly register it again.
    #[\CuyZ\Valinor\Mapper\Object\Constructor]
    public function __construct(public string $value) {}

    #[\CuyZ\Valinor\Mapper\Object\Constructor]
    public static function createFrom(
        string $userName, string $domainName
    ): self {
        return new self($userName . '@' . $domainName);
    }
}

(new \CuyZ\Valinor\MapperBuilder())
    ->mapper()
    ->map(Email::class, [
        'userName' => 'john.doe',
        'domainName' => 'example.com',
    ]); // john.doe@example.com
```

--- 

Fixes #99