### PR TITLE
fix: properly handle superfluous keys when source is an iterable

### DIFF
--- a/src/Mapper/Object/ArgumentsValues.php
+++ b/src/Mapper/Object/ArgumentsValues.php
@@ -13,8 +13,6 @@ use Traversable;
 use function array_key_exists;
 use function count;
 use function is_array;
-use function is_iterable;
-use function iterator_to_array;
 
 /**
  * @internal
@@ -82,10 +80,6 @@ final class ArgumentsValues implements IteratorAggregate
     private function transform(Shell $shell): void
     {
         $value = $shell->value();
-
-        if (is_iterable($value) && ! is_array($value)) {
-            $value = iterator_to_array($value);
-        }
 
         $transformedValue = $this->transformValueForSingleArgument($value, $shell->allowSuperfluousKeys());
 

--- a/src/Mapper/Tree/Builder/InterfaceNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/InterfaceNodeBuilder.php
@@ -50,6 +50,8 @@ final class InterfaceNodeBuilder implements NodeBuilder
 
         if ($shell->enableFlexibleCasting() && $shell->value() === null) {
             $shell = $shell->withValue([]);
+        } else {
+            $shell = $shell->transformIteratorToArray();
         }
 
         $className = $type->className();

--- a/src/Mapper/Tree/Builder/ObjectNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ObjectNodeBuilder.php
@@ -43,6 +43,8 @@ final class ObjectNodeBuilder implements NodeBuilder
 
         if ($shell->enableFlexibleCasting() && $shell->value() === null) {
             $shell = $shell->withValue([]);
+        } else {
+            $shell = $shell->transformIteratorToArray();
         }
 
         $class = $this->classDefinitionRepository->for($type);

--- a/src/Mapper/Tree/Shell.php
+++ b/src/Mapper/Tree/Shell.php
@@ -13,6 +13,8 @@ use CuyZ\Valinor\Type\Types\UnresolvableType;
 
 use function assert;
 use function implode;
+use function is_array;
+use function is_iterable;
 
 /** @internal */
 final class Shell
@@ -153,6 +155,18 @@ final class Shell
     public function allowedSuperfluousKeys(): array
     {
         return $this->allowedSuperfluousKeys;
+    }
+
+    public function transformIteratorToArray(): self
+    {
+        if (is_iterable($this->value) && ! is_array($this->value)) {
+            $self = clone $this;
+            $self->value = iterator_to_array($this->value);
+
+            return $self;
+        }
+
+        return $this;
     }
 
     public function path(): string

--- a/tests/Integration/Mapping/InterfaceInferringMappingTest.php
+++ b/tests/Integration/Mapping/InterfaceInferringMappingTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping;
 
 use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\Mapper\Source\Source;
 use CuyZ\Valinor\Mapper\Tree\Exception\CannotResolveObjectType;
 use CuyZ\Valinor\Mapper\Tree\Exception\InvalidResolvedImplementationValue;
 use CuyZ\Valinor\Mapper\Tree\Exception\MissingObjectImplementationRegistration;
@@ -63,6 +64,27 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
         self::assertSame('fooA', $resultA->valueA);
         self::assertInstanceOf(SomeClassThatInheritsInterfaceB::class, $resultB);
         self::assertSame('fooB', $resultB->valueB);
+    }
+
+    public function test_infer_interface_with_iterable_but_not_array_source(): void
+    {
+        try {
+            $result = $this->mapperBuilder()
+                ->infer(
+                    SomeInterface::class,
+                    /** @return class-string<SomeClassThatInheritsInterfaceA> */
+                    fn (string $foo): string => SomeClassThatInheritsInterfaceA::class
+                )
+                ->mapper()
+                ->map(SomeInterface::class, Source::iterable([
+                    'foo' => 'bar',
+                    'valueA' => 'value',
+                ]));
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertInstanceOf(SomeClassThatInheritsInterfaceA::class, $result);
     }
 
     public function test_infer_interface_with_union_of_class_string_works_properly(): void

--- a/tests/Integration/Mapping/Object/ObjectValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ObjectValuesMappingTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
 
 use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\Mapper\Source\Source;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject;
 use stdClass;
@@ -58,6 +59,22 @@ final class ObjectValuesMappingTest extends IntegrationTestCase
             self::assertMappingErrors($exception, [
                 '*root*' => "[1655117782] Unexpected key(s) `unexpectedValueA`, `unexpectedValueB`, `42`, expected `stringA`, `stringB`.",
                 'stringA' => '[unknown] Value 42 is not a valid string.'
+            ]);
+        }
+    }
+
+    public function test_superfluous_values_throws_exception_when_source_is_iterable_but_not_array(): void
+    {
+        try {
+            $this->mapperBuilder()->mapper()->map(ObjectWithTwoProperties::class, Source::iterable([
+                'stringA' => 'fooA',
+                'stringB' => 'fooB',
+                'unexpectedValue' => 'foo',
+                42 => 'baz',
+            ]));
+        } catch (MappingError $exception) {
+            self::assertMappingErrors($exception, [
+                '*root*' => "[1655117782] Unexpected key(s) `unexpectedValue`, `42`, expected `stringA`, `stringB`.",
             ]);
         }
     }

--- a/tests/Unit/Mapper/Tree/ShellTest.php
+++ b/tests/Unit/Mapper/Tree/ShellTest.php
@@ -87,4 +87,18 @@ final class ShellTest extends TestCase
         self::assertSame($value, $child->value());
         self::assertSame($attributes, $child->attributes());
     }
+
+    public function test_can_transform_iterator_to_array(): void
+    {
+        $value = (function () {
+            yield 'foo' => 'foo';
+            yield 'bar' => 'bar';
+        })();
+
+        $shellA = Shell::root(new Settings(), new FakeType(), $value);
+        $shellB = $shellA->transformIteratorToArray();
+
+        self::assertNotSame($shellA, $shellB);
+        self::assertSame(['foo' => 'foo', 'bar' => 'bar'], $shellB->value());
+    }
 }


### PR DESCRIPTION
Fixes #612