### PR TITLE
feat: improve union type narrowing during mapping

### DIFF
--- a/docs/pages/usage/type-reference.md
+++ b/docs/pages/usage/type-reference.md
@@ -153,10 +153,10 @@ final class SomeClass
         private array $unionInsideArray,
         
         /** @var int|true */
-        private int|bool $unionWithLiteralTrueType;
+        private int|bool $unionWithLiteralTrueType,
         
         /** @var int|false */
-        private int|bool $unionWithLiteralFalseType;
+        private int|bool $unionWithLiteralFalseType,
         
         /** @var 404.42|1337.42 */
         private float $unionOfFloatValues,

--- a/src/Library/Container.php
+++ b/src/Library/Container.php
@@ -35,6 +35,7 @@ use CuyZ\Valinor\Mapper\Tree\Builder\IterableNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\ListNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\NativeClassNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\NodeBuilder;
+use CuyZ\Valinor\Mapper\Tree\Builder\NullNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\ObjectImplementations;
 use CuyZ\Valinor\Mapper\Tree\Builder\ObjectNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\RootNodeBuilder;
@@ -63,6 +64,7 @@ use CuyZ\Valinor\Type\Types\IterableType;
 use CuyZ\Valinor\Type\Types\ListType;
 use CuyZ\Valinor\Type\Types\NonEmptyArrayType;
 use CuyZ\Valinor\Type\Types\NonEmptyListType;
+use CuyZ\Valinor\Type\Types\NullType;
 use CuyZ\Valinor\Type\Types\ShapedArrayType;
 use Psr\SimpleCache\CacheInterface;
 
@@ -108,6 +110,7 @@ final class Container
                     IterableType::class => $arrayNodeBuilder,
                     ShapedArrayType::class => new ShapedArrayNodeBuilder($settings->allowSuperfluousKeys),
                     ScalarType::class => new ScalarNodeBuilder($settings->enableFlexibleCasting),
+                    NullType::class => new NullNodeBuilder(),
                     ClassType::class => new NativeClassNodeBuilder(
                         $this->get(ClassDefinitionRepository::class),
                         $this->get(ObjectBuilderFactory::class),
@@ -116,13 +119,7 @@ final class Container
                     ),
                 ]);
 
