### PR TITLE
fix: load needed information only during interface inferring

### DIFF
--- a/src/Mapper/Tree/Builder/InterfaceNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/InterfaceNodeBuilder.php
@@ -74,7 +74,7 @@ final class InterfaceNodeBuilder implements NodeBuilder
         try {
             $classType = $this->implementations->implementation($className, $values);
         } catch (ObjectImplementationCallbackError $exception) {
-            throw UserlandError::from($exception->original());
+            throw UserlandError::from($exception);
         }
 
         $class = $this->classDefinitionRepository->for($classType);

--- a/src/Mapper/Tree/Builder/ObjectImplementations.php
+++ b/src/Mapper/Tree/Builder/ObjectImplementations.php
@@ -6,20 +6,20 @@ namespace CuyZ\Valinor\Mapper\Tree\Builder;
 
 use CuyZ\Valinor\Definition\FunctionDefinition;
 use CuyZ\Valinor\Definition\FunctionsContainer;
-use CuyZ\Valinor\Mapper\Tree\Exception\InvalidAbstractObjectName;
 use CuyZ\Valinor\Mapper\Tree\Exception\InvalidResolvedImplementationValue;
 use CuyZ\Valinor\Mapper\Tree\Exception\MissingObjectImplementationRegistration;
 use CuyZ\Valinor\Mapper\Tree\Exception\ObjectImplementationCallbackError;
 use CuyZ\Valinor\Mapper\Tree\Exception\ObjectImplementationNotRegistered;
 use CuyZ\Valinor\Mapper\Tree\Exception\ResolvedImplementationIsNotAccepted;
 use CuyZ\Valinor\Type\ClassType;
-use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use CuyZ\Valinor\Type\Parser\TypeParser;
 use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\ClassStringType;
 use CuyZ\Valinor\Type\Types\InterfaceType;
 use CuyZ\Valinor\Type\Types\UnionType;
 use Exception;
+
+use function assert;
 
 /** @internal */
 final class ObjectImplementations
