### PR TITLE
fix: skip node build for NullType when value is not null

### DIFF
--- a/src/Mapper/Tree/Builder/UnionNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/UnionNodeBuilder.php
@@ -13,6 +13,7 @@ use CuyZ\Valinor\Type\IntegerType;
 use CuyZ\Valinor\Type\ScalarType;
 use CuyZ\Valinor\Type\StringType;
 use CuyZ\Valinor\Type\Types\InterfaceType;
+use CuyZ\Valinor\Type\Types\NullType;
 use CuyZ\Valinor\Type\Types\ShapedArrayType;
 use CuyZ\Valinor\Type\Types\UnionType;
 
@@ -38,6 +39,12 @@ final class UnionNodeBuilder implements NodeBuilder
         $all = [];
 
         foreach ($type->types() as $subType) {
+            // Performance optimisation: No need to perform a node build for NullType if the value is not null.
+            // This speeds up the very common case of nullable types by halving the amount of node build calls.
+            if ($subType instanceof NullType && $shell->value() !== null) {
+                continue;
+            }
+
             $node = $rootBuilder->build($shell->withType($subType));
 
             if (! $node->isValid()) {

--- a/src/Mapper/Tree/Builder/UnionNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/UnionNodeBuilder.php
@@ -39,9 +39,13 @@ final class UnionNodeBuilder implements NodeBuilder
         $all = [];
 
         foreach ($type->types() as $subType) {
-            // Performance optimisation: No need to perform a node build for NullType if the value is not null.
-            // This speeds up the very common case of nullable types by halving the amount of node build calls.
-            if ($subType instanceof NullType && $shell->value() !== null) {
+            // Performance optimisation: a `NullType` only accepts a `null`
+            // value, in which case the `CasterProxyNodeBuilder` would have
+            // handled it already. We can safely skip it here.
+            //
+            // @infection-ignore-all / This is a performance optimisation, so we
+            // cannot easily test this behavior.
+            if ($subType instanceof NullType) {
                 continue;
             }
 

--- a/tests/Integration/Mapping/UnionMappingTest.php
+++ b/tests/Integration/Mapping/UnionMappingTest.php
@@ -58,6 +58,12 @@ final class UnionMappingTest extends IntegrationTestCase
 
     public static function union_mapping_works_properly_data_provider(): iterable
     {
+        yield 'nullable scalar' => [
+            'type' => 'string|null',
+            'source' => null,
+            'assertion' => fn (mixed $result) => self::assertNull($result),
+        ];
+
         yield 'string or list of string, with string' => [
             'type' => 'string|list<string>',
             'source' => 'foo',


### PR DESCRIPTION
Version 1.11 revamped union types but also deleted a fast path present in 1.10. In our use cases with many large objects with many nullable properties, this caused execution times to nearly double, especially with XDebug enabled.

The following test case sees its execution time drop from ~6.7 seconds to ~3.6 seconds on my local machine with the included patch. Profiling the test sees a reduction of node build calls to nearly half the original value.

```php
<?php

declare(strict_types=1);

namespace CuyZ\Valinor\Tests\Integration\Mapping;

use CuyZ\Valinor\Mapper\MappingError;
use CuyZ\Valinor\Mapper\Source\Source;
use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;

final class LotsOfObjectsMappingTest extends IntegrationTestCase
{
    public function test_can_map_lots_of_objects(): void
    {
        $objects = [];

        for ($i = 0; $i < 10000; ++$i) {
            $objects[] = [
                'valueA' => 'foo',
                'valueB' => 'bar',
                'valueC' => [
                    'valueA' => 'baz',
                    'valueB' => 'qux',
                ],
            ];
        }

        try {
            $result = $this->mapperBuilder()
                ->mapper()
                ->map(
                    'array<' . SomeClassWithNullableProperties::class . '>',
                    Source::array($objects)
                );
        } catch (MappingError $error) {
            $this->mappingFail($error);
        }

        self::assertCount(10000, $result);
    }
}

final class SomeClassWithNullableProperties
{
    public function __construct(
        public string                               $valueA,
        public string                               $valueB,
        public SomeClassWithNullableProperties|null $valueC = null,
        public SomeClassWithNullableProperties|null $valueD = null,
    ) {}
}
```