### PR TITLE
fix: normalize empty iterable object as empty array in JSON

### DIFF
--- a/src/Normalizer/Transformer/RecursiveTransformer.php
+++ b/src/Normalizer/Transformer/RecursiveTransformer.php
@@ -109,17 +109,11 @@ final class RecursiveTransformer
                 );
             }
 
-            $result = (function () use ($value, $references) {
+            return (function () use ($value, $references) {
                 foreach ($value as $key => $item) {
                     yield $key => $this->doTransform($item, $references);
                 }
             })();
-
-            if (! $result->valid()) {
-                return EmptyObject::get();
-            }
-
-            return $result;
         }
 
         if (is_object($value) && ! $value instanceof Closure) {

--- a/tests/Integration/Normalizer/NormalizerTest.php
+++ b/tests/Integration/Normalizer/NormalizerTest.php
@@ -743,7 +743,7 @@ final class NormalizerTest extends IntegrationTestCase
         yield 'ArrayObject with no property' => [
             'input' => new ArrayObject(),
             'expected array' => [],
-            'expected_json' => '{}',
+            'expected_json' => '[]',
         ];
 
         yield 'iterable class with no property' => [
@@ -757,7 +757,7 @@ final class NormalizerTest extends IntegrationTestCase
                 }
             },
             'expected array' => [],
-            'expected_json' => '{}',
+            'expected_json' => '[]',
         ];
 
         yield 'nested array with JSON_PRETTY_PRINT option' => [


### PR DESCRIPTION
Fixes #589