@@ -30,12 +30,7 @@ final class ObjectImplementations
     public function __construct(
         private FunctionsContainer $functions,
         private TypeParser $typeParser
-    ) {
-        foreach ($functions as $name => $function) {
-            /** @var string $name */
-            $this->implementations[$name] = $this->implementations($name);
-        }
-    }
+    ) {}
 
     public function has(string $name): bool
     {
@@ -52,6 +47,9 @@ final class ObjectImplementations
      */
     public function implementation(string $name, array $arguments): ClassType
     {
+        /** @infection-ignore-all / We cannot test the assignment */
+        $this->implementations[$name] ??= $this->implementations($name);
+
         $class = $this->call($name, $arguments);
 
         return $this->implementations[$name][$class]
@@ -83,18 +81,14 @@ final class ObjectImplementations
     {
         $function = $this->functions->get($name)->definition;
 
-        try {
-            $type = $this->typeParser->parse($name);
-        } catch (InvalidType) {
-        }
+        $type = $this->typeParser->parse($name);
 
-        if (! isset($type) || (! $type instanceof InterfaceType && ! $type instanceof ClassType)) {
-            throw new InvalidAbstractObjectName($name);
-        }
+        /** @infection-ignore-all */
+        assert($type instanceof InterfaceType || $type instanceof ClassType);
 
         $classes = $this->implementationsByReturnSignature($name, $function);
 
-        if (empty($classes)) {
+        if ($classes === []) {
             throw new MissingObjectImplementationRegistration($name, $function);
         }
 

--- a/tests/Integration/Cache/CacheInjectionTest.php
+++ b/tests/Integration/Cache/CacheInjectionTest.php
@@ -32,7 +32,7 @@ final class CacheInjectionTest extends IntegrationTestCase
 
         $files = $this->recursivelyFindPhpFiles($cacheDirectory);
 
-        self::assertCount(6, $files);
+        self::assertCount(4, $files);
 
         foreach ($files as $file) {
             $file->setContent($file->getContent() . "\n// generated value 1661895014");

--- a/tests/Integration/Cache/CacheWarmupTest.php
+++ b/tests/Integration/Cache/CacheWarmupTest.php
@@ -64,8 +64,8 @@ final class CacheWarmupTest extends IntegrationTestCase
         $mapper->warmup(ObjectToWarmupWithConstructors::class);
         $mapper->warmup(ObjectToWarmupWithConstructors::class, SomeObjectC::class);
 
-        self::assertSame(7, $this->cache->countEntries());
-        self::assertSame(7, $this->cache->timeSetWasCalled());
+        self::assertSame(6, $this->cache->countEntries());
+        self::assertSame(6, $this->cache->timeSetWasCalled());
     }
 
     public function test_will_warmup_type_parser_cache_for_interface(): void

--- a/tests/Integration/Mapping/InterfaceInferringMappingTest.php
+++ b/tests/Integration/Mapping/InterfaceInferringMappingTest.php
@@ -6,13 +6,11 @@ namespace CuyZ\Valinor\Tests\Integration\Mapping;
 
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Mapper\Tree\Exception\CannotResolveObjectType;
-use CuyZ\Valinor\Mapper\Tree\Exception\InvalidAbstractObjectName;
 use CuyZ\Valinor\Mapper\Tree\Exception\InvalidResolvedImplementationValue;
 use CuyZ\Valinor\Mapper\Tree\Exception\MissingObjectImplementationRegistration;
 use CuyZ\Valinor\Mapper\Tree\Exception\ObjectImplementationCallbackError;
 use CuyZ\Valinor\Mapper\Tree\Exception\ObjectImplementationNotRegistered;
 use CuyZ\Valinor\Mapper\Tree\Exception\ResolvedImplementationIsNotAccepted;
-use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeErrorMessage;
 use CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithDifferentNamespaces\A\ClassThatInheritsInterfaceA;
 use CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithDifferentNamespaces\B\ClassThatInheritsInterfaceB;
 use CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithDifferentNamespaces\ClassWithBothInterfaces;
@@ -279,30 +277,6 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
             ->map(DateTimeInterface::class, []);
     }
 
-    public function test_invalid_abstract_object_name_throws_exception(): void
-    {
-        $this->expectException(InvalidAbstractObjectName::class);
-        $this->expectExceptionCode(1653990369);
-        $this->expectExceptionMessage('Invalid interface or class name `invalid type`.');
-
-        $this->mapperBuilder()
-            ->infer('invalid type', fn () => stdClass::class) // @phpstan-ignore-line
-            ->mapper()
-            ->map(stdClass::class, []);
-    }
-
-    public function test_invalid_abstract_object_type_throws_exception(): void
-    {
-        $this->expectException(InvalidAbstractObjectName::class);
-        $this->expectExceptionCode(1653990369);
-        $this->expectExceptionMessage('Invalid interface or class name `string`.');
-
-        $this->mapperBuilder()
-            ->infer('string', fn () => stdClass::class) // @phpstan-ignore-line
-            ->mapper()
-            ->map(stdClass::class, []);
-    }
-
     public function test_missing_object_implementation_registration_throws_exception(): void
     {
         $this->expectException(MissingObjectImplementationRegistration::class);
@@ -315,7 +289,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
                 fn (string $type) => SomeClassThatInheritsInterfaceA::class
             )
             ->mapper()
-            ->map(SomeInterface::class, []);
+            ->map(SomeInterface::class, 'foo');
     }
 
     public function test_invalid_union_object_implementation_registration_throws_exception(): void
@@ -330,7 +304,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
                 fn (string $value): string|int => $value === 'foo' ? 'foo' : 42
             )
             ->mapper()
-            ->map(SomeInterface::class, []);
+            ->map(SomeInterface::class, 'foo');
     }
 
     public function test_invalid_class_string_object_implementation_registration_throws_exception(): void
@@ -399,25 +373,6 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
             $error = $exception->node()->children()['key']->messages()[0];
 
             self::assertSame("Value 'foo' is not a valid integer.", (string)$error);
-        }
-    }
-
-    public function test_exception_thrown_is_caught_and_throws_message_exception(): void
-    {
-        try {
-            $this->mapperBuilder()
-                ->infer(
-                    DateTimeInterface::class,
-                    /** @return class-string<DateTime> */
-                    fn (string $value) => throw new FakeErrorMessage('some error message', 1645303304)
-                )
-                ->mapper()
-                ->map(DateTimeInterface::class, 'foo');
-        } catch (MappingError $exception) {
-            $error = $exception->node()->messages()[0];
-
-            self::assertSame('1645303304', $error->code());
-            self::assertSame('some error message', (string)$error);
         }
     }
 


### PR DESCRIPTION
This commit changes the way interface inferring is done.

Previously, the whole set of information for all interfaces was loaded everytime the library was used, which could lead to performance issue for no reason.

Now, when an interface must be inferred, only information about this interface will be loaded.