### PR TITLE
Regression: Fix int and float compatibility in union types

### DIFF
--- a/src/Mapper/Tree/Shell.php
+++ b/src/Mapper/Tree/Shell.php
@@ -80,6 +80,7 @@ final class Shell
     {
         $clone = clone $this;
         $clone->type = $newType;
+        $clone->value = self::castCompatibleValue($newType, $this->value);
 
         return $clone;
     }
@@ -91,17 +92,9 @@ final class Shell
 
     public function withValue(mixed $value): self
     {
-        // When the value is an integer and the type is a float, the value is
-        // cast to float, to follow the rule of PHP regarding acceptance of an
-        // integer value in a float type. Note that PHPStan/Psalm analysis
-        // applies the same rule.
-        if ($this->type instanceof FloatType && is_int($value)) {
-            $value = (float)$value;
-        }
-
         $clone = clone $this;
         $clone->hasValue = true;
-        $clone->value = $value;
+        $clone->value = self::castCompatibleValue($clone->type, $value);
 
         return $clone;
     }
@@ -172,5 +165,18 @@ final class Shell
         }
 
         return implode('.', $path);
+    }
+
+    private static function castCompatibleValue(Type $type, mixed $value): mixed
+    {
+        // When the value is an integer and the type is a float, the value is
+        // cast to float, to follow the rule of PHP regarding acceptance of an
+        // integer value in a float type. Note that PHPStan/Psalm analysis
+        // applies the same rule.
+        if ($type instanceof FloatType && is_int($value)) {
+            return (float)$value;
+        }
+
+        return $value;
     }
 }

--- a/tests/Integration/Mapping/UnionMappingTest.php
+++ b/tests/Integration/Mapping/UnionMappingTest.php
@@ -64,6 +64,15 @@ final class UnionMappingTest extends IntegrationTestCase
             'assertion' => fn (mixed $result) => self::assertNull($result),
         ];
 
+        yield 'nullable float with integer value' => [
+            'type' => 'float|null',
+            'source' => 42,
+            'assertion' => function (mixed $result) {
+                self::assertIsFloat($result);
+                self::assertEquals(42.0, $result);
+            },
+        ];
+
         yield 'string or list of string, with string' => [
             'type' => 'string|list<string>',
             'source' => 'foo',


### PR DESCRIPTION
This was broken in commit
https://github.com/CuyZ/Valinor/commit/0479532fbc96fca35dcbfb4c1f5a9ef63e7625c5 as withType may be called in union type context.
First calling withValue() to set an int value and then updating the type with withType() does not trigger the float cast, in turn causing a mapping error.

Developed by: Social Deal (@socialdeal)