-                $builder = new UnionNodeBuilder(
-                    $builder,
-                    $this->get(ClassDefinitionRepository::class),
-                    $this->get(ObjectBuilderFactory::class),
-                    $this->get(ObjectNodeBuilder::class),
-                    $settings->enableFlexibleCasting
-                );
+                $builder = new UnionNodeBuilder($builder);
 
                 $builder = new InterfaceNodeBuilder(
                     $builder,

--- a/src/Mapper/Object/FilteredObjectBuilder.php
+++ b/src/Mapper/Object/FilteredObjectBuilder.php
@@ -16,17 +16,23 @@ final class FilteredObjectBuilder implements ObjectBuilder
 {
     private ObjectBuilder $delegate;
 
-    private Arguments $arguments;
-
-    public function __construct(mixed $source, ObjectBuilder ...$builders)
+    private function __construct(mixed $source, ObjectBuilder ...$builders)
     {
         $this->delegate = $this->filterBuilder($source, ...$builders);
-        $this->arguments = $this->delegate->describeArguments();
+    }
+
+    public static function from(mixed $source, ObjectBuilder ...$builders): ObjectBuilder
+    {
+        if (count($builders) === 1) {
+            return $builders[0];
+        }
+
+        return new self($source, ...$builders);
     }
 
     public function describeArguments(): Arguments
     {
-        return $this->arguments;
+        return $this->delegate->describeArguments();
     }
 
     public function build(array $arguments): object

--- a/src/Mapper/Tree/Builder/CasterProxyNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/CasterProxyNodeBuilder.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Tree\Builder;
 
 use CuyZ\Valinor\Mapper\Tree\Shell;
+use CuyZ\Valinor\Type\CompositeTraversableType;
+use CuyZ\Valinor\Type\Type;
+use CuyZ\Valinor\Type\Types\ShapedArrayType;
+use CuyZ\Valinor\Type\Types\UnionType;
 
 /** @internal */
 final class CasterProxyNodeBuilder implements NodeBuilder
@@ -16,11 +20,28 @@ final class CasterProxyNodeBuilder implements NodeBuilder
         if ($shell->hasValue()) {
             $value = $shell->value();
 
-            if ($shell->type()->accepts($value)) {
+            if ($this->typeAcceptsValue($shell->type(), $value)) {
                 return TreeNode::leaf($shell, $value);
             }
         }
 
         return $this->delegate->build($shell, $rootBuilder);
+    }
+
+    private function typeAcceptsValue(Type $type, mixed $value): bool
+    {
+        if ($type instanceof UnionType) {
+            foreach ($type->types() as $subType) {
+                if ($this->typeAcceptsValue($subType, $value)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return ! $type instanceof CompositeTraversableType
+            && ! $type instanceof ShapedArrayType
+            && $type->accepts($value);
     }
 }

--- a/src/Mapper/Tree/Builder/InterfaceNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/InterfaceNodeBuilder.php
@@ -78,7 +78,7 @@ final class InterfaceNodeBuilder implements NodeBuilder
         }
 
         $class = $this->classDefinitionRepository->for($classType);
-        $objectBuilder = new FilteredObjectBuilder($shell->value(), ...$this->objectBuilderFactory->for($class));
+        $objectBuilder = FilteredObjectBuilder::from($shell->value(), ...$this->objectBuilderFactory->for($class));
 
         $shell = $this->transformSourceForClass($shell, $arguments, $objectBuilder->describeArguments());
 

--- a/src/Mapper/Tree/Builder/NativeClassNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/NativeClassNodeBuilder.php
@@ -34,7 +34,7 @@ final class NativeClassNodeBuilder implements NodeBuilder
         }
 
         $class = $this->classDefinitionRepository->for($type);
-        $objectBuilder = new FilteredObjectBuilder($shell->value(), ...$this->objectBuilderFactory->for($class));
+        $objectBuilder = FilteredObjectBuilder::from($shell->value(), ...$this->objectBuilderFactory->for($class));
 
         return $this->objectNodeBuilder->build($objectBuilder, $shell, $rootBuilder);
     }

--- a/src/Mapper/Tree/Builder/NullNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/NullNodeBuilder.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Tree\Builder;
+
+use CuyZ\Valinor\Mapper\Tree\Exception\SourceIsNotNull;
+use CuyZ\Valinor\Mapper\Tree\Shell;
+use CuyZ\Valinor\Type\Types\NullType;
+
+use function assert;
+
+/** @internal */
+final class NullNodeBuilder implements NodeBuilder
+{
+    public function build(Shell $shell, RootNodeBuilder $rootBuilder): TreeNode
+    {
+        $type = $shell->type();
+        $value = $shell->value();
+
+        assert($type instanceof NullType);
+
+        if ($value !== null) {
+            throw new SourceIsNotNull();
+        }
+
+        return TreeNode::leaf($shell, null);
+    }
+}

--- a/src/Mapper/Tree/Builder/TreeNode.php
+++ b/src/Mapper/Tree/Builder/TreeNode.php
@@ -9,6 +9,7 @@ use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use CuyZ\Valinor\Mapper\Tree\Node;
 use CuyZ\Valinor\Mapper\Tree\Shell;
 use CuyZ\Valinor\Type\FloatType;
+use CuyZ\Valinor\Type\Type;
 use Throwable;
 
 use function array_map;
@@ -85,6 +86,19 @@ final class TreeNode
     public function name(): string
     {
         return $this->shell->name();
+    }
+
+    public function type(): Type
+    {
+        return $this->shell->type();
+    }
+
+    /**
+     * @return array<self>
+     */
+    public function children(): array
+    {
+        return $this->children;
     }
 
     public function isValid(): bool

--- a/src/Mapper/Tree/Exception/SourceIsNotNull.php
+++ b/src/Mapper/Tree/Exception/SourceIsNotNull.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Tree\Exception;
+
+use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
+use RuntimeException;
+
+/** @internal */
+final class SourceIsNotNull extends RuntimeException implements ErrorMessage
+{
+    private string $body;
+
+    public function __construct()
+    {
+        $this->body = 'Value {source_value} is not null.';
+
+        parent::__construct($this->body, 1710263908);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+}

--- a/src/Mapper/Tree/Exception/TooManyResolvedTypesFromUnion.php
+++ b/src/Mapper/Tree/Exception/TooManyResolvedTypesFromUnion.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Tree\Exception;
+
+use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
+use CuyZ\Valinor\Mapper\Tree\Message\HasParameters;
+use CuyZ\Valinor\Type\Types\UnionType;
+use CuyZ\Valinor\Utility\String\StringFormatter;
+use CuyZ\Valinor\Utility\TypeHelper;
+use RuntimeException;
+
+use function array_map;
+use function implode;
+
+/** @internal */
+final class TooManyResolvedTypesFromUnion extends RuntimeException implements ErrorMessage, HasParameters
+{
+    private string $body;
+
+    /** @var array<string, string> */
+    private array $parameters;
+
+    public function __construct(UnionType $unionType)
+    {
+        $this->parameters = [
+            'allowed_types' => implode(
+                ', ',
+                array_map(TypeHelper::dump(...), $unionType->types())
+            ),
+        ];
+
+        $this->body = TypeHelper::containsObject($unionType)
+            ? 'Invalid value {source_value}, it matches at least two types from union.'
+            : 'Invalid value {source_value}, it matches at least two types from {allowed_types}.';
+
+        parent::__construct(StringFormatter::for($this), 1710262975);
+    }
+
+    public function body(): string
+    {
+        return $this->body;
+    }
+
+    public function parameters(): array
+    {
+        return $this->parameters;
+    }
+}

--- a/src/Mapper/Tree/Exception/TooManyResolvedTypesFromUnion.php
+++ b/src/Mapper/Tree/Exception/TooManyResolvedTypesFromUnion.php
@@ -32,8 +32,8 @@ final class TooManyResolvedTypesFromUnion extends RuntimeException implements Er
         ];
 
         $this->body = TypeHelper::containsObject($unionType)
-            ? 'Invalid value {source_value}, it matches at least two types from union.'
-            : 'Invalid value {source_value}, it matches at least two types from {allowed_types}.';
+            ? 'Invalid value {source_value}, it matches two or more types from union.'
+            : 'Invalid value {source_value}, it matches two or more types from {allowed_types}.';
 
         parent::__construct(StringFormatter::for($this), 1710262975);
     }

