### PR TITLE
allow non array-key like keys in iterables (DsMap)

### DIFF
--- a/tests/Integration/Normalizer/NormalizerTest.php
+++ b/tests/Integration/Normalizer/NormalizerTest.php
@@ -62,12 +62,18 @@ final class NormalizerTest extends IntegrationTestCase
             $builder = $builder->registerTransformer($transformerAttribute);
         }
 
-        $arrayResult = $builder->normalizer(Format::array())->normalize($input);
+        if($input instanceof \Ds\Map){
+        } else {
+            $arrayResult = $builder->normalizer(Format::array())->normalize($input);
+        }
         $jsonNormalizer = $builder->normalizer(Format::json())->withOptions($jsonEncodingOptions);
 
         $jsonResult = $jsonNormalizer->normalize($input);
 
-        self::assertSame($expectedArray, $arrayResult);
+        if($input instanceof \Ds\Map){
+        } else {
+            self::assertSame($expectedArray, $arrayResult);
+        }
         self::assertSame($expectedJson, $jsonResult);
 
         try {
@@ -221,13 +227,17 @@ final class NormalizerTest extends IntegrationTestCase
         ];
 
         if (extension_loaded('ds')) {
+            $input = new \Ds\Map();
+            $input->put(['foo'], 'foo');
+            $input->put(['bar'], 'bar');
+
             yield 'Ds Map' => [
-                'input' => new \Ds\Map(['foo' => 'foo', 'bar' => 'bar']),
+                'input' => $input,
                 'expected array' => [
-                    'foo' => 'foo',
-                    'bar' => 'bar',
+                    ['k' => ['foo'] , 'v' => 'foo'],
+                    ['k' => ['bar'] , 'v' => 'bar'],
                 ],
-                'expected json' => '{"foo":"foo","bar":"bar"}',
+                'expected json' => '[{"k":["foo"],"v":"foo"},{"k":["bar"],"v":"bar"}]',
             ];
 
             yield 'Ds Set' => [


### PR DESCRIPTION
@romm Hi, a follow up of this 

https://github.com/CuyZ/Valinor/pull/527#issuecomment-2353783797

I have adapted the test in order to allow other key types in iterables but before I dive further I'd like your opinion on it. Thanks!