### PR TITLE
fix: properly handle nested local type aliases

### DIFF
--- a/src/Definition/Repository/Reflection/TypeResolver/ClassImportedTypeAliasResolver.php
+++ b/src/Definition/Repository/Reflection/TypeResolver/ClassImportedTypeAliasResolver.php
@@ -77,7 +77,7 @@ final class ClassImportedTypeAliasResolver
 
         $importedAliases = [];
 
-        $annotations = (new Annotations($docBlock))->allOf(
+        $annotations = (new Annotations($docBlock))->filteredByPriority(
             '@phpstan-import-type',
             '@psalm-import-type',
         );

--- a/src/Definition/Repository/Reflection/TypeResolver/ClassLocalTypeAliasResolver.php
+++ b/src/Definition/Repository/Reflection/TypeResolver/ClassLocalTypeAliasResolver.php
@@ -32,12 +32,12 @@ final class ClassLocalTypeAliasResolver
             return [];
         }
 
-        $typeParser = $this->typeParserFactory->buildAdvancedTypeParserForClass($type);
-
         $types = [];
 
         foreach ($localAliases as $name => $raw) {
             try {
+                $typeParser = $this->typeParserFactory->buildAdvancedTypeParserForClass($type, $types);
+
                 $types[$name] = $typeParser->parse($raw);
             } catch (InvalidType $exception) {
                 $types[$name] = UnresolvableType::forLocalAlias($raw, $name, $type, $exception);
@@ -61,7 +61,7 @@ final class ClassLocalTypeAliasResolver
 
         $aliases = [];
 
-        $annotations = (new Annotations($docBlock))->allOf(
+        $annotations = (new Annotations($docBlock))->filteredInOrder(
             '@phpstan-type',
             '@psalm-type',
         );
@@ -80,7 +80,7 @@ final class ClassLocalTypeAliasResolver
             $key = key($tokens);
 
             if ($key !== null) {
-                $aliases[$name] ??= $annotation->allAfter($key);
+                $aliases[$name] = $annotation->allAfter($key);
             }
         }
 

--- a/src/Definition/Repository/Reflection/TypeResolver/ClassParentTypeResolver.php
+++ b/src/Definition/Repository/Reflection/TypeResolver/ClassParentTypeResolver.php
@@ -72,7 +72,7 @@ final class ClassParentTypeResolver
             return [];
         }
 
-        $annotations = (new Annotations($docBlock))->allOf(
+        $annotations = (new Annotations($docBlock))->filteredByPriority(
             '@phpstan-extends',
             '@psalm-extends',
             '@extends',

--- a/src/Definition/Repository/Reflection/TypeResolver/ClassTemplatesResolver.php
+++ b/src/Definition/Repository/Reflection/TypeResolver/ClassTemplatesResolver.php
@@ -10,7 +10,6 @@ use CuyZ\Valinor\Utility\Reflection\Reflection;
 
 use function array_key_exists;
 use function array_keys;
-use function array_reverse;
 use function current;
 use function key;
 
@@ -40,7 +39,7 @@ final class ClassTemplatesResolver
 
         $templates = [];
 
-        $annotations = (new Annotations($docBlock))->allOf(
+        $annotations = (new Annotations($docBlock))->filteredByPriority(
             '@phpstan-template',
             '@psalm-template',
             '@template',
@@ -72,6 +71,6 @@ final class ClassTemplatesResolver
             }
         }
 
-        return array_reverse($templates);
+        return $templates;
     }
 }

--- a/src/Definition/Repository/Reflection/TypeResolver/FunctionReturnTypeResolver.php
+++ b/src/Definition/Repository/Reflection/TypeResolver/FunctionReturnTypeResolver.php
@@ -37,6 +37,6 @@ final class FunctionReturnTypeResolver
             '@phpstan-return',
             '@psalm-return',
             '@return',
-        );
+        )?->raw();
     }
 }

--- a/src/Definition/Repository/Reflection/TypeResolver/ParameterTypeResolver.php
+++ b/src/Definition/Repository/Reflection/TypeResolver/ParameterTypeResolver.php
@@ -58,7 +58,7 @@ final class ParameterTypeResolver
             return null;
         }
 