--- a/src/Mapper/Tree/Exception/TooManyResolvedTypesFromUnion.php
+++ b/src/Mapper/Tree/Exception/TooManyResolvedTypesFromUnion.php
@@ -32,8 +32,8 @@ final class TooManyResolvedTypesFromUnion extends RuntimeException implements Er
         ];
 
         $this->body = TypeHelper::containsObject($unionType)
-            ? 'Invalid value {source_value}, it matches two or more types from union.'
-            : 'Invalid value {source_value}, it matches two or more types from {allowed_types}.';
+            ? 'Invalid value {source_value}, it matches two or more types from union: cannot take a decision.'
+            : 'Invalid value {source_value}, it matches two or more types from {allowed_types}: cannot take a decision.';
 
         parent::__construct(StringFormatter::for($this), 1710262975);
     }

--- a/src/Mapper/Tree/Message/DefaultMessage.php
+++ b/src/Mapper/Tree/Message/DefaultMessage.php
@@ -35,6 +35,9 @@ interface DefaultMessage
         'Value {source_value} does not match string value {expected_value}.' => [
             'en' => 'Value {source_value} does not match string value {expected_value}.',
         ],
+        'Value {source_value} is not null.' => [
+            'en' => 'Value {source_value} is not null.',
+        ],
         'Value {source_value} is not a valid boolean.' => [
             'en' => 'Value {source_value} is not a valid boolean.',
         ],
@@ -73,6 +76,12 @@ interface DefaultMessage
         ],
         'Invalid value {source_value}.' => [
             'en' => 'Invalid value {source_value}.',
+        ],
+        'Invalid value {source_value}, it matches at least two types from union.' => [
+            'en' => 'Invalid value {source_value}, it matches at least two types from union.',
+        ],
+        'Invalid value {source_value}, it matches at least two types from {allowed_types}.' => [
+            'en' => 'Invalid value {source_value}, it matches at least two types from {allowed_types}.',
         ],
         'Invalid sequential key {key}, expected {expected}.' => [
             'en' => 'Invalid sequential key {key}, expected {expected}.',

--- a/tests/Integration/Mapping/Object/NullableMappingTest.php
+++ b/tests/Integration/Mapping/Object/NullableMappingTest.php
@@ -20,6 +20,31 @@ final class NullableMappingTest extends IntegrationTestCase
         self::assertSame(null, $result->nullableWithNull);
         self::assertSame('foo', $result->nullableWithString);
     }
+
+    public function test_null_value_mapped_in_null_is_handled_properly(): void
+    {
+        try {
+            $result = $this->mapperBuilder()->mapper()->map('null', null);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame(null, $result); // @phpstan-ignore-line
+    }
+
+    public function test_string_value_mapped_in_null_throws_exception(): void
+    {
+        try {
+            $this->mapperBuilder()->mapper()->map('null', 'foo');
+
+            self::fail('No mapping error when one was expected');
+        } catch (MappingError $exception) {
+            $error = $exception->node()->messages()[0];
+
+            self::assertSame('1710263908', $error->code());
+            self::assertSame("Value 'foo' is not null.", (string)$error);
+        }
+    }
 }
 
 final class NullablePropertyWithNullDefaultValue

--- a/tests/Integration/Mapping/Object/UnionOfObjectsMappingTest.php
+++ b/tests/Integration/Mapping/Object/UnionOfObjectsMappingTest.php
@@ -6,7 +6,6 @@ namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
 
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
-use PHPUnit\Framework\Attributes\DataProvider;
 
 final class UnionOfObjectsMappingTest extends IntegrationTestCase
 {
@@ -48,25 +47,6 @@ final class UnionOfObjectsMappingTest extends IntegrationTestCase
         self::assertInstanceOf(SomeObjectWithBazAndFiz::class, $result);
         self::assertSame('baz', $result->baz);
         self::assertSame('fiz', $result->fiz);
-    }
-
-    /**
-     *
-     * @param class-string $className
-     * @param mixed[] $source
-     */
-    #[DataProvider('mapping_error_when_cannot_resolve_union_data_provider')]
-    public function test_mapping_error_when_cannot_resolve_union(string $className, array $source): void
-    {
-        try {
-            $this->mapperBuilder()->mapper()->map($className, $source);
-
-            self::fail('No mapping error when one was expected');
-        } catch (MappingError $exception) {
-            $error = $exception->node()->children()[0]->messages()[0];
-
-            self::assertSame('1642787246', $error->code());
-        }
     }
 
     public static function mapping_error_when_cannot_resolve_union_data_provider(): iterable

