### PR TITLE
add dynamic interface resolution

### DIFF
--- a/src/InterfaceResolver.php
+++ b/src/InterfaceResolver.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace CuyZ\Valinor;
+
+interface InterfaceResolver
+{
+    public function resolve(string $interface, ?array $props) : ?string;
+
+    public function getResolverProps(string $interface) : array;
+
+    public function transform(object $input, callable $next) : array;
+}

--- a/src/InterfaceResolver.php
+++ b/src/InterfaceResolver.php
@@ -2,11 +2,24 @@
 
 namespace CuyZ\Valinor;
 
+/**
+ * @api
+ */
 interface InterfaceResolver
 {
-    public function resolve(string $interface, ?array $props) : ?string;
+    /**
+     * @param array<string,mixed>|null $props
+     * @return class-string|null
+     */
+    public function resolve(string $interface, ?array $props): ?string;
 
-    public function getResolverProps(string $interface) : array;
+    /**
+     * @return string[]
+     */
+    public function getResolverProps(string $interface): array;
 
-    public function transform(object $input, callable $next) : array;
+    /**
+     * @return array<string|int,mixed>
+     */
+    public function transform(object $input, callable $next): array;
 }

--- a/src/Library/Container.php
+++ b/src/Library/Container.php
@@ -128,6 +128,7 @@ final class Container
                         $this->get(FunctionDefinitionRepository::class),
                         $settings->customConstructors
                     ),
+                    $settings->interfaceResolver,
                 );
 
                 $builder = new CasterProxyNodeBuilder($builder);

--- a/src/Library/Settings.php
+++ b/src/Library/Settings.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Library;
 
+use CuyZ\Valinor\InterfaceResolver;
 use CuyZ\Valinor\Mapper\Object\Constructor;
 use CuyZ\Valinor\Mapper\Object\DynamicConstructor;
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
@@ -58,6 +59,9 @@ final class Settings
 
     /** @var array<class-string, null> */
     public array $transformerAttributes = [];
+
+    /** @var InterfaceResolver|null */
+    public ?InterfaceResolver $interfaceResolver = null;
 
     public function __construct()
     {

--- a/src/Library/Settings.php
+++ b/src/Library/Settings.php
@@ -60,7 +60,6 @@ final class Settings
     /** @var array<class-string, null> */
     public array $transformerAttributes = [];
 
-    /** @var InterfaceResolver|null */
     public ?InterfaceResolver $interfaceResolver = null;
 
     public function __construct()

--- a/src/Mapper/Tree/Builder/InterfaceNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/InterfaceNodeBuilder.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Mapper\Tree\Builder;
 
 use CuyZ\Valinor\Definition\FunctionsContainer;
 use CuyZ\Valinor\Definition\Repository\ClassDefinitionRepository;
+use CuyZ\Valinor\InterfaceResolver;
 use CuyZ\Valinor\Mapper\Object\Arguments;
 use CuyZ\Valinor\Mapper\Object\ArgumentsValues;
 use CuyZ\Valinor\Mapper\Object\Exception\InvalidSource;
@@ -27,6 +28,7 @@ final class InterfaceNodeBuilder implements NodeBuilder
         private ObjectImplementations $implementations,
         private ClassDefinitionRepository $classDefinitionRepository,
         private FunctionsContainer $constructors,
+        private InterfaceResolver $interfaceResolver,
     ) {}
 
     public function build(Shell $shell, RootNodeBuilder $rootBuilder): TreeNode
