### PR TITLE
misc: exclude unneeded attributes in class/function definitions

### DIFF
--- a/src/Definition/Repository/AttributesRepository.php
+++ b/src/Definition/Repository/AttributesRepository.php
@@ -5,13 +5,19 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Definition\Repository;
 
 use CuyZ\Valinor\Definition\AttributeDefinition;
-use ReflectionAttribute;
+use ReflectionClass;
+use ReflectionFunction;
+use ReflectionMethod;
+use ReflectionParameter;
+use ReflectionProperty;
+use Reflector;
 
 /** @internal */
 interface AttributesRepository
 {
     /**
-     * @param ReflectionAttribute<object> $reflection
+     * @param ReflectionClass<object>|ReflectionProperty|ReflectionMethod|ReflectionFunction|ReflectionParameter $reflection
+     * @return list<AttributeDefinition>
      */
-    public function for(ReflectionAttribute $reflection): AttributeDefinition;
+    public function for(Reflector $reflection): array;
 }

--- a/src/Definition/Repository/Reflection/ReflectionAttributesRepository.php
+++ b/src/Definition/Repository/Reflection/ReflectionAttributesRepository.php
@@ -7,21 +7,68 @@ namespace CuyZ\Valinor\Definition\Repository\Reflection;
 use CuyZ\Valinor\Definition\AttributeDefinition;
 use CuyZ\Valinor\Definition\Repository\AttributesRepository;
 use CuyZ\Valinor\Definition\Repository\ClassDefinitionRepository;
+use CuyZ\Valinor\Normalizer\AsTransformer;
 use CuyZ\Valinor\Type\Types\NativeClassType;
+use CuyZ\Valinor\Utility\Reflection\Reflection;
+use Error;
 use ReflectionAttribute;
+use Reflector;
+
+use function array_map;
+use function array_values;
 
 /** @internal */
 final class ReflectionAttributesRepository implements AttributesRepository
 {
-    public function __construct(private ClassDefinitionRepository $classDefinitionRepository) {}
+    public function __construct(
+        private ClassDefinitionRepository $classDefinitionRepository,
+        /** @var list<class-string> */
+        private array $allowedAttributes,
+    ) {}
 
-    public function for(ReflectionAttribute $reflection): AttributeDefinition
+    public function for(Reflector $reflection): array
     {
-        $class = $this->classDefinitionRepository->for(new NativeClassType($reflection->getName()));
+        $attributes = array_filter(
+            $reflection->getAttributes(),
+            function (ReflectionAttribute $attribute) {
+                foreach ($this->allowedAttributes as $allowedAttribute) {
+                    if (is_a($attribute->getName(), $allowedAttribute, true)) {
+                        return $this->attributeCanBeInstantiated($attribute);
+                    }
+                }
 
-        return new AttributeDefinition(
-            $class,
-            $reflection->getArguments(),
+                $parentAttributes = Reflection::class($attribute->getName())->getAttributes(AsTransformer::class);
+
+                return $parentAttributes !== [];
+            },
         );
+
+        return array_values(array_map(
+            fn (ReflectionAttribute $attribute) => new AttributeDefinition(
+                $this->classDefinitionRepository->for(new NativeClassType($attribute->getName())),
+                $attribute->getArguments(),
+            ),
+            $attributes,
+        ));
+    }
+
+    /**
+     * @param ReflectionAttribute<object> $attribute
+     */
+    private function attributeCanBeInstantiated(ReflectionAttribute $attribute): bool
+    {
+        try {
+            $attribute->newInstance();
+
+            return true;
+        } catch (Error) {
+            // Race condition when the attribute is affected to a property/parameter
+            // that was PROMOTED, in this case the attribute will be applied to both
+            // ParameterReflection AND PropertyReflection, BUT the target arg inside the attribute
+            // class is configured to support only ONE of them (parameter OR property)
+            // https://wiki.php.net/rfc/constructor_promotion#attributes for more details.
+            // Ignore attribute if the instantiation failed.
+            return false;
+        }
     }
 }

--- a/src/Definition/Repository/Reflection/ReflectionFunctionDefinitionRepository.php
+++ b/src/Definition/Repository/Reflection/ReflectionFunctionDefinitionRepository.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Definition\Repository\Reflection;
 
-use CuyZ\Valinor\Definition\AttributeDefinition;
 use CuyZ\Valinor\Definition\Attributes;
 use CuyZ\Valinor\Definition\FunctionDefinition;
 use CuyZ\Valinor\Definition\Parameters;
@@ -15,7 +14,6 @@ use CuyZ\Valinor\Definition\Repository\Reflection\TypeResolver\ReflectionTypeRes
 use CuyZ\Valinor\Type\Parser\Factory\TypeParserFactory;
 use CuyZ\Valinor\Type\Types\UnresolvableType;
 use CuyZ\Valinor\Utility\Reflection\Reflection;
-use ReflectionAttribute;
 use ReflectionFunction;
 use ReflectionParameter;
 
@@ -70,24 +68,13 @@ final class ReflectionFunctionDefinitionRepository implements FunctionDefinition
         return new FunctionDefinition(
             $name,
             $signature,
-            new Attributes(...$this->attributes($reflection)),
+            new Attributes(...$this->attributesRepository->for($reflection)),
             $reflection->getFileName() ?: null,
             $class?->name,
             $reflection->getClosureThis() === null,
             $isClosure,
             new Parameters(...$parameters),
             $returnType,
-        );
-    }
-
-    /**
-     * @return list<AttributeDefinition>
-     */
-    private function attributes(ReflectionFunction $reflection): array
-    {
-        return array_map(
-            fn (ReflectionAttribute $attribute) => $this->attributesRepository->for($attribute),
-            Reflection::attributes($reflection),
         );
     }
 