--- a/tests/Integration/Mapping/UnionMappingTest.php
+++ b/tests/Integration/Mapping/UnionMappingTest.php
@@ -254,7 +254,7 @@ final class UnionMappingTest extends IntegrationTestCase
             $error = $exception->node()->messages()[0];
 
             self::assertSame('1710262975', $error->code());
-            self::assertSame("Invalid value 'foo', it matches two or more types from union.", (string)$error);
+            self::assertSame("Invalid value 'foo', it matches two or more types from union: cannot take a decision.", (string)$error);
         }
     }
 
@@ -274,7 +274,7 @@ final class UnionMappingTest extends IntegrationTestCase
             $error = $exception->node()->messages()[0];
 
             self::assertSame('1710262975', $error->code());
-            self::assertSame("Invalid value array{string: 'foo'}, it matches two or more types from union.", (string)$error);
+            self::assertSame("Invalid value array{string: 'foo'}, it matches two or more types from union: cannot take a decision.", (string)$error);
         }
     }
 
@@ -293,7 +293,7 @@ final class UnionMappingTest extends IntegrationTestCase
             $error = $exception->node()->messages()[0];
 
             self::assertSame('1710262975', $error->code());
-            self::assertSame("Invalid value array{0: 'foo', 1: 'bar'}, it matches two or more types from `array<string>`, `array<'foo'|'bar'>`.", (string)$error);
+            self::assertSame("Invalid value array{0: 'foo', 1: 'bar'}, it matches two or more types from `array<string>`, `array<'foo'|'bar'>`: cannot take a decision.", (string)$error);
         }
     }
 
@@ -312,7 +312,7 @@ final class UnionMappingTest extends IntegrationTestCase
             $error = $exception->node()->messages()[0];
 
             self::assertSame('1710262975', $error->code());
-            self::assertSame("Invalid value array{string: 'foo'}, it matches two or more types from union.", (string)$error);
+            self::assertSame("Invalid value array{string: 'foo'}, it matches two or more types from union: cannot take a decision.", (string)$error);
         }
     }
 }

--- a/tests/Integration/Mapping/UnionMappingTest.php
+++ b/tests/Integration/Mapping/UnionMappingTest.php
@@ -71,37 +71,37 @@ final class UnionMappingTest extends IntegrationTestCase
         ];
 
         yield 'list of string or list of integer, with list of string' => [
-            'type' => "list<string>|list<int>",
+            'type' => 'list<string>|list<int>',
             'source' => ['foo', 'bar'],
             'assertion' => fn (mixed $result) => self::assertSame(['foo', 'bar'], $result),
         ];
 
         yield 'list of string or list of integer, with list of integer' => [
-            'type' => "list<string>|list<int>",
+            'type' => 'list<string>|list<int>',
             'source' => [42, 1337],
             'assertion' => fn (mixed $result) => self::assertSame([42, 1337], $result),
         ];
 
         yield 'shaped array with integer or array of integer, with integer' => [
-            'type' => "array{key: int|array<int>}",
+            'type' => 'array{key: int|array<int>}',
             'source' => ['key' => 42],
             'assertion' => fn (mixed $result) => self::assertSame(['key' => 42], $result),
         ];
 
         yield 'shaped array with integer or array of integer, with array of integer' => [
-            'type' => "array{key: int|array<int>}",
+            'type' => 'array{key: int|array<int>}',
             'source' => ['key' => [42, 1337]],
             'assertion' => fn (mixed $result) => self::assertSame(['key' => [42, 1337]], $result),
         ];
 
         yield 'shaped array representing http response with status 200' => [
-            'type' => "array{status: 200, data: array{text: string}} | array{status: 400, error: string}",
+            'type' => 'array{status: 200, data: array{text: string}} | array{status: 400, error: string}',
             'source' => ['status' => 200, 'data' => ['text' => 'foo']],
             'assertion' => fn (mixed $result) => self::assertSame(['status' => 200, 'data' => ['text' => 'foo']], $result),
         ];
 
         yield 'shaped array representing http response with status 400' => [
-            'type' => "array{status: 200, data: array{text: string}} | array{status: 400, error: string}",
+            'type' => 'array{status: 200, data: array{text: string}} | array{status: 400, error: string}',
             'source' => ['status' => 400, 'error' => 'foo'],
             'assertion' => fn (mixed $result) => self::assertSame(['status' => 400, 'error' => 'foo'], $result),
         ];
@@ -251,6 +251,22 @@ final class UnionMappingTest extends IntegrationTestCase
             'source' => 1,
             'assertion' => fn (mixed $result) => self::assertSame(true, $result),
         ];
