### PR TITLE
fix: relax callable typehints to not require pure

### DIFF
--- a/src/MapperBuilder.php
+++ b/src/MapperBuilder.php
@@ -57,7 +57,7 @@ final class MapperBuilder
      * ```
      *
      * @param interface-string|class-string $name
-     * @psalm-param pure-callable $callback
+     * @param callable $callback
      */
     public function infer(string $name, callable $callback): self
     {
@@ -200,7 +200,6 @@ final class MapperBuilder
      *     ]);
      * ```
      *
-     * @psalm-param pure-callable|class-string ...$constructors
      * @param callable|class-string ...$constructors
      */
     public function registerConstructor(callable|string ...$constructors): self
@@ -298,7 +297,6 @@ final class MapperBuilder
 
     /**
      * @template T
-     * @psalm-param pure-callable(T): T $callback
      * @param callable(T): T $callback
      */
     public function alter(callable $callback): self
@@ -446,7 +444,6 @@ final class MapperBuilder
      *     ]);
      * ```
      *
-     * @psalm-param pure-callable(Throwable): ErrorMessage $filter
      * @param callable(Throwable): ErrorMessage $filter
      */
     public function filterExceptions(callable $filter): self
@@ -514,7 +511,6 @@ final class MapperBuilder
      *     ->normalize('Hello world'); // HELLO WORLD?!
      * ```
      *
-     * @psalm-param pure-callable|class-string $transformer
      * @param callable|class-string $transformer
      */
     public function registerTransformer(callable|string $transformer, int $priority = 0): self


### PR DESCRIPTION
The purity requirement for callbacks is very annoying to deal with, also it is not needed.

1. PHPStan cannot auto-detect pure functions, so each transformer requires an annotation.
2. This library should not care wether a transformer is pure; it is not impacted by this.


This solves #550 