--- a/src/Definition/Repository/Reflection/ReflectionMethodDefinitionBuilder.php
+++ b/src/Definition/Repository/Reflection/ReflectionMethodDefinitionBuilder.php
@@ -11,8 +11,6 @@ use CuyZ\Valinor\Definition\Repository\AttributesRepository;
 use CuyZ\Valinor\Definition\Repository\Reflection\TypeResolver\FunctionReturnTypeResolver;
 use CuyZ\Valinor\Definition\Repository\Reflection\TypeResolver\ReflectionTypeResolver;
 use CuyZ\Valinor\Type\Types\UnresolvableType;
-use CuyZ\Valinor\Utility\Reflection\Reflection;
-use ReflectionAttribute;
 use ReflectionMethod;
 use ReflectionParameter;
 
@@ -37,11 +35,6 @@ final class ReflectionMethodDefinitionBuilder
         $name = $reflection->name;
         $signature = $reflection->getDeclaringClass()->name . '::' . $reflection->name . '()';
 
-        $attributes = array_map(
-            fn (ReflectionAttribute $attribute) => $this->attributesRepository->for($attribute),
-            Reflection::attributes($reflection)
-        );
-
         $parameters = array_map(
             fn (ReflectionParameter $parameter) => $this->parameterBuilder->for($parameter, $typeResolver),
             $reflection->getParameters()
@@ -61,7 +54,7 @@ final class ReflectionMethodDefinitionBuilder
         return new MethodDefinition(
             $name,
             $signature,
-            new Attributes(...$attributes),
+            new Attributes(...$this->attributesRepository->for($reflection)),
             new Parameters(...$parameters),
             $reflection->isStatic(),
             $reflection->isPublic(),

--- a/src/Definition/Repository/Reflection/ReflectionParameterDefinitionBuilder.php
+++ b/src/Definition/Repository/Reflection/ReflectionParameterDefinitionBuilder.php
@@ -4,18 +4,13 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Definition\Repository\Reflection;
 
-use CuyZ\Valinor\Definition\AttributeDefinition;
 use CuyZ\Valinor\Definition\Attributes;
 use CuyZ\Valinor\Definition\ParameterDefinition;
 use CuyZ\Valinor\Definition\Repository\AttributesRepository;
 use CuyZ\Valinor\Definition\Repository\Reflection\TypeResolver\ParameterTypeResolver;
 use CuyZ\Valinor\Definition\Repository\Reflection\TypeResolver\ReflectionTypeResolver;
 use CuyZ\Valinor\Type\Types\UnresolvableType;
-use CuyZ\Valinor\Utility\Reflection\Reflection;
-use ReflectionAttribute;
 use ReflectionParameter;
-
-use function array_map;
 
 /** @internal */
 final class ReflectionParameterDefinitionBuilder
@@ -58,18 +53,7 @@ final class ReflectionParameterDefinitionBuilder
             $isOptional,
             $isVariadic,
             $defaultValue,
-            new Attributes(...$this->attributes($reflection)),
-        );
-    }
-
-    /**
-     * @return list<AttributeDefinition>
-     */
-    private function attributes(ReflectionParameter $reflection): array
-    {
-        return array_map(
-            fn (ReflectionAttribute $attribute) => $this->attributesRepository->for($attribute),
-            Reflection::attributes($reflection)
+            new Attributes(...$this->attributesRepository->for($reflection)),
         );
     }
 

