### PR TITLE
Failing test case: Valinor cannot understand `array{k: T|list<T>}`

### DIFF
--- a/tests/Integration/Mapping/Fixture/SimpleObjectWithConstructor.php
+++ b/tests/Integration/Mapping/Fixture/SimpleObjectWithConstructor.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Mapping\Fixture;
+
+final class SimpleObjectWithConstructor
+{
+    public function __construct(public readonly string $value)
+    {
+    }
+}

--- a/tests/Integration/Mapping/Fixture/SimpleObjectWithConstructor.php
+++ b/tests/Integration/Mapping/Fixture/SimpleObjectWithConstructor.php
@@ -6,7 +6,5 @@ namespace CuyZ\Valinor\Tests\Integration\Mapping\Fixture;
 
 final class SimpleObjectWithConstructor
 {
-    public function __construct(public readonly string $value)
-    {
-    }
+    public function __construct(public readonly string $value) {}
 }

--- a/tests/Integration/Mapping/UnionMappingTest.php
+++ b/tests/Integration/Mapping/UnionMappingTest.php
@@ -87,8 +87,6 @@ final class UnionMappingTest extends IntegrationTestCase
                     )
             );
         } catch (MappingError $error) {
-            var_dump($input);
-            var_dump($expectedMap);
             $this->mappingFail($error);
         }
     }


### PR DESCRIPTION
In this test, Valinor is being challenged to understand de-serialization of a given hashmap when given a type `array{a-key: T|list<T>}`.

Specifically, at the time of this writing, Valinor only picks `T` during de-serialization, and seems to completely ignore the `list<T>` portion of the data.

This kind of de-serialization is relevant when dealing with XML structures, where an element could be singular or plural depending on context:

```xml
<Invoices>
  <Invoice>
    <!-- in this example, `Item` is singular, and needs to be handled as `Item` -->
    <Item><Price>123</Price></Item>
  </Invoice>
  <Invoice>
    <!-- in this example, `Item` is plural, and needs to be handled as `list<Item>` -->
    <Item><Price>456</Price></Item>
    <Item><Price>789</Price></Item>
  </Invoice>
</Invoices>
```

Initially discovered by @Tigerman55