### PR TITLE
fix: properly handle `ArrayObject` normalization

### DIFF
--- a/src/Normalizer/Transformer/RecursiveTransformer.php
+++ b/src/Normalizer/Transformer/RecursiveTransformer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Normalizer\Transformer;
 
+use ArrayObject;
 use BackedEnum;
 use Closure;
 use CuyZ\Valinor\Definition\AttributeDefinition;
@@ -111,7 +112,7 @@ final class RecursiveTransformer
                 return $value->getName();
             }
 
-            if ($value::class === stdClass::class) {
+            if ($value::class === stdClass::class || $value instanceof ArrayObject) {
                 return array_map(
                     fn (mixed $value) => $this->doTransform($value, $references),
                     (array)$value

--- a/tests/Integration/Normalizer/NormalizerTest.php
+++ b/tests/Integration/Normalizer/NormalizerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Integration\Normalizer;
 
+use ArrayObject;
 use Attribute;
 use CuyZ\Valinor\Normalizer\Exception\CircularReferenceFoundDuringNormalization;
 use CuyZ\Valinor\Normalizer\Exception\KeyTransformerHasTooManyParameters;
@@ -171,6 +172,24 @@ final class NormalizerTest extends IntegrationTestCase
 
                 return $object;
             })(),
+            'expected array' => [
+                'foo' => 'foo',
+                'bar' => 'bar',
+            ],
+            'expected json' => '{"foo":"foo","bar":"bar"}',
+        ];
+
+        yield 'ArrayObject' => [
+            'input' => new ArrayObject(['foo' => 'foo', 'bar' => 'bar']),
+            'expected array' => [
+                'foo' => 'foo',
+                'bar' => 'bar',
+            ],
+            'expected json' => '{"foo":"foo","bar":"bar"}',
+        ];
+
+        yield 'class inheriting ArrayObject' => [
+            'input' => new class (['foo' => 'foo', 'bar' => 'bar']) extends ArrayObject {},
             'expected array' => [
                 'foo' => 'foo',
                 'bar' => 'bar',


### PR DESCRIPTION
Fixes #486