--- a/src/Definition/Repository/Reflection/ReflectionPropertyDefinitionBuilder.php
+++ b/src/Definition/Repository/Reflection/ReflectionPropertyDefinitionBuilder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Definition\Repository\Reflection;
 
-use CuyZ\Valinor\Definition\AttributeDefinition;
 use CuyZ\Valinor\Definition\Attributes;
 use CuyZ\Valinor\Definition\PropertyDefinition;
 use CuyZ\Valinor\Definition\Repository\AttributesRepository;
@@ -13,11 +12,7 @@ use CuyZ\Valinor\Definition\Repository\Reflection\TypeResolver\ReflectionTypeRes
 use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\NullType;
 use CuyZ\Valinor\Type\Types\UnresolvableType;
-use CuyZ\Valinor\Utility\Reflection\Reflection;
-use ReflectionAttribute;
 use ReflectionProperty;
-
-use function array_map;
 
 /** @internal */
 final class ReflectionPropertyDefinitionBuilder
@@ -53,7 +48,7 @@ final class ReflectionPropertyDefinitionBuilder
             $hasDefaultValue,
             $defaultValue,
             $isPublic,
-            new Attributes(...$this->attributes($reflection)),
+            new Attributes(...$this->attributesRepository->for($reflection)),
         );
     }
 
@@ -65,16 +60,5 @@ final class ReflectionPropertyDefinitionBuilder
 
         return $reflection->getDeclaringClass()->getDefaultProperties()[$reflection->name] !== null
             || NullType::get()->matches($type);
-    }
-
-    /**
-     * @return list<AttributeDefinition>
-     */
-    private function attributes(ReflectionProperty $reflection): array
-    {
-        return array_map(
-            fn (ReflectionAttribute $attribute) => $this->attributesRepository->for($attribute),
-            Reflection::attributes($reflection)
-        );
     }
 }

--- a/src/Library/Container.php
+++ b/src/Library/Container.php
@@ -206,6 +206,7 @@ final class Container
             ClassDefinitionRepository::class => fn () => new CacheClassDefinitionRepository(
                 new ReflectionClassDefinitionRepository(
                     $this->get(TypeParserFactory::class),
+                    $settings->allowedAttributes(),
                 ),
                 $this->get(CacheInterface::class),
             ),
@@ -215,6 +216,7 @@ final class Container
                     $this->get(TypeParserFactory::class),
                     new ReflectionAttributesRepository(
                         $this->get(ClassDefinitionRepository::class),
+                        $settings->allowedAttributes(),
                     ),
                 ),
                 $this->get(CacheInterface::class)

--- a/src/Library/Settings.php
+++ b/src/Library/Settings.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Library;
 
+use CuyZ\Valinor\Mapper\Object\Constructor;
+use CuyZ\Valinor\Mapper\Object\DynamicConstructor;
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
+use CuyZ\Valinor\Normalizer\AsTransformer;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Psr\SimpleCache\CacheInterface;
 use Throwable;
+
+use function array_keys;
 
 /** @internal */
 final class Settings
