### PR TITLE
feat: introduce unsealed shaped array syntax

### DIFF
--- a/docs/pages/usage/type-reference.md
+++ b/docs/pages/usage/type-reference.md
@@ -134,6 +134,15 @@ final class SomeClass
 
         /** @var array{string, bar: int} */
         private array $shapedArrayWithUndefinedKey,
+
+        /** @var array{foo: string, ...} */
+        private array $unsealedShapedArray,
+        
+        /** @var array{foo: string, ...array<string>} */
+        private array $unsealedShapedArrayWithExplicitType,
+        
+        /** @var array{foo: string, ...array<int, string>} */
+        private array $unsealedShapedArrayWithExplicitKeyAndType,
     ) {}
 }
 ```

--- a/qa/PHPStan/Extension/TreeMapperPHPStanExtension.php
+++ b/qa/PHPStan/Extension/TreeMapperPHPStanExtension.php
@@ -50,6 +50,10 @@ final class TreeMapperPHPStanExtension implements DynamicMethodReturnTypeExtensi
         try {
             return $this->type($type);
         } catch (ParserException) {
+            // Fallback to `mixed` type if the type cannot be resolved. This can
+            // occur with a type that is not understood/supported by PHPStan. If
+            // that happens, returning a mixed type is the safest option, as it
+            // will not make the analysis fail.
             return new MixedType();
         }
     }

--- a/qa/PHPStan/Extension/TreeMapperPHPStanExtension.php
+++ b/qa/PHPStan/Extension/TreeMapperPHPStanExtension.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Mapper\TreeMapper;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\PhpDoc\TypeStringResolver;
+use PHPStan\PhpDocParser\Parser\ParserException;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\ClassStringType;
 use PHPStan\Type\Constant\ConstantStringType;
@@ -46,7 +47,11 @@ final class TreeMapperPHPStanExtension implements DynamicMethodReturnTypeExtensi
             return $type->traverse(fn (Type $type) => $this->type($type));
         }
 
-        return $this->type($type);
+        try {
+            return $this->type($type);
+        } catch (ParserException) {
+            return new MixedType();
+        }
     }
 
     private function type(Type $type): Type

--- a/src/Mapper/Tree/Builder/ShapedArrayNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ShapedArrayNodeBuilder.php
@@ -69,6 +69,15 @@ final class ShapedArrayNodeBuilder implements NodeBuilder
             unset($value[$key]);
         }
 
+        if ($type->isUnsealed()) {
+            $unsealedShell = $shell->withType($type->unsealedType())->withValue($value);
+            $unsealedChildren = $rootBuilder->build($unsealedShell)->children();
+
+            foreach ($unsealedChildren as $unsealedChild) {
+                $children[$unsealedChild->name()] = $unsealedChild;
+            }
+        }
+
         return $children;
     }
 

--- a/src/Type/Parser/Exception/Iterable/ShapedArrayClosingBracketMissing.php
+++ b/src/Type/Parser/Exception/Iterable/ShapedArrayClosingBracketMissing.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Type\Parser\Exception\Iterable;
 
 use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
+use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\ShapedArrayElement;
 use RuntimeException;
 
@@ -16,9 +17,15 @@ final class ShapedArrayClosingBracketMissing extends RuntimeException implements
     /**
      * @param ShapedArrayElement[] $elements
      */
-    public function __construct(array $elements)
+    public function __construct(array $elements, Type|null|false $unsealedType = null)
     {
         $signature = 'array{' . implode(', ', array_map(fn (ShapedArrayElement $element) => $element->toString(), $elements));
+
+        if ($unsealedType === false) {
+            $signature .= ', ...';
+        } elseif ($unsealedType instanceof Type) {
+            $signature .= ', ...' . $unsealedType->toString();
+        }
 
         parent::__construct(
             "Missing closing curly bracket in shaped array signature `$signature`.",

--- a/src/Type/Parser/Exception/Iterable/ShapedArrayInvalidUnsealedType.php
+++ b/src/Type/Parser/Exception/Iterable/ShapedArrayInvalidUnsealedType.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Type\Parser\Exception\Iterable;
+
+use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
+use CuyZ\Valinor\Type\Type;
+use CuyZ\Valinor\Type\Types\ShapedArrayElement;
+use RuntimeException;
+
+use function implode;
+
+/** @internal */
+final class ShapedArrayInvalidUnsealedType extends RuntimeException implements InvalidType
+{
+    /**
+     * @param ShapedArrayElement[] $elements
+     */
+    public function __construct(array $elements, Type $unsealedType)
+    {
+        $signature = 'array{';
+        $signature .= implode(', ', array_map(fn (ShapedArrayElement $element) => $element->toString(), $elements));
+        $signature .= ', ...' . $unsealedType->toString();
+        $signature .= '}';
+
+        parent::__construct(
+            "Invalid unsealed type `{$unsealedType->toString()}` in shaped array signature `$signature`, it should be a valid array.",
+            1711618899,
+        );
+    }
+}

--- a/src/Type/Parser/Exception/Iterable/ShapedArrayUnexpectedTokenAfterSealedType.php
+++ b/src/Type/Parser/Exception/Iterable/ShapedArrayUnexpectedTokenAfterSealedType.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Type\Parser\Exception\Iterable;
+
+use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
+use CuyZ\Valinor\Type\Parser\Lexer\Token\Token;
+use CuyZ\Valinor\Type\Type;
+use CuyZ\Valinor\Type\Types\ShapedArrayElement;
+use RuntimeException;
+
+use function implode;
+
+/** @internal */
+final class ShapedArrayUnexpectedTokenAfterSealedType extends RuntimeException implements InvalidType
+{
+    /**
+     * @param array<ShapedArrayElement> $elements
+     * @param list<Token> $unexpectedTokens
+     */
+    public function __construct(array $elements, Type $unsealedType, array $unexpectedTokens)
+    {
+        $unexpected = implode('', array_map(fn (Token $token) => $token->symbol(), $unexpectedTokens));
+
+        $signature = 'array{';
+        $signature .= implode(', ', array_map(fn (ShapedArrayElement $element) => $element->toString(), $elements));
+        $signature .= ', ...' . $unsealedType->toString();
+        $signature .= $unexpected;
+
+        parent::__construct(
+            "Unexpected `$unexpected` after sealed type in shaped array signature `$signature`, expected a `}`.",
+            1711618958,
+        );
+    }
+}

--- a/src/Type/Parser/Exception/Iterable/ShapedArrayWithoutElementsWithSealedType.php
+++ b/src/Type/Parser/Exception/Iterable/ShapedArrayWithoutElementsWithSealedType.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Type\Parser\Exception\Iterable;
+
+use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
+use CuyZ\Valinor\Type\Type;
+use RuntimeException;
+
+/** @internal */
+final class ShapedArrayWithoutElementsWithSealedType extends RuntimeException implements InvalidType
+{
+    public function __construct(Type $unsealedType)
+    {
+        $signature = "array{...{$unsealedType->toString()}}";
+
+        parent::__construct(
+            "Missing elements in shaped array signature `$signature`.",
+            1711629845,
+        );
+    }
+}

--- a/src/Type/Parser/Lexer/NativeLexer.php
+++ b/src/Type/Parser/Lexer/NativeLexer.php
@@ -26,6 +26,7 @@ use CuyZ\Valinor\Type\Parser\Lexer\Token\OpeningCurlyBracketToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\OpeningSquareBracketToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\QuoteToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\Token;
+use CuyZ\Valinor\Type\Parser\Lexer\Token\TripleDotsToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\UnionToken;
 
 use function filter_var;
@@ -56,6 +57,7 @@ final class NativeLexer implements TypeLexer
             ':' => ColonToken::get(),
             '?' => NullableToken::get(),
             ',' => CommaToken::get(),
+            '...' => TripleDotsToken::get(),
             '"', "'" => new QuoteToken($symbol),
             'int', 'integer' => IntegerToken::get(),
             'array' => ArrayToken::array(),

--- a/src/Type/Parser/Lexer/Token/ArrayToken.php
+++ b/src/Type/Parser/Lexer/Token/ArrayToken.php
@@ -12,6 +12,9 @@ use CuyZ\Valinor\Type\Parser\Exception\Iterable\ShapedArrayColonTokenMissing;
 use CuyZ\Valinor\Type\Parser\Exception\Iterable\ShapedArrayCommaMissing;
 use CuyZ\Valinor\Type\Parser\Exception\Iterable\ShapedArrayElementTypeMissing;
 use CuyZ\Valinor\Type\Parser\Exception\Iterable\ShapedArrayEmptyElements;
+use CuyZ\Valinor\Type\Parser\Exception\Iterable\ShapedArrayInvalidUnsealedType;
+use CuyZ\Valinor\Type\Parser\Exception\Iterable\ShapedArrayUnexpectedTokenAfterSealedType;
+use CuyZ\Valinor\Type\Parser\Exception\Iterable\ShapedArrayWithoutElementsWithSealedType;
 use CuyZ\Valinor\Type\Parser\Lexer\TokenStream;
 use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\ArrayKeyType;
@@ -99,6 +102,8 @@ final class ArrayToken implements TraversingToken
 
         $elements = [];
         $index = 0;
+        $isUnsealed = false;
+        $unsealedType = null;
 
         while (! $stream->done()) {
             if ($stream->next() instanceof ClosingCurlyBracketToken) {
@@ -121,10 +126,48 @@ final class ArrayToken implements TraversingToken
 
             $optional = false;
 
+            if ($stream->next() instanceof TripleDotsToken) {
+                $isUnsealed = true;
+                $stream->forward();
+            }
+
+            if ($stream->done()) {
+                throw new ShapedArrayClosingBracketMissing($elements, unsealedType: false);
+            }
+
             if ($stream->next() instanceof UnknownSymbolToken) {
                 $type = new StringValueType($stream->forward()->symbol());
+            } elseif ($isUnsealed && $stream->next() instanceof ClosingCurlyBracketToken) {
+                $stream->forward();
+                break;
             } else {
                 $type = $stream->read();
+            }
+
+            if ($isUnsealed) {
+                $unsealedType = $type;
+
+                if ($elements === []) {
+                    throw new ShapedArrayWithoutElementsWithSealedType($unsealedType);
+                }
+
+                if (! $unsealedType instanceof ArrayType) {
+                    throw new ShapedArrayInvalidUnsealedType($elements, $unsealedType);
+                }
+
+                if ($stream->done()) {
+                    throw new ShapedArrayClosingBracketMissing($elements, $unsealedType);
+                } elseif (! $stream->next() instanceof ClosingCurlyBracketToken) {
+                    $unexpected = [];
+
+                    while (! $stream->done() && ! $stream->next() instanceof ClosingCurlyBracketToken) {
+                        $unexpected[] = $stream->forward();
+                    }
+
+                    throw new ShapedArrayUnexpectedTokenAfterSealedType($elements, $unsealedType, $unexpected);
+                }
+
+                continue;
             }
 
             if ($stream->done()) {
@@ -178,8 +221,14 @@ final class ArrayToken implements TraversingToken
             }
         }
 
-        if (empty($elements)) {
+        if ($elements === []) {
             throw new ShapedArrayEmptyElements();
+        }
+
+        if ($unsealedType) {
+            return ShapedArrayType::unsealed($unsealedType, ...$elements);
+        } elseif ($isUnsealed) {
+            return ShapedArrayType::unsealedWithoutType(...$elements);
         }
 
         return new ShapedArrayType(...$elements);

--- a/src/Type/Parser/Lexer/Token/TripleDotsToken.php
+++ b/src/Type/Parser/Lexer/Token/TripleDotsToken.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Type\Parser\Lexer\Token;
+
+use CuyZ\Valinor\Utility\IsSingleton;
+
+/** @internal */
+final class TripleDotsToken implements Token
+{
+    use IsSingleton;
+
+    public function symbol(): string
+    {
+        return '...';
+    }
+}

--- a/src/Type/Types/ArrayKeyType.php
+++ b/src/Type/Types/ArrayKeyType.php
@@ -66,7 +66,7 @@ final class ArrayKeyType implements ScalarType
         return self::$string ??= new self(NativeStringType::get());
     }
 
-    public static function from(Type $type): ?self
+    public static function from(Type $type): self
     {
         return match (true) {
             $type instanceof self => $type,

--- a/tests/Functional/Definition/Repository/Cache/Compiler/TypeCompilerTest.php
+++ b/tests/Functional/Definition/Repository/Cache/Compiler/TypeCompilerTest.php
@@ -124,6 +124,15 @@ final class TypeCompilerTest extends TestCase
             new ShapedArrayElement(new StringValueType('foo'), NativeStringType::get()),
             new ShapedArrayElement(new IntegerValueType(1337), NativeIntegerType::get(), true)
         )];
+        yield [ShapedArrayType::unsealedWithoutType(
+            new ShapedArrayElement(new StringValueType('foo'), NativeStringType::get()),
+            new ShapedArrayElement(new IntegerValueType(1337), NativeIntegerType::get(), true)
+        )];
+        yield [ShapedArrayType::unsealed(
+            new ArrayType(ArrayKeyType::default(), NativeFloatType::get()),
+            new ShapedArrayElement(new StringValueType('foo'), NativeStringType::get()),
+            new ShapedArrayElement(new IntegerValueType(1337), NativeIntegerType::get(), true)
+        )];
         yield [new IterableType(ArrayKeyType::default(), NativeFloatType::get())];
         yield [new IterableType(ArrayKeyType::integer(), NativeIntegerType::get())];
         yield [new IterableType(ArrayKeyType::string(), NativeStringType::get())];

--- a/tests/Functional/Type/Parser/Lexer/NativeLexerTest.php
+++ b/tests/Functional/Type/Parser/Lexer/NativeLexerTest.php
@@ -29,6 +29,9 @@ use CuyZ\Valinor\Type\Parser\Exception\Iterable\ShapedArrayColonTokenMissing;
 use CuyZ\Valinor\Type\Parser\Exception\Iterable\ShapedArrayCommaMissing;
 use CuyZ\Valinor\Type\Parser\Exception\Iterable\ShapedArrayElementTypeMissing;
 use CuyZ\Valinor\Type\Parser\Exception\Iterable\ShapedArrayEmptyElements;
+use CuyZ\Valinor\Type\Parser\Exception\Iterable\ShapedArrayInvalidUnsealedType;
+use CuyZ\Valinor\Type\Parser\Exception\Iterable\ShapedArrayUnexpectedTokenAfterSealedType;
+use CuyZ\Valinor\Type\Parser\Exception\Iterable\ShapedArrayWithoutElementsWithSealedType;
 use CuyZ\Valinor\Type\Parser\Exception\Iterable\SimpleArrayClosingBracketMissing;
 use CuyZ\Valinor\Type\Parser\Exception\MissingClosingQuoteChar;
 use CuyZ\Valinor\Type\Parser\Exception\RightIntersectionTypeMissing;
@@ -1286,6 +1289,51 @@ final class NativeLexerTest extends TestCase
         $this->expectExceptionMessage('Comma missing in shaped array signature `array{0: int, 1: string`.');
 
         $this->parser->parse('array{int, string]');
+    }
+
+    public function test_unsealed_shaped_array_with_missing_closing_bracket_throws_exception(): void
+    {
+        $this->expectException(ShapedArrayClosingBracketMissing::class);
+        $this->expectExceptionCode(1631283658);
+        $this->expectExceptionMessage('Missing closing curly bracket in shaped array signature `array{0: int, ...`.');
+
+        $this->parser->parse('array{int, ...');
+    }
+
+    public function test_shaped_array_with_unsealed_type_with_missing_closing_bracket_throws_exception(): void
+    {
+        $this->expectException(ShapedArrayClosingBracketMissing::class);
+        $this->expectExceptionCode(1631283658);
+        $this->expectExceptionMessage('Missing closing curly bracket in shaped array signature `array{0: int, ...array`.');
+
+        $this->parser->parse('array{int, ...array');
+    }
+
+    public function test_shaped_array_with_invalid_unsealed_type_throws_exception(): void
+    {
+        $this->expectException(ShapedArrayInvalidUnsealedType::class);
+        $this->expectExceptionCode(1711618899);
+        $this->expectExceptionMessage('Invalid unsealed type `string` in shaped array signature `array{0: int, ...string}`, it should be a valid array.');
+
+        $this->parser->parse('array{int, ...string}');
+    }
+
+    public function test_shaped_array_with_unsealed_type_followed_by_unexpected_token_throws_exception(): void
+    {
+        $this->expectException(ShapedArrayUnexpectedTokenAfterSealedType::class);
+        $this->expectExceptionCode(1711618958);
+        $this->expectExceptionMessage('Unexpected `int|string` after sealed type in shaped array signature `array{0: int, ...array<string>int|string`, expected a `}`.');
+
+        $this->parser->parse('array{int, ...array<string>int|string}');
+    }
+
+    public function test_unsealed_shaped_array_without_elements_throws_exception(): void
+    {
+        $this->expectException(ShapedArrayWithoutElementsWithSealedType::class);
+        $this->expectExceptionCode(1711629845);
+        $this->expectExceptionMessage('Missing elements in shaped array signature `array{...array<string>}`.');
+
+        $this->parser->parse('array{...array<string>}');
     }
 
     public function test_missing_min_value_for_integer_range_throws_exception(): void

--- a/tests/Integration/Mapping/Other/PermissiveTypesMappingTest.php
+++ b/tests/Integration/Mapping/Other/PermissiveTypesMappingTest.php
@@ -47,4 +47,30 @@ final class PermissiveTypesMappingTest extends IntegrationTestCase
 
         self::assertSame($source, $result);
     }
+
+    public function test_can_map_to_unsealed_shaped_array_without_type(): void
+    {
+        $source = ['foo' => 'foo', 'bar' => 'bar', 42 => 42];
+
+        try {
+            $result = $this->mapper->map('array{foo: string, ...}', $source);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame($source, $result); // @phpstan-ignore-line / PHPStan does not (yet) understand the unsealed shaped array syntax
+    }
+
+    public function test_can_map_to_unsealed_shaped_array_without_type_or_string(): void
+    {
+        $source = 'foo';
+
+        try {
+            $result = $this->mapper->map('array{foo: string, ...}|string', $source);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame($source, $result);
+    }
 }

--- a/tests/Integration/Mapping/Other/StrictMappingTest.php
+++ b/tests/Integration/Mapping/Other/StrictMappingTest.php
@@ -53,13 +53,22 @@ final class StrictMappingTest extends IntegrationTestCase
         $this->mapperBuilder()->mapper()->map(ObjectContainingUndefinedObjectType::class, ['value' => new stdClass()]);
     }
 
-    public function test_map_to_type_containing_mixed_type_throws_exception(): void
+    public function test_map_to_shaped_array_containing_mixed_type_throws_exception(): void
     {
         $this->expectException(PermissiveTypeFound::class);
         $this->expectExceptionCode(1655231817);
         $this->expectExceptionMessage('Type `mixed` in `array{foo: string, bar: mixed}` is too permissive.');
 
         $this->mapperBuilder()->mapper()->map('array{foo: string, bar: mixed}', ['foo' => 'foo', 'bar' => 42]);
+    }
+
+    public function test_map_to_unsealed_shaped_array_without_type_throws_exception(): void
+    {
+        $this->expectException(PermissiveTypeFound::class);
+        $this->expectExceptionCode(1655231817);
+        $this->expectExceptionMessage('Type `mixed` in `array{foo: string, ...}` is too permissive.');
+
+        $this->mapperBuilder()->mapper()->map('array{foo: string, ...}', ['foo' => 'foo', 'bar' => 42]);
     }
 
     public function test_map_to_object_containing_mixed_type_throws_exception(): void

--- a/tests/Integration/Mapping/UnionMappingTest.php
+++ b/tests/Integration/Mapping/UnionMappingTest.php
@@ -106,6 +106,18 @@ final class UnionMappingTest extends IntegrationTestCase
             'assertion' => fn (mixed $result) => self::assertSame(['status' => 400, 'error' => 'foo'], $result),
         ];
 
+        yield 'unsealed shaped array of non-empty-string or string with array of strings' => [
+            'type' => "array{'en_US': non-empty-string, ...array<non-empty-string, non-empty-string>} | string",
+            'source' => ['en_US' => 'Hello', 'fr_FR' => 'Salut'],
+            'assertion' => fn (mixed $result) => self::assertSame(['en_US' => 'Hello', 'fr_FR' => 'Salut'], $result),
+        ];
+
+        yield 'unsealed shaped array of non-empty-string or string with string' => [
+            'type' => "array{'en_US': non-empty-string, ...array<non-empty-string, non-empty-string>} | string",
+            'source' => 'Hello',
+            'assertion' => fn (mixed $result) => self::assertSame('Hello', $result),
+        ];
+
         yield 'array of string or object with one string value, with array of string' => [
             'type' => 'array<string>|' . SomeObjectWithOneStringValue::class,
             'source' => ['foo', 'bar'],


### PR DESCRIPTION
This syntax enables an extension of the shaped array type by allowing additional values that must respect a certain type.

```php
$mapper = (new \CuyZ\Valinor\MapperBuilder())->mapper();

// Default syntax can be used like this:
$mapper->map(
    'array{foo: string, ...array<string>}',
    [
        'foo' => 'foo',
        'bar' => 'bar', // ✅ valid additional value
    ]
);

$mapper->map(
    'array{foo: string, ...array<string>}',
    [
        'foo' => 'foo',
        'bar' => 1337, // ❌ invalid value 1337
    ]
);

// Key type can be added as well:
$mapper->map(
    'array{foo: string, ...array<int, string>}',
    [
        'foo' => 'foo',
        42 => 'bar', // ✅ valid additional key
    ]
);

$mapper->map(
    'array{foo: string, ...array<int, string>}',
    [
        'foo' => 'foo',
        'bar' => 'bar' // ❌ invalid key
    ]
);

// Advanced types can be used:
$mapper->map(
    "array{
        'en_US': non-empty-string,
        ...array<non-empty-string, non-empty-string>
    }",
    [
        'en_US' => 'Hello',
        'fr_FR' => 'Salut', // ✅ valid additional value
    ]
);

$mapper->map(
    "array{
        'en_US': non-empty-string,
        ...array<non-empty-string, non-empty-string>
    }",
    [
        'en_US' => 'Hello',
        'fr_FR' => '', // ❌ invalid value
    ]
);

// If the permissive type is enabled, the following will work:
(new \CuyZ\Valinor\MapperBuilder())
    ->allowPermissiveTypes()
    ->mapper()
    ->map(
        'array{foo: string, ...}',
        ['foo' => 'foo', 'bar' => 'bar', 42 => 1337]
    ); // ✅
```

Fixes #438