+    }
+
+    public function test_shaped_array_representing_http_response_with_status_200_with_superfluous_key(): void
+    {
+        $result = $this->mapperBuilder()
+            ->allowSuperfluousKeys()
+            ->mapper()
+            ->map('array{status: 200, data: array{text: string}} | array{status: 400, error: string}', [
+                'status' => 200,
+                'data' => [
+                    'text' => 'foo',
+                    'superfluous' => 'key',
+                ],
+            ]);
+
+        self::assertSame(['status' => 200, 'data' => ['text' => 'foo']], $result);
     }
 
     public function test_scalar_value_matching_two_objects_in_union_throws_exception(): void

--- a/tests/Integration/Mapping/UnionMappingTest.php
+++ b/tests/Integration/Mapping/UnionMappingTest.php
@@ -254,7 +254,7 @@ final class UnionMappingTest extends IntegrationTestCase
             $error = $exception->node()->messages()[0];
 
             self::assertSame('1710262975', $error->code());
-            self::assertSame("Invalid value 'foo', it matches at least two types from union.", (string)$error);
+            self::assertSame("Invalid value 'foo', it matches two or more types from union.", (string)$error);
         }
     }
 
@@ -274,7 +274,7 @@ final class UnionMappingTest extends IntegrationTestCase
             $error = $exception->node()->messages()[0];
 
             self::assertSame('1710262975', $error->code());
-            self::assertSame("Invalid value array{string: 'foo'}, it matches at least two types from union.", (string)$error);
+            self::assertSame("Invalid value array{string: 'foo'}, it matches two or more types from union.", (string)$error);
         }
     }
 
@@ -293,7 +293,7 @@ final class UnionMappingTest extends IntegrationTestCase
             $error = $exception->node()->messages()[0];
 
             self::assertSame('1710262975', $error->code());
-            self::assertSame("Invalid value array{0: 'foo', 1: 'bar'}, it matches at least two types from `array<string>`, `array<'foo'|'bar'>`.", (string)$error);
+            self::assertSame("Invalid value array{0: 'foo', 1: 'bar'}, it matches two or more types from `array<string>`, `array<'foo'|'bar'>`.", (string)$error);
         }
     }
 
@@ -312,7 +312,7 @@ final class UnionMappingTest extends IntegrationTestCase
             $error = $exception->node()->messages()[0];
 
             self::assertSame('1710262975', $error->code());
-            self::assertSame("Invalid value array{string: 'foo'}, it matches at least two types from union.", (string)$error);
+            self::assertSame("Invalid value array{string: 'foo'}, it matches two or more types from union.", (string)$error);
         }
     }
 }

