### PR TITLE
fix(lexer): Fix typo in TokenizedAnnotation breaking psalm

### DIFF
--- a/src/Type/Parser/Lexer/TokenizedAnnotation.php
+++ b/src/Type/Parser/Lexer/TokenizedAnnotation.php
@@ -13,7 +13,7 @@ final class TokenizedAnnotation
     public function __construct(
         /** @var non-empty-string */
         private string $name,
-        /** @var non-empty-list<string>> */
+        /** @var non-empty-list<string> */
         private array $tokens,
     ) {}
 


### PR DESCRIPTION
Currently 1.13.0 breaks psalm:
```
psalm --no-cache --threads=$(nproc)
Target PHP version: 8.1 (set by config file).
Scanning files...
Uncaught Exception: Psalm\Exception\DocblockParseException Invalid string non-empty-list<string>>
Emitted in …/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/CommentAnalyzer.php:357
Stack trace in the forked worker:
#0 …/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/CommentAnalyzer.php(109): Psalm\Internal\Analyzer\CommentAnalyzer::splitDocLine('...')
#1 …/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/CommentAnalyzer.php(63): Psalm\Internal\Analyzer\CommentAnalyzer::arrayToDocblocks(Object(PhpParser\Comment\Doc), Object(Psalm\Internal\Scanner\ParsedDocblock), Object(Psalm\Internal\Scanner\FileScanner), Object(Psalm\Aliases), Array, Array)
#2 …/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php(599): Psalm\Internal\Analyzer\CommentAnalyzer::getTypeFromComment(Object(PhpParser\Comment\Doc), Object(Psalm\Internal\Scanner\FileScanner), Object(Psalm\Aliases), Array, Array)
#3 …/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php(207): Psalm\Internal\PhpVisitor\Reflector\FunctionLikeNodeScanner->start(Object(PhpParser\Node\Stmt\ClassMethod))
#4 …/vendor-bin/psalm/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(200): Psalm\Internal\PhpVisitor\ReflectorVisitor->enterNode(Object(PhpParser\Node\Stmt\ClassMethod))
#5 …/vendor-bin/psalm/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(114): PhpParser\NodeTraverser->traverseArray(Array)
#6 …/vendor-bin/psalm/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(223): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\Class_))
#7 …/vendor-bin/psalm/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(114): PhpParser\NodeTraverser->traverseArray(Array)
#8 …/vendor-bin/psalm/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(223): PhpParser\NodeTraverser->traverseNode(Object(PhpParser\Node\Stmt\Namespace_))
#9 …/vendor-bin/psalm/vendor/nikic/php-parser/lib/PhpParser/NodeTraverser.php(91): PhpParser\NodeTraverser->traverseArray(Array)
#10 …/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Internal/Scanner/FileScanner.php(79): PhpParser\NodeTraverser->traverse(Array)
#11 …/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Internal/Codebase/Scanner.php(550): Psalm\Internal\Scanner\FileScanner->scan(Object(Psalm\Codebase), Object(Psalm\Storage\FileStorage), false, Object(Psalm\Progress\DefaultProgress))
#12 …/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Internal/Codebase/Scanner.php(778): Psalm\Internal\Codebase\Scanner->scanFile('...', Array, false)
#13 …/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Internal/Fork/Pool.php(189): Psalm\Internal\Codebase\Scanner->scanAPath(9, '...')
#14 …/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Internal/Codebase/Scanner.php(332): Psalm\Internal\Fork\Pool->__construct(Object(Psalm\Config), Array, Object(Closure), Object(Closure), Object(Closure))
#15 …/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Internal/Codebase/Scanner.php(280): Psalm\Internal\Codebase\Scanner->scanFilePaths(7.0)
#16 …/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Codebase.php(505): Psalm\Internal\Codebase\Scanner->scanFiles(Object(Psalm\Internal\Codebase\ClassLikes), 8)
#17 …/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php(496): Psalm\Codebase->scanFiles(8)
#18 …/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Internal/Cli/Psalm.php(379): Psalm\Internal\Analyzer\ProjectAnalyzer->check('...', true)
#19 …/vendor-bin/psalm/vendor/vimeo/psalm/psalm(9): Psalm\Internal\Cli\Psalm::run(Array)
#20 …/vendor/bin/psalm(119): include('...')
#21 {main} in …/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Internal/Fork/Pool.php:383
Stack trace:
#0 …/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Internal/Fork/Pool.php(417): Psalm\Internal\Fork\Pool->readResultsFromChildren()
#1 …/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Internal/Codebase/Scanner.php(384): Psalm\Internal\Fork\Pool->wait()
#2 …/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Internal/Codebase/Scanner.php(280): Psalm\Internal\Codebase\Scanner->scanFilePaths(7.0)
#3 …/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Codebase.php(505): Psalm\Internal\Codebase\Scanner->scanFiles(Object(Psalm\Internal\Codebase\ClassLikes), 8)
#4 …/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php(496): Psalm\Codebase->scanFiles(8)
#5 …/vendor-bin/psalm/vendor/vimeo/psalm/src/Psalm/Internal/Cli/Psalm.php(379): Psalm\Internal\Analyzer\ProjectAnalyzer->check('...', true)
#6 …/vendor-bin/psalm/vendor/vimeo/psalm/psalm(9): Psalm\Internal\Cli\Psalm::run(Array)
#7 …/vendor/bin/psalm(119): include('...')
#8 {main}
(Psalm 5.26.0@4787eaf414e16c661902b94dfe5d882223e5b513 crashed due to an uncaught Throwable)
```

E.g. https://github.com/nextcloud/spreed/pull/13220