@@ -53,6 +55,19 @@ final class InterfaceNodeBuilder implements NodeBuilder
 
         if (! $this->implementations->has($className)) {
             if ($type instanceof InterfaceType || $this->classDefinitionRepository->for($type)->isAbstract) {
+                 if ($this->interfaceResolver){
+                    $value = $shell->value();
+                     $resolver_props = [];
+                    foreach($this->interfaceResolver->getResolverProps($className) as $prop){
+                         $resolver_props[$prop] = $value[$prop];
+                         unset($value[$prop]);
+                    }
+                    $resolvedClassName = $this->interfaceResolver->resolve($className, $resolver_props);
+                    if ($resolvedClassName !== null) {
+                        $shell = $shell->withType(new NativeClassType($resolvedClassName))->withValue($value);
+                        return $this->delegate->build($shell, $rootBuilder);
+                    }
+                }
                 throw new CannotResolveObjectType($className);
             }
 

--- a/src/MapperBuilder.php
+++ b/src/MapperBuilder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor;
 
-use CuyZ\Valinor\InterfaceResolver;
 use CuyZ\Valinor\Library\Container;
 use CuyZ\Valinor\Library\Settings;
 use CuyZ\Valinor\Mapper\ArgumentsMapper;
@@ -531,10 +530,6 @@ final class MapperBuilder
         return $clone;
     }
 
-    /**
-     * @param string $factoryClass
-     * @return void
-     */
     public function withInterfaceResolver(InterfaceResolver $resolver): self
     {
 

--- a/src/MapperBuilder.php
+++ b/src/MapperBuilder.php
@@ -536,7 +536,7 @@ final class MapperBuilder
         $clone = clone $this;
         $clone->settings->interfaceResolver = $resolver;
 
-        return $clone->registerTransformer([$resolver, 'transform']);
+        return $clone->registerTransformer($resolver->transform(...));
     }
 
     /**

--- a/src/MapperBuilder.php
+++ b/src/MapperBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor;
 
+use CuyZ\Valinor\InterfaceResolver;
 use CuyZ\Valinor\Library\Container;
 use CuyZ\Valinor\Library\Settings;
 use CuyZ\Valinor\Mapper\ArgumentsMapper;
@@ -528,6 +529,19 @@ final class MapperBuilder
         }
 
         return $clone;
+    }
+
+    /**
+     * @param string $factoryClass
+     * @return void
+     */
+    public function withInterfaceResolver(InterfaceResolver $resolver): self
+    {
+
+        $clone = clone $this;
+        $clone->settings->interfaceResolver = $resolver;
+
+        return $clone->registerTransformer([$resolver, 'transform']);
     }
 
     /**


### PR DESCRIPTION
Made interface resolvers implementation for #558 . This implementation allows to add discriminator properties to normalized array and resove actual class based on descriminator props

Example:

```php
interface Container{}

class BoxContainer implements Container{
    function __construct(int $width, int $height){}
}

class SquereContainer implements Container{
    function __construct(int $width, int $height){}
}

class CircleContainer implements Container{
    function __construct(int $radius){}
}

class MyResolver(){
    public function resolve(string $interface, ?array $props) : ?string
    {
        if ($interface === 'Container'){
            return match($props['type']){
                'box' => BoxContainer::class,
                'squere' => SquereContainer::class,
                'circle' => CircleContainer::class,
            }
        }
    }
    
    public function getResolverProps(string $interface) : array
    {
        return ['type'];
    }
    
    public function transform(object $input, callable $next) : array
    {
         $result = $next($input);
         if ($input instanceOf ContainerInterface){
              $result['type'] = match(get_class($input)){
                 BoxContainer::class => 'box',
                SquereContainer::class => 'squere',
                CircleContainer::class => 'circle',
             }
         }
         return  $result;
    }
}

$mapperBuilder->withInterfaceResolver(new MyResolver());
$normalized  = $normalizer->normalize(new BoxContainer(3,5)); // ['type'=>'box', 'width'=>3, 'height'=>5]
$object = $mapper->map(Container::class, $normalized); //new BoxContainer(3,5)
```


This can partialy be done with infer / transform, but some validations faild due too extra fields and dynamic interface reading is not possible. In my project i use Attribute on interfaces to declare type mapping and discriminator field:

```php
#[TypedInterface([
    'box' => BoxContainer::class,
    'squere' => SquereContainer::class,
    'circle' => CircleContainer::class,
], 'conteiner_type')]
interface Container{
...

class InterfaceObjectResolver implements \CuyZ\Valinor\InterfaceResolver
{

    public function resolve(string $interface, ?array $props) : ?string
    {
        [$type_map, $discriminator] = $this->readAttributes($interface);
        if (!$type_map){
            return null;
        }
        return $type_map[$props[$discriminator]];
    }
...
```
