### PR TITLE
feat: handle type importation from interface

### DIFF
--- a/src/Definition/Repository/Reflection/ReflectionClassDefinitionRepository.php
+++ b/src/Definition/Repository/Reflection/ReflectionClassDefinitionRepository.php
@@ -23,6 +23,7 @@ use CuyZ\Valinor\Definition\Repository\AttributesRepository;
 use CuyZ\Valinor\Definition\Repository\ClassDefinitionRepository;
 use CuyZ\Valinor\Type\ClassType;
 use CuyZ\Valinor\Type\GenericType;
+use CuyZ\Valinor\Type\ObjectType;
 use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use CuyZ\Valinor\Type\Parser\Factory\Specifications\AliasSpecification;
 use CuyZ\Valinor\Type\Parser\Factory\Specifications\ClassContextSpecification;
@@ -183,7 +184,7 @@ final class ReflectionClassDefinitionRepository implements ClassDefinitionReposi
     /**
      * @return array<string, Type>
      */
-    private function localTypeAliases(ClassType $type): array
+    private function localTypeAliases(ObjectType $type): array
     {
         $reflection = Reflection::class($type->className());
         $rawTypes = DocParser::localTypeAliases($reflection);
@@ -224,7 +225,7 @@ final class ReflectionClassDefinitionRepository implements ClassDefinitionReposi
                 throw new InvalidTypeAliasImportClass($type, $class);
             }
 
-            if (! $classType instanceof ClassType) {
+            if (! $classType instanceof ObjectType) {
                 throw new InvalidTypeAliasImportClassType($type, $classType);
             }
 
@@ -242,7 +243,7 @@ final class ReflectionClassDefinitionRepository implements ClassDefinitionReposi
         return $importedTypes;
     }
 
-    private function typeParser(ClassType $type): TypeParser
+    private function typeParser(ObjectType $type): TypeParser
     {
         $specs = [
             new ClassContextSpecification($type->className()),

--- a/src/Type/Types/UnresolvableType.php
+++ b/src/Type/Types/UnresolvableType.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Types;
 
-use CuyZ\Valinor\Type\ClassType;
+use CuyZ\Valinor\Type\ObjectType;
 use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Utility\Reflection\Reflection;
@@ -81,7 +81,7 @@ final class UnresolvableType implements Type
         return new self($typeFromDocBlock->toString(), $message);
     }
 
-    public static function forLocalAlias(string $raw, string $name, ClassType $type, InvalidType $exception): self
+    public static function forLocalAlias(string $raw, string $name, ObjectType $type, InvalidType $exception): self
     {
         return new self(
             $raw,

--- a/tests/Integration/Mapping/Object/LocalTypeAliasMappingTest.php
+++ b/tests/Integration/Mapping/Object/LocalTypeAliasMappingTest.php
@@ -51,10 +51,12 @@ final class LocalTypeAliasMappingTest extends IntegrationTestCase
                     ->map($class, [
                         'firstImportedType' => 42,
                         'secondImportedType' => 1337,
+                        'thirdImportedType' => 404,
                     ]);
 
                 self::assertSame(42, $result->firstImportedType);
                 self::assertSame(1337, $result->secondImportedType);
+                self::assertSame(404, $result->thirdImportedType);
             } catch (MappingError $error) {
                 $this->mappingFail($error);
             }
@@ -113,11 +115,17 @@ class AnotherPhpStanLocalAlias
 }
 
 /**
+ * @phpstan-type AliasOfInteger = int
+ */
+interface InterfaceWithPhpStanLocalAlias {}
+
+/**
  * Comment:
  * Some comment before import
  *
  * @phpstan-import-type AliasWithEqualsSign from PhpStanLocalAliases
  * @phpstan-import-type AliasWithoutEqualsSign from AnotherPhpStanLocalAlias
+ * @phpstan-import-type AliasOfInteger from InterfaceWithPhpStanLocalAlias
  */
 class PhpStanAliasImport
 {
@@ -126,6 +134,9 @@ class PhpStanAliasImport
 
     /** @var AliasWithoutEqualsSign */
     public int $secondImportedType;
+
+    /** @var AliasOfInteger */
+    public int $thirdImportedType;
 }
 
 /**
@@ -179,11 +190,17 @@ class AnotherPsalmLocalAliases
 }
 
 /**
+ * @phpstan-type AliasOfInteger = int
+ */
+interface InterfaceWithPsalmLocalAlias {}
+
+/**
  * Comment:
  * Some comment before import
  *
  * @psalm-import-type AliasWithEqualsSign from PsalmLocalAliases
  * @psalm-import-type AliasWithoutEqualsSign from AnotherPsalmLocalAliases
+ * @psalm-import-type AliasOfInteger from InterfaceWithPsalmLocalAlias
  */
 class PsalmAliasImport
 {
@@ -192,4 +209,7 @@ class PsalmAliasImport
 
     /** @var AliasWithoutEqualsSign */
     public int $secondImportedType;
+
+    /** @var AliasOfInteger */
+    public int $thirdImportedType;
 }


### PR DESCRIPTION
Allows usage of `@phpstan-import-type` and `@psalm-import-type` from interfaces:

```php
/**
 * @phpstan-type SomeAlias = array{foo: string, bar: int}
 */
interface InterfaceWithPhpStanLocalAlias { }

/**
 * @phpstan-import-type SomeAlias from InterfaceWithPhpStanLocalAlias
 */
final class SomeClass
{
    /** @var SomeAlias */
    public $value;
}

(new \CuyZ\Valinor\MapperBuilder())
    ->mapper()
    ->map(SomeClass::class, [
        'foo' => 'bar',
        'bar' => 42,
    ]);
```

Fixes #353