--- a/tests/Integration/Mapping/UnionMappingTest.php
+++ b/tests/Integration/Mapping/UnionMappingTest.php
@@ -6,66 +6,333 @@ namespace CuyZ\Valinor\Tests\Integration\Mapping;
 
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
-use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\City;
-use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class UnionMappingTest extends IntegrationTestCase
 {
-    public function test_union_with_int_or_object(): void
+    #[DataProvider('union_mapping_works_properly_data_provider')]
+    public function test_union_mapping_works_properly(string $type, mixed $source, callable $assertion): void
     {
         try {
-            $array = $this->mapperBuilder()->mapper()->map("list<int|" . SimpleObject::class . ">", [123, "foo"]);
-        } catch (MappingError $error) {
-            $this->mappingFail($error);
-        }
-
-        self::assertSame(123, $array[0]);
-        self::assertInstanceOf(SimpleObject::class, $array[1]);
-    }
-
-    public function test_union_with_string_or_object_prioritizes_string(): void
-    {
-        try {
-            $array = $this->mapperBuilder()
+            $result = $this->mapperBuilder()
+                ->infer(SomeInterfaceForObjectWithOneStringValue::class, fn () => SomeObjectWithOneStringValue::class)
                 ->mapper()
-                ->map("list<string|" . SimpleObject::class . ">", ["foo", "bar", "baz"]);
+                ->map($type, $source);
+
+            $assertion($result);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }
-
-        self::assertSame(["foo", "bar", "baz"], $array);
     }
 
-    public function test_union_with_string_literal_or_object_prioritizes_string_literal(): void
+    #[DataProvider('union_mapping_works_properly_data_provider')]
+    public function test_union_mapping_works_properly_with_superfluous_keys_allowed(string $type, mixed $source, callable $assertion): void
     {
         try {
-            $array = $this->mapperBuilder()
+            $result = $this->mapperBuilder()
+                ->infer(SomeInterfaceForObjectWithOneStringValue::class, fn () => SomeObjectWithOneStringValue::class)
+                ->allowSuperfluousKeys()
                 ->mapper()
-                ->map("list<'foo'|" . SimpleObject::class . "|'bar'>", ["foo", "bar", "baz"]);
+                ->map($type, $source);
+
+            $assertion($result);
         } catch (MappingError $error) {
             $this->mappingFail($error);
         }
-
-        self::assertSame("foo", $array[0]);
-        self::assertSame("bar", $array[1]);
-        self::assertInstanceOf(SimpleObject::class, $array[2]);
     }
 
-    public function test_union_of_objects(): void
+    #[DataProvider('union_mapping_works_properly_with_flexible_casting_enabled_data_provider')]
+    public function test_union_mapping_works_properly_with_flexible_casting_enabled(string $type, mixed $source, callable $assertion): void
     {
         try {
-            $array = $this->mapperBuilder()
+            $result = $this->mapperBuilder()
+                ->enableFlexibleCasting()
+                ->mapper()
+                ->map($type, $source);
+
+            $assertion($result);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+    }
+
+    public static function union_mapping_works_properly_data_provider(): iterable
+    {
+        yield 'string or list of string, with string' => [
+            'type' => 'string|list<string>',
+            'source' => 'foo',
+            'assertion' => fn (mixed $result) => self::assertSame('foo', $result),
+        ];
+
+        yield 'string or list of string, with list of string' => [
+            'type' => 'string|list<string>',
+            'source' => ['foo', 'bar'],
+            'assertion' => fn (mixed $result) => self::assertSame(['foo', 'bar'], $result),
+        ];
+
+        yield 'list of string or list of integer, with list of string' => [
+            'type' => "list<string>|list<int>",
+            'source' => ['foo', 'bar'],
+            'assertion' => fn (mixed $result) => self::assertSame(['foo', 'bar'], $result),
+        ];
+
+        yield 'list of string or list of integer, with list of integer' => [
+            'type' => "list<string>|list<int>",
+            'source' => [42, 1337],
+            'assertion' => fn (mixed $result) => self::assertSame([42, 1337], $result),
+        ];
+
+        yield 'shaped array with integer or array of integer, with integer' => [
+            'type' => "array{key: int|array<int>}",
+            'source' => ['key' => 42],
+            'assertion' => fn (mixed $result) => self::assertSame(['key' => 42], $result),
+        ];
+
+        yield 'shaped array with integer or array of integer, with array of integer' => [
+            'type' => "array{key: int|array<int>}",
+            'source' => ['key' => [42, 1337]],
+            'assertion' => fn (mixed $result) => self::assertSame(['key' => [42, 1337]], $result),
+        ];
+
+        yield 'array of string or object with one string value, with array of string' => [
+            'type' => 'array<string>|' . SomeObjectWithOneStringValue::class,
+            'source' => ['foo', 'bar'],
+            'assertion' => fn (mixed $result) => self::assertSame(['foo', 'bar'], $result),
+        ];
+
+        yield 'array of string or object with one string value, with scalar' => [
+            'type' => 'array<string>|' . SomeObjectWithOneStringValue::class,
+            'source' => 'foo',
+            'assertion' => function (mixed $result) {
+                self::assertInstanceOf(SomeObjectWithOneStringValue::class, $result);
+                self::assertSame('foo', $result->string);
+            },
+        ];
+
+        yield 'array of string or object with one string value, with array containing value for object' => [
+            'type' => 'array<string>|' . SomeObjectWithOneStringValue::class,
+            'source' => ['string' => 'foo'],
+            'assertion' => function (mixed $result) {
+                self::assertInstanceOf(SomeObjectWithOneStringValue::class, $result);
+                self::assertSame('foo', $result->string);
+            },
+        ];
+
+        yield 'string or object with one string value, with string value' => [
+            'type' => 'string|' . SomeObjectWithOneStringValue::class,
+            'source' => 'foo',
+            'assertion' => fn (mixed $result) => self::assertSame('foo', $result),
+        ];
+
+        yield 'string value or object with one string value, with matching string value' => [
+            'type' => "'foo'|" . SomeObjectWithOneStringValue::class,
+            'source' => 'foo',
+            'assertion' => fn (mixed $result) => self::assertSame('foo', $result),
+        ];
+
+        yield 'string value or object with one string value, with non-matching string value' => [
+            'type' => "'foo'|" . SomeObjectWithOneStringValue::class,
+            'source' => 'bar',
+            'assertion' => function (mixed $result) {
+                self::assertInstanceOf(SomeObjectWithOneStringValue::class, $result);
+                self::assertSame('bar', $result->string);
+            },
+        ];
+
+        yield 'object with one string value or object with one string value and one integer value, with array containing string' => [
+            'type' => SomeObjectWithOneStringValue::class . '|' . SomeObjectWithOneStringValueAndOneIntValue::class,
+            'source' => ['string' => 'foo'],
+            'assertion' => function (mixed $result) {
+                self::assertInstanceOf(SomeObjectWithOneStringValue::class, $result);
+                self::assertSame('foo', $result->string);
+            },
+        ];
+
+        yield 'object with one string value or object with one string value and one integer value, with array containing string and integer' => [
+            'type' => SomeObjectWithOneStringValue::class . '|' . SomeObjectWithOneStringValueAndOneIntValue::class,
+            'source' => [
+                'string' => 'foo',
+                'integer' => 42,
+            ],
+            'assertion' => function (mixed $result) {
+                self::assertInstanceOf(SomeObjectWithOneStringValueAndOneIntValue::class, $result);
+                self::assertSame('foo', $result->string);
+                self::assertSame(42, $result->integer);
+            },
+        ];
+
+        yield 'array of string or interface for object with one string value or object with one string value and one integer value, with array containing string' => [
+            'type' => 'array<string>|' . SomeInterfaceForObjectWithOneStringValue::class . '|' . SomeObjectWithOneStringValueAndOneIntValue::class,
+            'source' => ['string' => 'foo'],
+            'assertion' => function (mixed $result) {
+                self::assertInstanceOf(SomeObjectWithOneStringValue::class, $result);
+                self::assertSame('foo', $result->string);
+            },
+        ];
+
+        yield 'array of string or interface for object with one string value or object with one string value and one integer value, with array containing string and integer' => [
+            'type' => 'array<string>|' . SomeInterfaceForObjectWithOneStringValue::class . '|' . SomeObjectWithOneStringValueAndOneIntValue::class,
+            'source' => [
+                'string' => 'foo',
+                'integer' => 42,
+            ],
+            'assertion' => function (mixed $result) {
+                self::assertInstanceOf(SomeObjectWithOneStringValueAndOneIntValue::class, $result);
+                self::assertSame('foo', $result->string);
+                self::assertSame(42, $result->integer);
+            },
+        ];
+    }
+
+    public static function union_mapping_works_properly_with_flexible_casting_enabled_data_provider(): iterable
+    {
+        yield 'float or integer, with string containing float' => [
+            'type' => 'float|integer',
+            'source' => '42.0',
+            'assertion' => fn (mixed $result) => self::assertSame(42.0, $result),
+        ];
+
+        yield 'float or integer, with string containing integer' => [
+            'type' => 'float|integer',
+            'source' => '42',
+            'assertion' => fn (mixed $result) => self::assertSame(42, $result),
+        ];
+
+        yield 'boolean or integer, with string containing integer' => [
+            'type' => 'bool|int',
+            'source' => '1',
+            'assertion' => fn (mixed $result) => self::assertSame(1, $result),
+        ];
+
+        yield 'integer or boolean, with string containing integer' => [
+            'type' => 'int|bool',
+            'source' => '1',
+            'assertion' => fn (mixed $result) => self::assertSame(1, $result),
+        ];
+
+        yield 'boolean or float, with string containing integer' => [
+            'type' => 'bool|float',
+            'source' => '1',
+            'assertion' => fn (mixed $result) => self::assertSame(1.0, $result),
+        ];
+
+        yield 'float or boolean, with string containing integer' => [
+            'type' => 'float|bool',
+            'source' => '1',
+            'assertion' => fn (mixed $result) => self::assertSame(1.0, $result),
+        ];
+
+        yield 'boolean or string, with integer' => [
+            'type' => 'bool|string',
+            'source' => 1,
+            'assertion' => fn (mixed $result) => self::assertSame('1', $result),
+        ];
+
+        yield 'string or boolean, with integer' => [
+            'type' => 'string|bool',
+            'source' => 1,
+            'assertion' => fn (mixed $result) => self::assertSame('1', $result),
+        ];
+
+        yield 'array of integer or boolean, with integer' => [
+            'type' => 'array<int>|bool|true',
+            'source' => 1,
+            'assertion' => fn (mixed $result) => self::assertSame(true, $result),
+        ];
+    }
+
+    public function test_scalar_value_matching_two_objects_in_union_throws_exception(): void
+    {
+        try {
+            $this->mapperBuilder()
+                ->allowSuperfluousKeys()
+                ->mapper()
+                ->map(SomeObjectWithOneStringValue::class . '|' . AnotherObjectWithOneStringValue::class, 'foo');
+
+            self::fail('No mapping error when one was expected');
+        } catch (MappingError $exception) {
+            $error = $exception->node()->messages()[0];
+
+            self::assertSame('1710262975', $error->code());
+            self::assertSame("Invalid value 'foo', it matches at least two types from union.", (string)$error);
+        }
+    }
+
+    public function test_array_value_matching_two_objects_in_union_throws_exception(): void
+    {
+        try {
+            $this->mapperBuilder()
+                ->allowSuperfluousKeys()
                 ->mapper()
                 ->map(
-                    "list<" . SimpleObject::class . "|" . City::class . ">",
-                    ["foo", ["name" => "foobar", "timeZone" => "UTC"], "baz"],
+                    SomeObjectWithOneStringValue::class . '|' . AnotherObjectWithOneStringValue::class,
+                    ['string' => 'foo'],
                 );
-        } catch (MappingError $error) {
-            $this->mappingFail($error);
-        }
 
-        self::assertInstanceOf(SimpleObject::class, $array[0]);
-        self::assertInstanceOf(City::class, $array[1]);
-        self::assertInstanceOf(SimpleObject::class, $array[2]);
+            self::fail('No mapping error when one was expected');
+        } catch (MappingError $exception) {
+            $error = $exception->node()->messages()[0];
+
+            self::assertSame('1710262975', $error->code());
+            self::assertSame("Invalid value array{string: 'foo'}, it matches at least two types from union.", (string)$error);
+        }
     }
+
+    public function test_array_value_matching_two_arrays_in_union_throws_exception(): void
+    {
+        try {
+            $this->mapperBuilder()
+                ->mapper()
+                ->map(
+                    "array<string>|array<'foo'|'bar'>",
+                    ['foo', 'bar'],
+                );
+
+            self::fail('No mapping error when one was expected');
+        } catch (MappingError $exception) {
+            $error = $exception->node()->messages()[0];
+
+            self::assertSame('1710262975', $error->code());
+            self::assertSame("Invalid value array{0: 'foo', 1: 'bar'}, it matches at least two types from `array<string>`, `array<'foo'|'bar'>`.", (string)$error);
+        }
+    }
+
+    public function test_array_value_matching_array_shape_and_object_in_union_throws_exception(): void
+    {
+        try {
+            $this->mapperBuilder()
+                ->mapper()
+                ->map(
+                    'array{string: string}|' . SomeObjectWithOneStringValue::class,
+                    ['string' => 'foo'],
+                );
+
+            self::fail('No mapping error when one was expected');
+        } catch (MappingError $exception) {
+            $error = $exception->node()->messages()[0];
+
+            self::assertSame('1710262975', $error->code());
+            self::assertSame("Invalid value array{string: 'foo'}, it matches at least two types from union.", (string)$error);
+        }
+    }
+}
+
+interface SomeInterfaceForObjectWithOneStringValue {}
+
+final class SomeObjectWithOneStringValue implements SomeInterfaceForObjectWithOneStringValue
+{
+    public function __construct(public readonly string $string) {}
+}
+
+final class AnotherObjectWithOneStringValue
+{
+    public function __construct(public readonly string $string) {}
+}
+
+final class SomeObjectWithOneStringValueAndOneIntValue
+{
+    public function __construct(
+        public readonly string $string,
+        public readonly int $integer,
+    ) {}
 }

