### PR TITLE
fix: properly format empty object with JSON normalizer

### DIFF
--- a/src/Normalizer/ArrayNormalizer.php
+++ b/src/Normalizer/ArrayNormalizer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Normalizer;
 
+use CuyZ\Valinor\Normalizer\Transformer\EmptyObject;
 use CuyZ\Valinor\Normalizer\Transformer\RecursiveTransformer;
 
 use function array_map;
@@ -38,6 +39,8 @@ final class ArrayNormalizer implements Normalizer
             }
 
             $value = array_map($this->normalizeIterator(...), $value);
+        } elseif ($value instanceof EmptyObject) {
+            return [];
         }
 
         return $value;

--- a/src/Normalizer/Formatter/JsonFormatter.php
+++ b/src/Normalizer/Formatter/JsonFormatter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Normalizer\Formatter;
 
 use CuyZ\Valinor\Normalizer\Formatter\Exception\CannotFormatInvalidTypeToJson;
+use CuyZ\Valinor\Normalizer\Transformer\EmptyObject;
 use Generator;
 
 use function array_is_list;
@@ -41,6 +42,8 @@ final class JsonFormatter implements StreamFormatter
              *                             tools understand that JSON_THROW_ON_ERROR is always set.
              */
             $this->write(json_encode($value, $this->jsonEncodingOptions));
+        } elseif ($value instanceof EmptyObject) {
+            $this->write('{}');
         } elseif (is_iterable($value)) {
             // Note: when a generator is formatted, it is considered as a list
             // if its first key is 0. This is done early because the first JSON

--- a/src/Normalizer/Transformer/EmptyObject.php
+++ b/src/Normalizer/Transformer/EmptyObject.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Normalizer\Transformer;
+
+use CuyZ\Valinor\Utility\IsSingleton;
+
+/** @internal */
+final class EmptyObject
+{
+    use IsSingleton;
+}

--- a/tests/Integration/Normalizer/NormalizerTest.php
+++ b/tests/Integration/Normalizer/NormalizerTest.php
@@ -695,6 +695,32 @@ final class NormalizerTest extends IntegrationTestCase
             'transformerAttributes' => [],
             'jsonEncodingOptions' => JSON_HEX_AMP,
         ];
+
+        yield 'stdClass with no property' => [
+            'input' => new stdClass(),
+            'expected array' => [],
+            'expected_json' => '{}',
+        ];
+
+        yield 'ArrayObject with no property' => [
+            'input' => new ArrayObject(),
+            'expected array' => [],
+            'expected_json' => '{}',
+        ];
+
+        yield 'iterable class with no property' => [
+            'input' => new class () implements IteratorAggregate {
+                public function getIterator(): Traversable
+                {
+                    // @phpstan-ignore-next-line / Empty array is here on purpose
+                    foreach ([] as $value) {
+                        yield $value;
+                    }
+                }
+            },
+            'expected array' => [],
+            'expected_json' => '{}',
+        ];
     }
 
     public function test_generator_of_scalar_yields_expected_array(): void


### PR DESCRIPTION
Objects that yield no value or have no property will now properly be formatted into `{}` instead of `[]`.

fixes #542 