### PR TITLE
feat: support normalizing `Ds\Collection`

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       php-version: '8.1'
-      php-extensions: yaml
+      php-extensions: ds,yaml
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
           - "8.3"
 
     env:
-      php-extensions: yaml
+      php-extensions: ds,yaml
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/tests/Integration/Normalizer/NormalizerTest.php
+++ b/tests/Integration/Normalizer/NormalizerTest.php
@@ -203,6 +203,24 @@ final class NormalizerTest extends IntegrationTestCase
             'expected json' => '{"foo":"foo","bar":"bar"}',
         ];
 
+        yield 'Ds Map' => [
+            'input' => new \Ds\Map(['foo' => 'foo', 'bar' => 'bar']),
+            'expected array' => [
+                'foo' => 'foo',
+                'bar' => 'bar',
+            ],
+            'expected json' => '{"foo":"foo","bar":"bar"}',
+        ];
+
+        yield 'Ds Set' => [
+            'input' => new \Ds\Set(['foo', 'bar']),
+            'expected array' => [
+                0 => 'foo',
+                1 => 'bar',
+            ],
+            'expected json' => '["foo","bar"]',
+        ];
+
         yield 'class inheriting ArrayObject' => [
             'input' => new class (['foo' => 'foo', 'bar' => 'bar']) extends ArrayObject {},
             'expected array' => [

--- a/tests/Integration/Normalizer/NormalizerTest.php
+++ b/tests/Integration/Normalizer/NormalizerTest.php
@@ -311,10 +311,9 @@ final class NormalizerTest extends IntegrationTestCase
                 }
             },
             'expected array' => [
-                'foo' => 'foo',
-                'bar' => 'bar',
+                'baz' => 'baz',
             ],
-            'expected json' => '{"foo":"foo","bar":"bar"}',
+            'expected json' => '{"baz":"baz"}',
         ];
 
         yield 'date with default transformer' => [
@@ -384,7 +383,7 @@ final class NormalizerTest extends IntegrationTestCase
             'expected array' => 'value',
             'expected json' => '"value"',
             'transformers' => [
-                [fn (object $object) => 'value'],
+                [fn (IteratorAggregate $object) => 'value'],
             ],
         ];
 


### PR DESCRIPTION
When I use transformers

```php
(new \CuyZ\Valinor\MapperBuilder())
    ->registerTransformer(fn (\Ds\Set $v) => $v->toArray())
    ->registerTransformer(fn(Value $v) => $v->get())
    ->normalizer(\CuyZ\Valinor\Normalizer\Format::json())
```

My `\Ds\Set<Value>` is normalized to `array<Value>` but the Value is then ignored since the serialization is not recursive for the `Set`.

This fixes it.

Initially, I wanted to make this work for all `IteratorAggregate`s and `Iterator`s but with then `'iterable class'` case does not pass since it is designed to serialize its properties and not inner Iterator.
