### PR TITLE
misc: remove "pure" requirements from several methods

### DIFF
--- a/src/Mapper/ArgumentsMapper.php
+++ b/src/Mapper/ArgumentsMapper.php
@@ -8,8 +8,6 @@ namespace CuyZ\Valinor\Mapper;
 interface ArgumentsMapper
 {
     /**
-     * @pure
-     *
      * @return array<string, mixed>
      *
      * @throws MappingError

--- a/src/Mapper/Tree/Message/MessageBuilder.php
+++ b/src/Mapper/Tree/Message/MessageBuilder.php
@@ -53,9 +53,6 @@ final class MessageBuilder
         return $instance;
     }
 
-    /**
-     * @psalm-pure
-     */
     public static function from(Throwable $error): ErrorMessage
     {
         if ($error instanceof ErrorMessage) {
@@ -119,8 +116,6 @@ final class MessageBuilder
     }
 
     /**
-     * @psalm-pure
-     *
      * @return MessageType&HasCode&HasParameters
      */
     public function build(): Message&HasCode&HasParameters

--- a/src/Mapper/TreeMapper.php
+++ b/src/Mapper/TreeMapper.php
@@ -8,8 +8,6 @@ namespace CuyZ\Valinor\Mapper;
 interface TreeMapper
 {
     /**
-     * @pure
-     *
      * @template T of object
      *
      * @param string|class-string<T> $signature

--- a/src/Mapper/TypeArgumentsMapper.php
+++ b/src/Mapper/TypeArgumentsMapper.php
@@ -24,7 +24,6 @@ final class TypeArgumentsMapper implements ArgumentsMapper
         private Settings $settings,
     ) {}
 
-    /** @pure */
     public function mapArguments(callable $callable, mixed $source): array
     {
         $function = $this->functionDefinitionRepository->for($callable);

--- a/src/Mapper/TypeTreeMapper.php
+++ b/src/Mapper/TypeTreeMapper.php
@@ -23,7 +23,6 @@ final class TypeTreeMapper implements TreeMapper
         private Settings $settings,
     ) {}
 
-    /** @pure */
     public function map(string $signature, mixed $source): mixed
     {
         $node = $this->node($signature, $source);

--- a/src/MapperBuilder.php
+++ b/src/MapperBuilder.php
@@ -36,9 +36,6 @@ final class MapperBuilder
      * using the given source. These arguments can then be used to decide which
      * implementation should be used.
      *
-     * The callback *must* be pure, its output must be deterministic.
-     * @see https://en.wikipedia.org/wiki/Pure_function
-     *
      * Example:
      *
      * ```php
@@ -57,7 +54,6 @@ final class MapperBuilder
      * ```
      *
      * @param interface-string|class-string $name
-     * @psalm-param pure-callable $callback
      */
     public function infer(string $name, callable $callback): self
     {
@@ -85,9 +81,6 @@ final class MapperBuilder
      * `__construct` method — of the targeted class. If for some reason it still
      * needs to be handled as well, the name of the class must be given to this
      * method.
-     *
-     * A constructor *must* be pure, its output must be deterministic.
-     * @see https://en.wikipedia.org/wiki/Pure_function
      *
      * ```php
      * final class SomeClass
@@ -200,7 +193,6 @@ final class MapperBuilder
      *     ]);
      * ```
      *
-     * @psalm-param pure-callable|class-string ...$constructors
      * @param callable|class-string ...$constructors
      */
     public function registerConstructor(callable|string ...$constructors): self
@@ -298,7 +290,6 @@ final class MapperBuilder
 
     /**
      * @template T
-     * @psalm-param pure-callable(T): T $callback
      * @param callable(T): T $callback
      */
     public function alter(callable $callback): self
@@ -418,9 +409,6 @@ final class MapperBuilder
      * part of a query should never be allowed. Therefore, only an exhaustive
      * list of carefully chosen exceptions should be filtered.
      *
-     * The filter callback *must* be pure, its output must be deterministic.
-     * @see https://en.wikipedia.org/wiki/Pure_function
-     *
      * ```php
      * final class SomeClass
      * {
@@ -446,7 +434,6 @@ final class MapperBuilder
      *     ]);
      * ```
      *
-     * @psalm-param pure-callable(Throwable): ErrorMessage $filter
      * @param callable(Throwable): ErrorMessage $filter
      */
     public function filterExceptions(callable $filter): self
@@ -514,7 +501,6 @@ final class MapperBuilder
      *     ->normalize('Hello world'); // HELLO WORLD?!
      * ```
      *
-     * @psalm-param pure-callable|class-string $transformer
      * @param callable|class-string $transformer
      */
     public function registerTransformer(callable|string $transformer, int $priority = 0): self


### PR DESCRIPTION
Due to the current overhead required to make PHPStan and Psalm work with the pure feature, these requirements have been removed.

Since PHPStan and Psalm are unfortunately unable to automatically detect whether callable values provided to `MapperBuilder` are pure, users are forced to manually add `@pure` annotations.

This decision aims to strike a fair balance between the library's strictness and user experience.

Fixes #540, #550
Closes #563