@@ -57,6 +62,19 @@ final class Settings
     {
         $this->inferredMapping[DateTimeInterface::class] = static fn () => DateTimeImmutable::class;
         $this->exceptionFilter = fn (Throwable $exception) => throw $exception;
+    }
+
+    /**
+     * @return non-empty-list<class-string>
+     */
+    public function allowedAttributes(): array
+    {
+        return [
+            AsTransformer::class,
+            Constructor::class,
+            DynamicConstructor::class,
+            ...array_keys($this->transformerAttributes),
+        ];
     }
 
     /**

--- a/src/Utility/Reflection/Reflection.php
+++ b/src/Utility/Reflection/Reflection.php
@@ -4,20 +4,11 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Utility\Reflection;
 
-use Attribute;
 use Closure;
-use Error;
-use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionFunction;
-use ReflectionMethod;
-use ReflectionParameter;
-use ReflectionProperty;
-use Reflector;
 use UnitEnum;
 
-use function array_filter;
-use function array_map;
 use function class_exists;
 use function enum_exists;
 use function interface_exists;
@@ -74,38 +65,5 @@ final class Reflection
         $closure = Closure::fromCallable($function);
 
         return self::$functionReflection[spl_object_hash($closure)] ??= new ReflectionFunction($closure);
-    }
-
-    /**
-     * @param ReflectionClass<object>|ReflectionProperty|ReflectionMethod|ReflectionFunction|ReflectionParameter $reflection
-     * @return array<ReflectionAttribute<object>>
-     */
-    public static function attributes(Reflector $reflection): array
-    {
-        $attributes = array_filter(
-            $reflection->getAttributes(),
-            static fn (ReflectionAttribute $attribute) => $attribute->getName() !== Attribute::class,
-        );
-
-        return array_filter(
-            array_map(
-                static function (ReflectionAttribute $attribute) {
-                    try {
-                        $attribute->newInstance();
-
-                        return $attribute;
-                    } catch (Error) {
-                        // Race condition when the attribute is affected to a property/parameter
-                        // that was PROMOTED, in this case the attribute will be applied to both
-                        // ParameterReflection AND PropertyReflection, BUT the target arg inside the attribute
-                        // class is configured to support only ONE of them (parameter OR property)
-                        // https://wiki.php.net/rfc/constructor_promotion#attributes for more details.
-                        // Ignore attribute if the instantiation failed.
-                        return null;
-                    }
-                },
-                $attributes,
-            ),
-        );
     }
 }

--- a/tests/Fake/Definition/FakeAttributes.php
+++ b/tests/Fake/Definition/FakeAttributes.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Fake\Definition;
 
 use CuyZ\Valinor\Definition\Attributes;
-use CuyZ\Valinor\Utility\Reflection\Reflection;
 use ReflectionClass;
 use ReflectionFunction;
 use ReflectionMethod;
@@ -24,7 +23,7 @@ final class FakeAttributes
         return new Attributes(
             ...array_map(
                 static fn (ReflectionAttribute $reflection) => FakeAttributeDefinition::fromReflection($reflection),
-                Reflection::attributes($reflection),
+                $reflection->getAttributes(),
             ),
         );
     }

--- a/tests/Functional/Definition/Repository/Cache/Compiler/AttributesCompilerTest.php
+++ b/tests/Functional/Definition/Repository/Cache/Compiler/AttributesCompilerTest.php
@@ -17,7 +17,6 @@ use Error;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionMethod;
-use ReflectionParameter;
 use ReflectionProperty;
 
 final class AttributesCompilerTest extends TestCase
@@ -137,16 +136,6 @@ final class AttributesCompilerTest extends TestCase
 
         self::assertCount(1, $attributes);
         self::assertTrue($attributes->has(PropertyTargetAttribute::class));
-    }
-
-    public function test_compiles_an_empty_attributes_instance_for_promoted_parameter_with_property_target_attribute(): void
-    {
-        $reflection = new ReflectionParameter([ObjectWithAttributes::class, '__construct'], 'promotedProperty');
-        $attributes = FakeAttributes::fromReflection($reflection);
-
-        $attributes = $this->compile($attributes);
-
-        self::assertSame(Attributes::empty(), $attributes);
     }
 
     private function compile(Attributes $attributes): Attributes

--- a/tests/Functional/Definition/Repository/Cache/Compiler/ClassDefinitionCompilerTest.php
+++ b/tests/Functional/Definition/Repository/Cache/Compiler/ClassDefinitionCompilerTest.php
@@ -30,7 +30,10 @@ final class ClassDefinitionCompilerTest extends TestCase
         parent::setUp();
 
         $this->compiler = new ClassDefinitionCompiler();
