### PR TITLE
misc: remove the need to keep a reference to the parent node

### DIFF
--- a/tests/Unit/Mapper/Tree/ShellTest.php
+++ b/tests/Unit/Mapper/Tree/ShellTest.php
@@ -80,6 +80,7 @@ final class ShellTest extends TestCase
         $shell = Shell::root(new Settings(), new FakeType(), []);
         $child = $shell->child('foo', $type, $attributes)->withValue($value);
 
+        self::assertFalse($child->isRoot());
         self::assertSame('foo', $child->name());
         self::assertSame('foo', $child->path());
         self::assertSame($type, $child->type());


### PR DESCRIPTION
## Problem

The current implementation keeps a reference in each `Shell` to its parent in order to know if it's the root node and be able to generate the its path.

The problem with this design is that this creates circular references, making the job difficult for PHP to free these objects from memory.

## Solution

Since we build a child from the parent object we create the path by duplicating the path of the parent and adding the child name.