### PR TITLE
Fix typo

### DIFF
--- a/docs/pages/usage/validation-and-error-handling.md
+++ b/docs/pages/usage/validation-and-error-handling.md
@@ -163,7 +163,7 @@ It is possible to set up a list of exceptions that can be caught by the mapper,
 for instance when using lightweight validation tools like [Webmozart Assert].
 
 It is advised to use this feature with caution: userland exceptions may contain
-sensible information — for instance an SQL exception showing a part of a query
+sensitive information — for instance an SQL exception showing a part of a query
 should never be allowed. Therefore, only an exhaustive list of carefully chosen
 exceptions should be filtered.
 


### PR DESCRIPTION
Hey, I noticed what looks like a small typo on the documentation.

![image](https://github.com/user-attachments/assets/af509a94-fad2-4367-86a6-511ef12627cc)