--- a/tests/Integration/Mapping/UnionMappingTest.php
+++ b/tests/Integration/Mapping/UnionMappingTest.php
@@ -94,6 +94,18 @@ final class UnionMappingTest extends IntegrationTestCase
             'assertion' => fn (mixed $result) => self::assertSame(['key' => [42, 1337]], $result),
         ];
 
+        yield 'shaped array representing http response with status 200' => [
+            'type' => "array{status: 200, data: array{text: string}} | array{status: 400, error: string}",
+            'source' => ['status' => 200, 'data' => ['text' => 'foo']],
+            'assertion' => fn (mixed $result) => self::assertSame(['status' => 200, 'data' => ['text' => 'foo']], $result),
+        ];
+
+        yield 'shaped array representing http response with status 400' => [
+            'type' => "array{status: 200, data: array{text: string}} | array{status: 400, error: string}",
+            'source' => ['status' => 400, 'error' => 'foo'],
+            'assertion' => fn (mixed $result) => self::assertSame(['status' => 400, 'error' => 'foo'], $result),
+        ];
+
         yield 'array of string or object with one string value, with array of string' => [
             'type' => 'array<string>|' . SomeObjectWithOneStringValue::class,
             'source' => ['foo', 'bar'],


### PR DESCRIPTION
The algorithm used by the mapper to narrow a union type has been greatly improved, and should cover more edge-cases that would previously prevent the mapper from performing well.

If an interface, a class or a shaped array is matched by the input, it will take precedence over arrays or scalars.

```php
(new \CuyZ\Valinor\MapperBuilder())
    ->mapper()
    ->map(
        signature: 'array<int>|' . Color::class,
        source: [
            'red' => 255,
            'green' => 128,
            'blue' => 64,
        ],
    ); // Returns an instance of `Color`
```

When superfluous keys are allowed, if the input matches several interfaces, classes or shaped array, the one with the most children node will be prioritized, as it is considered the most specific type:

```php
(new \CuyZ\Valinor\MapperBuilder())
    ->allowSuperfluousKeys()
    ->mapper()
    ->map(
        // Even if the first shaped array matches the input, the second one is
        // used because it's more specific.
        signature: 'array{foo: int}|array{foo: int, bar: int}',
        source: [
            'foo' => 42,
            'bar' => 1337,
        ],
    );
```

If the input matches several types within the union, a collision will occur and cause the mapper to fail:

```php
(new \CuyZ\Valinor\MapperBuilder())
    ->mapper()
    ->map(
        // Even if the first shaped array matches the input, the second one is
        // used because it's more specific.
        signature: 'array{red: int, green: int, blue: int}|' . Color::class,
        source: [
            'red' => 255,
            'green' => 128,
            'blue' => 64,
        ],
    );

// ⚠️ Invalid value array{red: 255, green: 128, blue: 64}, it matches at
//    least two types from union.
```

Fixes #395
Fixes #356
Closes #487
Closes #495