### PR TITLE
doc: fix some typos

### DIFF
--- a/docs/pages/serialization/normalizer.md
+++ b/docs/pages/serialization/normalizer.md
@@ -51,7 +51,7 @@ unsupported by serialization functions like `json_encode()`:
 - Objects are transformed to arrays based on their properties, no matter their
   visibility (public, protected or private)
 - Dates are formatted to the RFC 3339 format
-- Baked enums use their value, unit enums use their name
+- Backed enums use their value, unit enums use their name
 
 Custom transformations can be applied, see [normalizer extension chapter] for
 more information.

--- a/docs/pages/usage/type-strictness-and-flexibility.md
+++ b/docs/pages/usage/type-strictness-and-flexibility.md
@@ -42,7 +42,7 @@ $flexibleMapper->map('int', '42');
 // List type will accept non-incremental keys.
 
 $flexibleMapper->map('list<int>', ['foo' => 42, 'bar' => 1337]);
-// => [0 => 42, 1 => 1338]
+// => [0 => 42, 1 => 1337]
 
 // ---
 // If a value is missing in a source for a node that accepts `null`, the


### PR DESCRIPTION
Hi, and thanks for the library!

Spotted these errors while reading the docs.