### PR TITLE
Failing test case: `''|array{foo: int}` if superfluous key exists

### DIFF
--- a/tests/Integration/Mapping/UnionMappingTest.php
+++ b/tests/Integration/Mapping/UnionMappingTest.php
@@ -11,6 +11,24 @@ use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject;
 
 final class UnionMappingTest extends IntegrationTestCase
 {
+    public function test_union_with_empty_string_or_array_containing_superfluous_key(): void
+    {
+        try {
+            $array = $this->mapperBuilder()
+                ->allowSuperfluousKeys()
+                ->mapper()
+                ->map("list<''|array{foo: int}>", [
+                    '',
+                    ['foo' => 1, 'bar' => 'superfluous'],
+                ]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame('', $array[0]);
+        self::assertSame(['foo' => 1], $array[1]);
+    }
+
     public function test_union_with_int_or_object(): void
     {
         try {


### PR DESCRIPTION
Found an issue where valinor does not appear to interpret a union with an empty string and array when the array being mapped contains a superfluous key. I was also able to reproduce this bug using `string|array{foo:int}`.