### PR TITLE
Allow option to use dynamic properties for specific classes

### DIFF
--- a/docs/pages/usage/type-strictness-and-flexibility.md
+++ b/docs/pages/usage/type-strictness-and-flexibility.md
@@ -102,3 +102,40 @@ mapping.
         ]
     );
 ```
+
+## Allowing dynamic Properties
+
+In some cases it could be required to map dynamic properties if the class implements the magic `__get` and `__set` Methods.
+To archive this you should mark the classes with an Interface and all not explicit allowed values would be allowed.
+
+```php
+interface MagicGetterSetter {
+    public function __get(string $name): string|null;
+    public function __set(string $name, string $value): void;
+}
+
+class DynamicClass implements MagicGetterSetter {
+    /** @var array<string, string> */
+    public array $dynamicProperties = [];
+    public function __get(string $name): string|null { 
+        return $this->dynamicProperties[$name] ?? null; 
+    }
+    public function __set(string $name, string $value): void {
+        $this->dynamicProperties[$name] = $value;
+    }
+}
+
+(new \CuyZ\Valinor\MapperBuilder())
+    ->allowDynamicPropertiesFor(MagicGetterSetter::class)
+    ->mapper()
+    ->map(
+        DynamicClass::class,
+        [
+            'foo' => 'foo',
+            'bar' => 'baz',
+        ]
+    );
+
+// Result
+// DynamicClass::$dynamicProperties' = ['foo' => 'foo','bar' => 'baz']
+```

--- a/src/Library/Settings.php
+++ b/src/Library/Settings.php
@@ -50,6 +50,9 @@ final class Settings
 
     public bool $allowPermissiveTypes = false;
 
+    /** @var list<class-string> */
+    public array $allowDynamicPropertiesFor = [];
+
     /** @var callable(Throwable): ErrorMessage */
     public $exceptionFilter;
 

--- a/src/Mapper/Tree/Shell.php
+++ b/src/Mapper/Tree/Shell.php
@@ -7,6 +7,7 @@ namespace CuyZ\Valinor\Mapper\Tree;
 use CuyZ\Valinor\Definition\Attributes;
 use CuyZ\Valinor\Library\Settings;
 use CuyZ\Valinor\Mapper\Tree\Exception\UnresolvableShellType;
+use CuyZ\Valinor\Type\ClassType;
 use CuyZ\Valinor\Type\FloatType;
 use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\UnresolvableType;
@@ -175,5 +176,20 @@ final class Shell
         }
 
         return $value;
+    }
+
+    public function allowDynamicProperties(): bool
+    {
+        if (!$this->type instanceof ClassType) {
+            return false;
+        }
+        $dependencies = class_implements($this->type->className());
+        $dependencies[] = $this->type->className();
+        foreach ($this->settings->allowDynamicPropertiesFor as $dynamicPropertyClass) {
+            if (in_array($dynamicPropertyClass, $dependencies, true)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/MapperBuilder.php
+++ b/src/MapperBuilder.php
@@ -378,6 +378,15 @@ final class MapperBuilder
         return $clone;
     }
 
+    /** @param class-string $classNames */
+    public function allowDynamicPropertiesFor(string ...$classNames): self
+    {
+        $clone = clone $this;
+        $clone->settings->allowDynamicPropertiesFor = array_values(array_unique($classNames));
+
+        return $clone;
+    }
+
     /**
      * Allows permissive types `mixed` and `object` to be used during mapping.
      *

--- a/tests/Integration/Mapping/DynamicPropertiesMappingTest.php
+++ b/tests/Integration/Mapping/DynamicPropertiesMappingTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace CuyZ\Valinor\Tests\Integration\Mapping;
+
+use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
+
+final class DynamicPropertiesMappingTest extends IntegrationTestCase
+{
+    public function test_map_dynamic_properties_to_class(): void
+    {
+        $class = new class () implements \ArrayAccess {
+            /** @var array<string, string> */
+            public array $storage = [];
+
+            public function __get(string $name): mixed
+            {
+                return $this->offsetGet($name);
+            }
+
+            public function __set(string $name, mixed $value): void
+            {
+                $this->offsetSet($name, $value);
+            }
+
+            public function __isset(string $name): bool
+            {
+                return $this->offsetExists($name);
+            }
+
+            public function offsetExists(mixed $offset): bool
+            {
+                return isset($this->storage[$offset]);
+            }
+
+            public function offsetGet(mixed $offset): mixed
+            {
+                return $this->storage[$offset] ?? null;
+            }
+
+            public function offsetSet(mixed $offset, mixed $value): void
+            {
+                if (!is_string($offset)) {
+                    return;
+                }
+                $this->storage[$offset] = is_string($value) ? $value : serialize($value);
+            }
+
+            public function offsetUnset(mixed $offset): void
+            {
+                unset($this->storage[$offset]);
+            }
+        };
+
+        $res = $this->mapperBuilder()
+            ->allowDynamicPropertiesFor(
+                \ArrayAccess::class,
+            )
+            ->mapper()
+            ->map($class::class, [
+                'bar' => 'baz',
+                'storage' => ['foo' => 'bar'],
+            ]);
+
+        self::assertSame('bar', $res['foo']);
+        self::assertSame('baz', $res['bar']);
+    }
+}

--- a/tests/Unit/Mapper/Object/ArgumentsValuesTest.php
+++ b/tests/Unit/Mapper/Object/ArgumentsValuesTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Unit\Mapper\Object;
+
+use CuyZ\Valinor\Library\Settings;
+use CuyZ\Valinor\Mapper\Object\Argument;
+use CuyZ\Valinor\Mapper\Object\Arguments;
+use CuyZ\Valinor\Mapper\Object\ArgumentsValues;
+use CuyZ\Valinor\Mapper\Tree\Shell;
+use CuyZ\Valinor\Type\Types\NativeClassType;
+use CuyZ\Valinor\Type\Types\StringValueType;
+use PHPUnit\Framework\TestCase;
+
+final class ArgumentsValuesTest extends TestCase
+{
+    public function test_dynamic_properties_to_arguments(): void
+    {
+        $settings = new Settings();
+        $settings->allowDynamicPropertiesFor = [\ArrayAccess::class];
+
+        $shell = Shell::root(
+            $settings,
+            new NativeClassType(\ArrayAccess::class),
+            [
+                'foo' => 'fooExists',
+                'dynamic' => 'baz',
+            ]
+        );
+        $arguments = new Arguments(
+            new Argument('foo', StringValueType::from('bar'))
+        );
+        $values = ArgumentsValues::forClass($arguments, $shell);
+
+        self::assertSame(2, iterator_count($values->getIterator()));
+        $argumentNames = [];
+        foreach ($values->getIterator() as $value) {
+            $argumentNames[] = $value->name();
+        }
+        self::assertSame(['foo', 'dynamic'], $argumentNames);
+    }
+
+    public function test_dynamic_properties_to_arguments_skip_on_non_objects(): void
+    {
+        $settings = new Settings();
+        $settings->allowDynamicPropertiesFor = [\ArrayAccess::class];
+
+        $shell = Shell::root(
+            $settings,
+            new StringValueType('test'),
+            [
+                'foo' => 'fooExists',
+                'dynamic' => 'baz',
+            ]
+        );
+        $arguments = new Arguments(
+            new Argument('foo', StringValueType::from('bar'))
+        );
+        $values = ArgumentsValues::forClass($arguments, $shell);
+
+        self::assertSame(1, iterator_count($values->getIterator()));
+    }
+}

--- a/tests/Unit/MapperBuilderTest.php
+++ b/tests/Unit/MapperBuilderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Unit;
 
+use CuyZ\Valinor\Library\Settings;
 use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Tests\Fake\Cache\FakeCache;
 use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeErrorMessage;
@@ -36,6 +37,7 @@ final class MapperBuilderTest extends TestCase
         $builderI = $builderA->withCache(new FakeCache());
         $builderJ = $builderA->supportDateFormats('Y-m-d');
         $builderK = $builderA->registerTransformer(fn (stdClass $object) => 'foo');
+        $builderL = $builderA->allowDynamicPropertiesFor();
 
         self::assertNotSame($builderA, $builderB);
         self::assertNotSame($builderA, $builderC);
@@ -47,6 +49,7 @@ final class MapperBuilderTest extends TestCase
         self::assertNotSame($builderA, $builderI);
         self::assertNotSame($builderA, $builderJ);
         self::assertNotSame($builderA, $builderK);
+        self::assertNotSame($builderA, $builderL);
     }
 
     public function test_mapper_instance_is_the_same(): void
@@ -80,5 +83,20 @@ final class MapperBuilderTest extends TestCase
         $mapperBuilder = $this->mapperBuilder->supportDateFormats('Y-m-d', 'd/m/Y', 'Y-m-d');
 
         self::assertSame(['Y-m-d', 'd/m/Y'], $mapperBuilder->supportedDateFormats());
+    }
+
+    public function test_allow_dynamic_properties(): void
+    {
+        $mapperBuilder = $this->mapperBuilder->allowDynamicPropertiesFor(
+            keyA: \ArrayAccess::class,
+            keyB: \ArrayAccess::class,
+        );
+        $settingsReceiver = \Closure::bind(
+            fn (): Settings => $this->settings,
+            $mapperBuilder,
+            $mapperBuilder,
+        );
+
+        self::assertSame([\ArrayAccess::class], $settingsReceiver()->allowDynamicPropertiesFor);
     }
 }


### PR DESCRIPTION
Hey,
i have a special use case where i need to allow dynamic properties via `__get` and `__set` in a class.
But with the strict type handling this package will not allow this, because all parameters must be known already. 

So i created this PR for discussion if this solution would be fine for you.
The next idea could also be to check for the `#[\AllowDynamicProperties]` class attribute - But this will takle a little bit other problem, where you don't need the `__get` and `__set` at all. 