### PR TITLE
Add PHP 8.4 compatibility

### DIFF
--- a/src/Mapper/Tree/Shell.php
+++ b/src/Mapper/Tree/Shell.php
@@ -53,7 +53,7 @@ final class Shell
         return (new self($settings, $type))->withValue($value);
     }
 
-    public function child(string $name, Type $type, Attributes $attributes = null): self
+    public function child(string $name, Type $type, ?Attributes $attributes = null): self
     {
         $instance = new self($this->settings, $type);
         $instance->name = $name;

--- a/src/Type/Types/ClassStringType.php
+++ b/src/Type/Types/ClassStringType.php
@@ -27,7 +27,7 @@ final class ClassStringType implements StringType, CompositeType
 
     private string $signature;
 
-    public function __construct(ObjectType|UnionType $subType = null)
+    public function __construct(ObjectType|UnionType|null $subType = null)
     {
         if ($subType instanceof UnionType) {
             foreach ($subType->types() as $type) {


### PR DESCRIPTION
Fixes 2 issues:

```
CuyZ\Valinor\Mapper\Tree\Shell::child(): Implicitly marking parameter $attributes as nullable is deprecated, the explicit nullable type must be used instead
CuyZ\Valinor\Type\Types\ClassStringType::__construct(): Implicitly marking parameter $subType as nullable is deprecated, the explicit nullable type must be used instead
```

See https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

This PR **doesn't** add PHP 8.4 support, it just makes it runnable in PHP 8.4 without errors.