-        $this->classDefinitionRepository = new ReflectionClassDefinitionRepository(new LexingTypeParserFactory());
+        $this->classDefinitionRepository = new ReflectionClassDefinitionRepository(
+            new LexingTypeParserFactory(),
+            [],
+        );
     }
 
     public function test_class_definition_is_compiled_correctly(): void

--- a/tests/Functional/Definition/Repository/Reflection/ReflectionAttributesRepositoryTest.php
+++ b/tests/Functional/Definition/Repository/Reflection/ReflectionAttributesRepositoryTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Functional\Definition\Repository\Reflection;
+
+use CuyZ\Valinor\Definition\Repository\Reflection\ReflectionAttributesRepository;
+use CuyZ\Valinor\Definition\Repository\Reflection\ReflectionClassDefinitionRepository;
+use CuyZ\Valinor\Tests\Fixture\Attribute\AttributeWithArguments;
+use CuyZ\Valinor\Tests\Fixture\Attribute\BasicAttribute;
+use CuyZ\Valinor\Tests\Fixture\Attribute\PropertyTargetAttribute;
+use CuyZ\Valinor\Type\Parser\Factory\LexingTypeParserFactory;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionParameter;
+
+final class ReflectionAttributesRepositoryTest extends TestCase
+{
+    public function test_only_allowed_attributes_are_selected(): void
+    {
+        $class =
+            new #[BasicAttribute(), AttributeWithArguments('foo', 'bar')] class () {};
+
+        $reflection = new ReflectionClass($class::class);
+
+        $attributes = $this->attributesRepository(
+            allowedAttributes: [AttributeWithArguments::class]
+        )->for($reflection);
+
+        self::assertCount(1, $attributes);
+        self::assertSame(AttributeWithArguments::class, $attributes[0]->class->name);
+    }
+
+    public function test_attributes_for_promoted_parameter_with_property_target_attribute_is_not_selected(): void
+    {
+        $class = new class (true) {
+            public function __construct(
+                #[PropertyTargetAttribute] public bool $promotedProperty,
+            ) {}
+        };
+
+        $reflection = new ReflectionParameter([$class::class, '__construct'], 'promotedProperty');
+
+        $attributes = $this->attributesRepository(
+            allowedAttributes: [PropertyTargetAttribute::class]
+        )->for($reflection);
+
+        self::assertSame([], $attributes);
+    }
+
+    /**
+     * @param list<class-string> $allowedAttributes
+     */
+    private function attributesRepository(array $allowedAttributes = []): ReflectionAttributesRepository
+    {
+        return new ReflectionAttributesRepository(
+            new ReflectionClassDefinitionRepository(new LexingTypeParserFactory(), $allowedAttributes),
+            $allowedAttributes,
+        );
+    }
+}

--- a/tests/Functional/Definition/Repository/Reflection/ReflectionClassDefinitionRepositoryTest.php
+++ b/tests/Functional/Definition/Repository/Reflection/ReflectionClassDefinitionRepositoryTest.php
@@ -25,7 +25,8 @@ final class ReflectionClassDefinitionRepositoryTest extends TestCase
         parent::setUp();
 
         $this->repository = new ReflectionClassDefinitionRepository(
-            new LexingTypeParserFactory()
+            new LexingTypeParserFactory(),
+            [],
         );
     }
 

--- a/tests/Functional/Definition/Repository/Reflection/ReflectionFunctionDefinitionRepositoryTest.php
+++ b/tests/Functional/Definition/Repository/Reflection/ReflectionFunctionDefinitionRepositoryTest.php
@@ -23,7 +23,8 @@ final class ReflectionFunctionDefinitionRepositoryTest extends TestCase
         $this->repository = new ReflectionFunctionDefinitionRepository(
             new LexingTypeParserFactory(),
             new ReflectionAttributesRepository(
-                new ReflectionClassDefinitionRepository(new LexingTypeParserFactory())
+                new ReflectionClassDefinitionRepository(new LexingTypeParserFactory(), []),
+                []
             ),
         );
     }


### PR DESCRIPTION
This change aims to reduce the memory usage, as well as the compiled cache size for classes that heavily rely on attributes that are not used by this library, for instance `OpenAPI` attributes.

Fixes #525