### PR TITLE
misc: fix PHP 8.4 deprecations

### DIFF
--- a/qa/Psalm/ValinorPsalmPlugin.php
+++ b/qa/Psalm/ValinorPsalmPlugin.php
@@ -10,7 +10,7 @@ use SimpleXMLElement;
 
 class ValinorPsalmPlugin implements PluginEntryPointInterface
 {
-    public function __invoke(RegistrationInterface $api, SimpleXMLElement $config = null): void
+    public function __invoke(RegistrationInterface $api, ?SimpleXMLElement $config = null): void
     {
         require_once __DIR__ . '/Plugin/TreeMapperPsalmPlugin.php';
         require_once __DIR__ . '/Plugin/ArgumentsMapperPsalmPlugin.php';

--- a/tests/Fake/Definition/FakeFunctionDefinition.php
+++ b/tests/Fake/Definition/FakeFunctionDefinition.php
@@ -16,7 +16,7 @@ final class FakeFunctionDefinition
     /**
      * @param non-empty-string|null $fileName
      */
-    public static function new(string $fileName = null): FunctionDefinition
+    public static function new(?string $fileName = null): FunctionDefinition
     {
         return new FunctionDefinition(
             'foo',

--- a/tests/Fake/Definition/FakeParameterDefinition.php
+++ b/tests/Fake/Definition/FakeParameterDefinition.php
@@ -17,7 +17,7 @@ final class FakeParameterDefinition
     /**
      * @param non-empty-string $name
      */
-    public static function new(string $name = 'someParameter', Type $type = null): ParameterDefinition
+    public static function new(string $name = 'someParameter', ?Type $type = null): ParameterDefinition
     {
         return new ParameterDefinition(
             $name,

--- a/tests/Fake/Mapper/Tree/Builder/FakeNodeBuilder.php
+++ b/tests/Fake/Mapper/Tree/Builder/FakeNodeBuilder.php
@@ -17,7 +17,7 @@ final class FakeNodeBuilder implements NodeBuilder
     /**
      * @param null|callable(Shell): TreeNode $callback
      */
-    public function __construct(callable $callback = null)
+    public function __construct(?callable $callback = null)
     {
         if ($callback) {
             $this->callback = $callback;

--- a/tests/Fake/Mapper/Tree/Builder/FakeTreeNode.php
+++ b/tests/Fake/Mapper/Tree/Builder/FakeTreeNode.php
@@ -30,7 +30,7 @@ final class FakeTreeNode
     /**
      * @param array<array{name?: string, type?: Type, value?: mixed, attributes?: Attributes, message?: Message}> $children
      */
-    public static function branch(array $children, Type $type = null, mixed $value = null): TreeNode
+    public static function branch(array $children, ?Type $type = null, mixed $value = null): TreeNode
     {
         $shell = FakeShell::new($type ?? FakeType::permissive(), $value);
         $nodes = [];
@@ -58,7 +58,7 @@ final class FakeTreeNode
     /**
      * @param Throwable&Message $error
      */
-    public static function error(Throwable $error = null): TreeNode
+    public static function error(?Throwable $error = null): TreeNode
     {
         $shell = FakeShell::new(FakeType::permissive(), []);
 

--- a/tests/Fake/Type/FakeType.php
+++ b/tests/Fake/Type/FakeType.php
@@ -29,7 +29,7 @@ final class FakeType implements Type
 
     private bool $permissive = false;
 
-    public function __construct(string $name = null)
+    public function __construct(?string $name = null)
     {
         $this->name = $name ?? 'FakeType' . self::$counter++;
     }

--- a/tests/StaticAnalysis/inferring-types-with-plugin.php
+++ b/tests/StaticAnalysis/inferring-types-with-plugin.php
@@ -44,7 +44,7 @@ function mapping_union_of_types_will_infer_correct_type(TreeMapper $mapper): voi
 
 function mapping_function_arguments_will_infer_object_of_same_type(ArgumentsMapper $mapper): void
 {
-    $result = $mapper->mapArguments(fn (string $foo, int $bar = null): string => "$foo / $bar", []);
+    $result = $mapper->mapArguments(fn (string $foo, ?int $bar = null): string => "$foo / $bar", []);
 
     /** @psalm-check-type $result = array{foo: string, bar?: int|null} */
     assertType('array{foo: string, bar?: int|null}', $result);
@@ -68,12 +68,12 @@ function mapping_method_arguments_will_infer_object_of_same_type(ArgumentsMapper
 
 final class SomeClass
 {
-    public static function someStaticMethod(string $foo, int $bar = null): string
+    public static function someStaticMethod(string $foo, ?int $bar = null): string
     {
         return "$foo / $bar";
     }
 
-    public function someMethod(string $foo, int $bar = null): string
+    public function someMethod(string $foo, ?int $bar = null): string
     {
         return "$foo / $bar";
     }


### PR DESCRIPTION
Implicitly nullable parameter types are deprecated in PHP 8.4:

https://wiki.php.net/rfc/deprecate-implicitly-nullable-types