-        $annotations = (new Annotations($docBlock))->allOf(
+        $annotations = (new Annotations($docBlock))->filteredByPriority(
             '@phpstan-param',
             '@psalm-param',
             '@param',

--- a/src/Definition/Repository/Reflection/TypeResolver/PropertyTypeResolver.php
+++ b/src/Definition/Repository/Reflection/TypeResolver/PropertyTypeResolver.php
@@ -37,6 +37,6 @@ final class PropertyTypeResolver
             '@phpstan-var',
             '@psalm-var',
             '@var',
-        );
+        )?->raw();
     }
 }

--- a/src/Type/Parser/Lexer/TokenizedAnnotation.php
+++ b/src/Type/Parser/Lexer/TokenizedAnnotation.php
@@ -11,9 +11,19 @@ use function trim;
 final class TokenizedAnnotation
 {
     public function __construct(
+        /** @var non-empty-string */
+        private string $name,
         /** @var non-empty-list<string>> */
         private array $tokens,
     ) {}
+
+    /**
+     * @return non-empty-string
+     */
+    public function name(): string
+    {
+        return $this->name;
+    }
 
     public function splice(int $length): string
     {

--- a/tests/Functional/Definition/Repository/Reflection/TypeResolver/ClassLocalTypeAliasResolverTest.php
+++ b/tests/Functional/Definition/Repository/Reflection/TypeResolver/ClassLocalTypeAliasResolverTest.php
@@ -81,5 +81,47 @@ final class ClassLocalTypeAliasResolverTest extends TestCase
                 'SomeType' => 'int<42, 1337>',
             ]
         ];
+
+        yield 'types can be nested' => [
+            'className' => (
+                /**
+                 * @phpstan-type SomeType = non-empty-string
+                 * @phpstan-type SomeNestedType = array<SomeType>
+                 */
+                new class () {}
+            )::class,
+            [
+                'SomeType' => 'non-empty-string',
+                'SomeNestedType' => 'array<non-empty-string>',
+            ]
+        ];
+
+        yield 'PHPStan type can use a Psalm type' => [
+            'className' => (
+                /**
+                 * @psalm-type SomeType = non-empty-string
+                 * @phpstan-type SomeNestedType = array<SomeType>
+                 */
+                new class () {}
+            )::class,
+            [
+                'SomeType' => 'non-empty-string',
+                'SomeNestedType' => 'array<non-empty-string>',
+            ]
+        ];
+
+        yield 'Psalm type can use a PHPStan type' => [
+            'className' => (
+                /**
+                 * @phpstan-type SomeType = non-empty-string
+                 * @psalm-type SomeNestedType = array<SomeType>
+                 */
+                new class () {}
+            )::class,
+            [
+                'SomeType' => 'non-empty-string',
+                'SomeNestedType' => 'array<non-empty-string>',
+            ]
+        ];
     }
 }

--- a/tests/Functional/Definition/Repository/Reflection/TypeResolver/PropertyTypeResolverTest.php
+++ b/tests/Functional/Definition/Repository/Reflection/TypeResolver/PropertyTypeResolverTest.php
@@ -139,5 +139,15 @@ final class PropertyTypeResolverTest extends TestCase
             }, 'foo'),
             'non-empty-string',
         ];
+
+        yield 'docBlock present but no @var annotation' => [
+            new ReflectionProperty(new class () {
+                /**
+                 * Some comment
+                 */
+                public string $foo;
+            }, 'foo'),
+            'string',
+        ];
     }
 }

--- a/tests/Unit/Type/Parser/Lexer/AnnotationsTest.php
+++ b/tests/Unit/Type/Parser/Lexer/AnnotationsTest.php
@@ -24,7 +24,7 @@ final class AnnotationsTest extends TestCase
         foreach ($expectedAnnotations as $name => $expected) {
             $result = array_map(
                 fn (TokenizedAnnotation $annotation) => $annotation->raw(),
-                $annotations->allOf($name)
+                $annotations->filteredByPriority($name)
             );
 
             self::assertSame($expected, $result);


### PR DESCRIPTION
The following annotation now works properly:

```php
/**
 * @phpstan-type Address = array{street?: string, city: string}
 * @phpstan-type User = array{name: non-empty-string, address: Address}
 */
final class SomeClass
{
    public function __construct(
        /** @var User */
        public $value,
    ) {}
}

(new \CuyZ\Valinor\MapperBuilder())
    ->mapper()
    ->map(SomeClass::class, [
        'name' => 'John Doe',
        'address' => [
            'street' => 'Bron-Yr-Aur',
            'city' => 'SY20 8QA, Machynlleth',
        ],
    ]);
 ```

Fixes #308
Fixes #428 