### PR TITLE
feat: handle interface constructor registration

### DIFF
--- a/docs/pages/how-to/infer-interfaces.md
+++ b/docs/pages/how-to/infer-interfaces.md
@@ -1,8 +1,10 @@
 # Inferring interfaces
 
 When the mapper meets an interface, it needs to understand which implementation
-(a class that implements this interface) will be used — this information must be
-provided in the mapper builder, using the method `infer()`.
+will be used. This can be done by [registering a constructor for the interface],
+but it can have limitations. A more powerful way to handle this is to infer the
+implementation based on the data provided to the mapper. This can be done using
+the `infer()` method.
 
 The callback given to this method must return the name of a class that
 implements the interface. Any arguments can be required by the callback; they
@@ -124,3 +126,5 @@ assert($result->foo === 'foo');
 assert($result->bar === 'bar');
 assert($result->baz === 'baz');
 ```
+
+[registering a constructor for the interface]: use-custom-object-constructors.md#interface-implementation-constructor

--- a/docs/pages/how-to/use-custom-object-constructors.md
+++ b/docs/pages/how-to/use-custom-object-constructors.md
@@ -130,6 +130,37 @@ final class Color
 }
 ```
 
+## Interface implementation constructor
+
+By default, the mapper cannot instantiate an interface, as it does not know
+which implementation to use. To do so, it is possible to register a constructor
+for an interface, in the same way as for a class.
+
+!!! note
+
+    Because the mapper cannot automatically guess which implementation can be
+    used for an interface, it is not possible to use the `Constructor`
+    attribute, the `MapperBuilder::registerConstructor()` method must be used
+    instead.
+
+In the example below, the mapper is taught how to instantiate an implementation
+of `UuidInterface` from package [`ramsey/uuid`](https://github.com/ramsey/uuid):
+
+```php
+(new \CuyZ\Valinor\MapperBuilder())
+    ->registerConstructor(
+        // The static method below has return type `UuidInterface`; therefore,
+        // the mapper will build an instance of `Uuid` when it needs to 
+        // instantiate an implementation of `UuidInterface`.
+        Ramsey\Uuid\Uuid::fromString(...)
+    )
+    ->mapper()
+    ->map(
+        Ramsey\Uuid\UuidInterface::class,
+        '663bafbf-c3b5-4336-b27f-1796be8554e0'
+    );
+```
+
 ## Custom enum constructor
 
 Registering a constructor for an enum works the same way as for a class, as

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -1,5 +1,4 @@
 {
-    "timeout": 1,
     "source": {
         "directories": [
             "src"

--- a/src/Definition/ClassDefinition.php
+++ b/src/Definition/ClassDefinition.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Definition;
 
-use CuyZ\Valinor\Type\ClassType;
+use CuyZ\Valinor\Type\ObjectType;
 
 /** @internal */
 final class ClassDefinition
@@ -12,7 +12,7 @@ final class ClassDefinition
     public function __construct(
         /** @var class-string */
         public readonly string $name,
-        public readonly ClassType $type,
+        public readonly ObjectType $type,
         public readonly Attributes $attributes,
         public readonly Properties $properties,
         public readonly Methods $methods,

--- a/src/Definition/Exception/InvalidTypeAliasImportClass.php
+++ b/src/Definition/Exception/InvalidTypeAliasImportClass.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Definition\Exception;
 
-use CuyZ\Valinor\Type\ClassType;
+use CuyZ\Valinor\Type\ObjectType;
 use LogicException;
 
 /** @internal */
 final class InvalidTypeAliasImportClass extends LogicException
 {
-    public function __construct(ClassType $type, string $className)
+    public function __construct(ObjectType $type, string $className)
     {
         parent::__construct(
             "Cannot import a type alias from unknown class `$className` in class `{$type->className()}`.",

--- a/src/Definition/Exception/InvalidTypeAliasImportClassType.php
+++ b/src/Definition/Exception/InvalidTypeAliasImportClassType.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Definition\Exception;
 
+use CuyZ\Valinor\Type\ObjectType;
 use CuyZ\Valinor\Type\Type;
-use CuyZ\Valinor\Type\ClassType;
 use LogicException;
 
 /** @internal */
 final class InvalidTypeAliasImportClassType extends LogicException
 {
-    public function __construct(ClassType $classType, Type $type)
+    public function __construct(ObjectType $classType, Type $type)
     {
         parent::__construct(
             "Importing a type alias can only be done with classes, `{$type->toString()}` was given in class `{$classType->className()}`.",

--- a/src/Definition/Exception/UnknownTypeAliasImport.php
+++ b/src/Definition/Exception/UnknownTypeAliasImport.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Definition\Exception;
 
-use CuyZ\Valinor\Type\ClassType;
+use CuyZ\Valinor\Type\ObjectType;
 use LogicException;
 
 /** @internal */
@@ -13,7 +13,7 @@ final class UnknownTypeAliasImport extends LogicException
     /**
      * @param class-string $importClassName
      */
-    public function __construct(ClassType $type, string $importClassName, string $alias)
+    public function __construct(ObjectType $type, string $importClassName, string $alias)
     {
         parent::__construct(
             "Type alias `$alias` imported in `{$type->className()}` could not be found in `$importClassName`",

--- a/src/Definition/Repository/Cache/CacheClassDefinitionRepository.php
+++ b/src/Definition/Repository/Cache/CacheClassDefinitionRepository.php
@@ -6,7 +6,7 @@ namespace CuyZ\Valinor\Definition\Repository\Cache;
 
 use CuyZ\Valinor\Definition\ClassDefinition;
 use CuyZ\Valinor\Definition\Repository\ClassDefinitionRepository;
-use CuyZ\Valinor\Type\ClassType;
+use CuyZ\Valinor\Type\ObjectType;
 use Psr\SimpleCache\CacheInterface;
 
 use function sha1;
@@ -20,7 +20,7 @@ final class CacheClassDefinitionRepository implements ClassDefinitionRepository
         private CacheInterface $cache
     ) {}
 
-    public function for(ClassType $type): ClassDefinition
+    public function for(ObjectType $type): ClassDefinition
     {
         // @infection-ignore-all
         $key = 'class-definition' . sha1($type->toString());

--- a/src/Definition/Repository/ClassDefinitionRepository.php
+++ b/src/Definition/Repository/ClassDefinitionRepository.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Definition\Repository;
 
 use CuyZ\Valinor\Definition\ClassDefinition;
-use CuyZ\Valinor\Type\ClassType;
+use CuyZ\Valinor\Type\ObjectType;
 
 /** @internal */
 interface ClassDefinitionRepository
 {
-    public function for(ClassType $type): ClassDefinition;
+    public function for(ObjectType $type): ClassDefinition;
 }

--- a/src/Definition/Repository/Reflection/ReflectionClassDefinitionRepository.php
+++ b/src/Definition/Repository/Reflection/ReflectionClassDefinitionRepository.php
@@ -21,7 +21,6 @@ use CuyZ\Valinor\Definition\Properties;
 use CuyZ\Valinor\Definition\PropertyDefinition;
 use CuyZ\Valinor\Definition\Repository\AttributesRepository;
 use CuyZ\Valinor\Definition\Repository\ClassDefinitionRepository;
-use CuyZ\Valinor\Type\ClassType;
 use CuyZ\Valinor\Type\GenericType;
 use CuyZ\Valinor\Type\ObjectType;
 use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
@@ -67,7 +66,7 @@ final class ReflectionClassDefinitionRepository implements ClassDefinitionReposi
         $this->methodBuilder = new ReflectionMethodDefinitionBuilder($this->attributesRepository);
     }
 
-    public function for(ClassType $type): ClassDefinition
+    public function for(ObjectType $type): ClassDefinition
     {
         $reflection = Reflection::class($type->className());
 
@@ -97,7 +96,7 @@ final class ReflectionClassDefinitionRepository implements ClassDefinitionReposi
     /**
      * @return list<PropertyDefinition>
      */
-    private function properties(ClassType $type): array
+    private function properties(ObjectType $type): array
     {
         return array_map(
             function (ReflectionProperty $property) use ($type) {
@@ -112,7 +111,7 @@ final class ReflectionClassDefinitionRepository implements ClassDefinitionReposi
     /**
      * @return list<MethodDefinition>
      */
-    private function methods(ClassType $type): array
+    private function methods(ObjectType $type): array
     {
         $reflection = Reflection::class($type->className());
         $methods = $reflection->getMethods();
@@ -134,7 +133,7 @@ final class ReflectionClassDefinitionRepository implements ClassDefinitionReposi
     /**
      * @param ReflectionClass<object> $target
      */
-    private function typeResolver(ClassType $type, ReflectionClass $target): ReflectionTypeResolver
+    private function typeResolver(ObjectType $type, ReflectionClass $target): ReflectionTypeResolver
     {
         $typeKey = $target->isInterface()
             ? "{$type->toString()}/{$type->className()}"
@@ -209,7 +208,7 @@ final class ReflectionClassDefinitionRepository implements ClassDefinitionReposi
     /**
      * @return array<string, Type>
      */
-    private function importedTypeAliases(ClassType $type): array
+    private function importedTypeAliases(ObjectType $type): array
     {
         $reflection = Reflection::class($type->className());
         $importedTypesRaw = DocParser::importedTypeAliases($reflection);
@@ -258,7 +257,7 @@ final class ReflectionClassDefinitionRepository implements ClassDefinitionReposi
         return $this->typeParserFactory->get(...$specs);
     }
 
-    private function parentType(ClassType $type): NativeClassType
+    private function parentType(ObjectType $type): NativeClassType
     {
         $reflection = Reflection::class($type->className());
 

--- a/src/Library/Container.php
+++ b/src/Library/Container.php
@@ -33,7 +33,7 @@ use CuyZ\Valinor\Mapper\Tree\Builder\ErrorCatcherNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\InterfaceNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\IterableNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\ListNodeBuilder;
-use CuyZ\Valinor\Mapper\Tree\Builder\NativeClassNodeBuilder;
+use CuyZ\Valinor\Mapper\Tree\Builder\ObjectNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\NodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\NullNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\ObjectImplementations;
@@ -111,7 +111,7 @@ final class Container
                     ShapedArrayType::class => new ShapedArrayNodeBuilder($settings->allowSuperfluousKeys),
                     ScalarType::class => new ScalarNodeBuilder($settings->enableFlexibleCasting),
                     NullType::class => new NullNodeBuilder(),
-                    ObjectType::class => new NativeClassNodeBuilder(
+                    ObjectType::class => new ObjectNodeBuilder(
                         $this->get(ClassDefinitionRepository::class),
                         $this->get(ObjectBuilderFactory::class),
                         $this->get(FilteredObjectNodeBuilder::class),

--- a/src/Mapper/Object/Factory/ConstructorObjectBuilderFactory.php
+++ b/src/Mapper/Object/Factory/ConstructorObjectBuilderFactory.php
@@ -131,7 +131,7 @@ final class ConstructorObjectBuilderFactory implements ObjectBuilderFactory
         return array_values($builders);
     }
 
-    private function constructorMatches(FunctionObject $function, ClassType $classType): bool
+    private function constructorMatches(FunctionObject $function, ObjectType $classType): bool
     {
         $definition = $function->definition;
 

--- a/src/Mapper/Object/Factory/DateTimeObjectBuilderFactory.php
+++ b/src/Mapper/Object/Factory/DateTimeObjectBuilderFactory.php
@@ -12,7 +12,7 @@ use CuyZ\Valinor\Mapper\Object\DateTimeFormatConstructor;
 use CuyZ\Valinor\Mapper\Object\FunctionObjectBuilder;
 use CuyZ\Valinor\Mapper\Object\NativeConstructorObjectBuilder;
 use CuyZ\Valinor\Mapper\Object\ObjectBuilder;
-use CuyZ\Valinor\Type\ClassType;
+use CuyZ\Valinor\Type\ObjectType;
 use DateTime;
 use DateTimeImmutable;
 
@@ -51,7 +51,7 @@ final class DateTimeObjectBuilderFactory implements ObjectBuilderFactory
         return $builders;
     }
 
-    private function internalDateTimeBuilder(ClassType $type): FunctionObjectBuilder
+    private function internalDateTimeBuilder(ObjectType $type): FunctionObjectBuilder
     {
         $constructor = new DateTimeFormatConstructor(...$this->supportedDateFormats);
         $function = new FunctionObject($this->functionDefinitionRepository->for($constructor), $constructor);

--- a/src/Mapper/Object/Factory/DateTimeZoneObjectBuilderFactory.php
+++ b/src/Mapper/Object/Factory/DateTimeZoneObjectBuilderFactory.php
@@ -11,7 +11,7 @@ use CuyZ\Valinor\Mapper\Object\FunctionObjectBuilder;
 use CuyZ\Valinor\Mapper\Object\NativeConstructorObjectBuilder;
 use CuyZ\Valinor\Mapper\Object\ObjectBuilder;
 use CuyZ\Valinor\Mapper\Tree\Message\MessageBuilder;
-use CuyZ\Valinor\Type\ClassType;
+use CuyZ\Valinor\Type\ObjectType;
 use DateTimeZone;
 use Exception;
 
@@ -60,7 +60,7 @@ final class DateTimeZoneObjectBuilderFactory implements ObjectBuilderFactory
         return $builders;
     }
 
-    private function defaultBuilder(ClassType $type): FunctionObjectBuilder
+    private function defaultBuilder(ObjectType $type): FunctionObjectBuilder
     {
         $constructor = function (string $timezone) {
             try {

--- a/src/Mapper/Object/FunctionObjectBuilder.php
+++ b/src/Mapper/Object/FunctionObjectBuilder.php
@@ -7,7 +7,7 @@ namespace CuyZ\Valinor\Mapper\Object;
 use CuyZ\Valinor\Definition\FunctionObject;
 use CuyZ\Valinor\Definition\ParameterDefinition;
 use CuyZ\Valinor\Mapper\Tree\Message\UserlandError;
-use CuyZ\Valinor\Type\ClassType;
+use CuyZ\Valinor\Type\ObjectType;
 use Exception;
 
 use function array_map;
@@ -24,7 +24,7 @@ final class FunctionObjectBuilder implements ObjectBuilder
 
     private bool $isDynamicConstructor;
 
-    public function __construct(FunctionObject $function, ClassType $type)
+    public function __construct(FunctionObject $function, ObjectType $type)
     {
         $definition = $function->definition;
 

--- a/src/Mapper/Tree/Builder/FilteredObjectNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/FilteredObjectNodeBuilder.php
@@ -12,7 +12,7 @@ use CuyZ\Valinor\Mapper\Tree\Shell;
 use function count;
 
 /** @internal */
-final class ObjectNodeBuilder
+final class FilteredObjectNodeBuilder
 {
     public function __construct(private bool $allowSuperfluousKeys) {}
 

--- a/src/Mapper/Tree/Builder/NativeClassNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/NativeClassNodeBuilder.php
@@ -8,7 +8,8 @@ use CuyZ\Valinor\Definition\Repository\ClassDefinitionRepository;
 use CuyZ\Valinor\Mapper\Object\Factory\ObjectBuilderFactory;
 use CuyZ\Valinor\Mapper\Object\FilteredObjectBuilder;
 use CuyZ\Valinor\Mapper\Tree\Shell;
-use CuyZ\Valinor\Type\ClassType;
+
+use CuyZ\Valinor\Type\ObjectType;
 
 use function assert;
 
@@ -18,7 +19,7 @@ final class NativeClassNodeBuilder implements NodeBuilder
     public function __construct(
         private ClassDefinitionRepository $classDefinitionRepository,
         private ObjectBuilderFactory $objectBuilderFactory,
-        private ObjectNodeBuilder $objectNodeBuilder,
+        private FilteredObjectNodeBuilder $filteredObjectNodeBuilder,
         private bool $enableFlexibleCasting,
     ) {}
 
@@ -27,7 +28,7 @@ final class NativeClassNodeBuilder implements NodeBuilder
         $type = $shell->type();
 
         // @infection-ignore-all
-        assert($type instanceof ClassType);
+        assert($type instanceof ObjectType);
 
         if ($this->enableFlexibleCasting && $shell->value() === null) {
             $shell = $shell->withValue([]);
@@ -36,6 +37,6 @@ final class NativeClassNodeBuilder implements NodeBuilder
         $class = $this->classDefinitionRepository->for($type);
         $objectBuilder = FilteredObjectBuilder::from($shell->value(), ...$this->objectBuilderFactory->for($class));
 
-        return $this->objectNodeBuilder->build($objectBuilder, $shell, $rootBuilder);
+        return $this->filteredObjectNodeBuilder->build($objectBuilder, $shell, $rootBuilder);
     }
 }

--- a/src/Mapper/Tree/Builder/ObjectNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ObjectNodeBuilder.php
@@ -14,7 +14,7 @@ use CuyZ\Valinor\Type\ObjectType;
 use function assert;
 
 /** @internal */
-final class NativeClassNodeBuilder implements NodeBuilder
+final class ObjectNodeBuilder implements NodeBuilder
 {
     public function __construct(
         private ClassDefinitionRepository $classDefinitionRepository,

--- a/src/Mapper/Tree/Exception/InterfaceHasBothConstructorAndInfer.php
+++ b/src/Mapper/Tree/Exception/InterfaceHasBothConstructorAndInfer.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Tree\Exception;
+
+use LogicException;
+
+/** @internal */
+final class InterfaceHasBothConstructorAndInfer extends LogicException
+{
+    /**
+     * @param interface-string $name
+     */
+    public function __construct(string $name)
+    {
+        parent::__construct(
+            "Interface `$name` is configured with at least one constructor but also has an infer configuration. Only one method can be used.",
+            1711915749,
+        );
+    }
+}

--- a/src/Type/Types/InterfaceType.php
+++ b/src/Type/Types/InterfaceType.php
@@ -51,7 +51,7 @@ final class InterfaceType implements ObjectType, GenericType
             return false;
         }
 
-        return is_a($other->className(), $this->interfaceName, true);
+        return is_a($this->interfaceName, $other->className(), true);
     }
 
     public function traverse(): array

--- a/tests/Fake/Definition/Repository/FakeClassDefinitionRepository.php
+++ b/tests/Fake/Definition/Repository/FakeClassDefinitionRepository.php
@@ -7,11 +7,11 @@ namespace CuyZ\Valinor\Tests\Fake\Definition\Repository;
 use CuyZ\Valinor\Definition\ClassDefinition;
 use CuyZ\Valinor\Definition\Repository\ClassDefinitionRepository;
 use CuyZ\Valinor\Tests\Fake\Definition\FakeClassDefinition;
-use CuyZ\Valinor\Type\ClassType;
+use CuyZ\Valinor\Type\ObjectType;
 
 final class FakeClassDefinitionRepository implements ClassDefinitionRepository
 {
-    public function for(ClassType $type): ClassDefinition
+    public function for(ObjectType $type): ClassDefinition
     {
         return FakeClassDefinition::new();
     }

--- a/tests/Unit/Type/Types/InterfaceTypeTest.php
+++ b/tests/Unit/Type/Types/InterfaceTypeTest.php
@@ -66,8 +66,8 @@ final class InterfaceTypeTest extends TestCase
 
     public function test_matches_sub_class(): void
     {
-        $interfaceTypeA = new InterfaceType(DateTimeInterface::class);
-        $interfaceTypeB = new InterfaceType(DateTime::class);
+        $interfaceTypeA = new InterfaceType(SomeChildInterface::class);
+        $interfaceTypeB = new InterfaceType(SomeParentInterface::class);
 
         self::assertTrue($interfaceTypeA->matches($interfaceTypeB));
     }
@@ -117,11 +117,11 @@ final class InterfaceTypeTest extends TestCase
     public function test_matches_intersection_of_valid_types(): void
     {
         $intersectionType = new IntersectionType(
-            new InterfaceType(DateTimeInterface::class),
-            new InterfaceType(DateTime::class)
+            new InterfaceType(SomeParentInterface::class),
+            new InterfaceType(SomeOtherParentInterface::class),
         );
 
-        self::assertTrue((new InterfaceType(DateTimeInterface::class))->matches($intersectionType));
+        self::assertTrue((new InterfaceType(SomeChildInterface::class))->matches($intersectionType));
     }
 
     public function test_does_not_match_intersection_containing_invalid_type(): void
@@ -134,3 +134,9 @@ final class InterfaceTypeTest extends TestCase
         self::assertFalse((new InterfaceType(DateTime::class))->matches($intersectionType));
     }
 }
+
+interface SomeParentInterface {}
+
+interface SomeOtherParentInterface {}
+
+interface SomeChildInterface extends SomeParentInterface, SomeOtherParentInterface {}


### PR DESCRIPTION
By default, the mapper cannot instantiate an interface, as it does not
know which implementation to use. To do so, the `MapperBuilder::infer()`
method can be used, but it is cumbersome in most cases.

It is now also possible to register a constructor for an interface, in
the same way as for a class.

Because the mapper cannot automatically guess which implementation can
be used for an interface, it is not possible to use the `Constructor`
attribute, the `MapperBuilder::registerConstructor()` method must be
used instead.

In the example below, the mapper is taught how to instantiate an
implementation of `UuidInterface` from package `ramsey/uuid`:

```php
(new \CuyZ\Valinor\MapperBuilder())
    ->registerConstructor(
        // The static method below has return type `UuidInterface`;
        // therefore, the mapper will build an instance of `Uuid` when
        // it needs to instantiate an implementation of `UuidInterface`.
        Ramsey\Uuid\Uuid::fromString(...)
    )
    ->mapper()
    ->map(
        Ramsey\Uuid\UuidInterface::class,
        '663bafbf-c3b5-4336-b27f-1796be8554e0'
    );
```

Fixes #217
Fixes #426 