### PR TITLE
fix(transformers): allow phpdoc for callables

### DIFF
--- a/src/Normalizer/Transformer/ValueTransformersHandler.php
+++ b/src/Normalizer/Transformer/ValueTransformersHandler.php
@@ -118,8 +118,8 @@ final class ValueTransformersHandler
             throw new TransformerHasTooManyParameters($method);
         }
 
-        if ($parameters->count() > 1 && ! $parameters->at(1)->type instanceof CallableType) {
-            throw new TransformerHasInvalidCallableParameter($method, $parameters->at(1)->type);
+        if ($parameters->count() > 1 && ! $parameters->at(1)->nativeType instanceof CallableType) {
+            throw new TransformerHasInvalidCallableParameter($method, $parameters->at(1)->nativeType);
         }
     }
 }

--- a/tests/Integration/Normalizer/NormalizerTest.php
+++ b/tests/Integration/Normalizer/NormalizerTest.php
@@ -979,6 +979,23 @@ final class NormalizerTest extends IntegrationTestCase
             ->normalize(new stdClass());
     }
 
+    public function test_second_param_in_transformer_is_callable_with_phpdoc_spec_does_not_throw(): void
+    {
+        $class = new class () {
+            /** @param callable():mixed $next */
+            public function __invoke(stdClass $object, callable $next): int
+            {
+                return 42;
+            }
+        };
+        $this->mapperBuilder()
+            ->registerTransformer($class)
+            ->normalizer(Format::array())
+            ->normalize(new stdClass());
+
+        self::addToAssertionCount(1);
+    }
+
     public function test_no_param_in_transformer_attribute_throws_exception(): void
     {
         $this->expectException(TransformerHasNoParameter::class);


### PR DESCRIPTION
Currently, when I have some docblock for callable in Transformer, the `TransformerHasInvalidCallableParameter` is thrown. I want to allow more specific callable, phpstan requires it (`missingType.callable`).