### PR TITLE
misc: remove `Throwable` inheritance from `ErrorMessage`

### DIFF
--- a/src/Mapper/Object/Exception/CannotFindObjectBuilder.php
+++ b/src/Mapper/Object/Exception/CannotFindObjectBuilder.php
@@ -6,19 +6,20 @@ namespace CuyZ\Valinor\Mapper\Object\Exception;
 
 use CuyZ\Valinor\Mapper\Object\ObjectBuilder;
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
+use CuyZ\Valinor\Mapper\Tree\Message\HasCode;
 use CuyZ\Valinor\Mapper\Tree\Message\HasParameters;
-use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\TypeHelper;
-use RuntimeException;
 
 use function array_keys;
 use function count;
 use function ksort;
 
 /** @internal */
-final class CannotFindObjectBuilder extends RuntimeException implements ErrorMessage, HasParameters
+final class CannotFindObjectBuilder implements ErrorMessage, HasCode, HasParameters
 {
     private string $body = 'Value {source_value} does not match any of {allowed_types}.';
+
+    private string $code = '1642183169';
 
     /** @var array<string, string> */
     private array $parameters;
@@ -52,13 +53,16 @@ final class CannotFindObjectBuilder extends RuntimeException implements ErrorMes
                 return implode(', ', $sortedSignatures);
             })(),
         ];
-
-        parent::__construct(StringFormatter::for($this), 1642183169);
     }
 
     public function body(): string
     {
         return $this->body;
+    }
+
+    public function code(): string
+    {
+        return $this->code;
     }
 
     public function parameters(): array

--- a/src/Mapper/Object/Exception/CannotParseToDateTime.php
+++ b/src/Mapper/Object/Exception/CannotParseToDateTime.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Object\Exception;
 
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
+use CuyZ\Valinor\Mapper\Tree\Message\HasCode;
 use CuyZ\Valinor\Mapper\Tree\Message\HasParameters;
-use CuyZ\Valinor\Utility\String\StringFormatter;
 use RuntimeException;
 
 /** @internal */
-final class CannotParseToDateTime extends RuntimeException implements ErrorMessage, HasParameters
+final class CannotParseToDateTime extends RuntimeException implements ErrorMessage, HasCode, HasParameters
 {
     private string $body = 'Value {source_value} does not match any of the following formats: {formats}.';
 
@@ -26,12 +26,18 @@ final class CannotParseToDateTime extends RuntimeException implements ErrorMessa
             'formats' => '`' . implode('`, `', $formats) . '`',
         ];
 
-        parent::__construct(StringFormatter::for($this), 1630686564);
+        // @infection-ignore-all
+        parent::__construct($this->body);
     }
 
     public function body(): string
     {
         return $this->body;
+    }
+
+    public function code(): string
+    {
+        return '1630686564';
     }
 
     public function parameters(): array

--- a/src/Mapper/Object/Exception/InvalidSource.php
+++ b/src/Mapper/Object/Exception/InvalidSource.php
@@ -6,15 +6,16 @@ namespace CuyZ\Valinor\Mapper\Object\Exception;
 
 use CuyZ\Valinor\Mapper\Object\Arguments;
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
+use CuyZ\Valinor\Mapper\Tree\Message\HasCode;
 use CuyZ\Valinor\Mapper\Tree\Message\HasParameters;
-use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\TypeHelper;
-use RuntimeException;
 
 /** @internal */
-final class InvalidSource extends RuntimeException implements ErrorMessage, HasParameters
+final class InvalidSource implements ErrorMessage, HasCode, HasParameters
 {
     private string $body;
+
+    private string $code = '1632903281';
 
     /** @var array<string, string> */
     private array $parameters;
@@ -28,13 +29,16 @@ final class InvalidSource extends RuntimeException implements ErrorMessage, HasP
         $this->body = $source === null
             ? 'Cannot be empty and must be filled with a value matching type {expected_type}.'
             : 'Value {source_value} does not match type {expected_type}.';
-
-        parent::__construct(StringFormatter::for($this), 1632903281);
     }
 
     public function body(): string
     {
         return $this->body;
+    }
+
+    public function code(): string
+    {
+        return $this->code;
     }
 
     public function parameters(): array

--- a/src/Mapper/Tree/Builder/ArrayNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ArrayNodeBuilder.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Tree\Builder;
 
 use CuyZ\Valinor\Mapper\Tree\Exception\InvalidIterableKeyType;
-use CuyZ\Valinor\Mapper\Tree\Exception\InvalidTraversableKey;
+use CuyZ\Valinor\Mapper\Tree\Exception\InvalidArrayKey;
 use CuyZ\Valinor\Mapper\Tree\Exception\SourceIsEmptyArray;
 use CuyZ\Valinor\Mapper\Tree\Exception\SourceMustBeIterable;
 use CuyZ\Valinor\Mapper\Tree\Shell;
@@ -56,7 +56,7 @@ final class ArrayNodeBuilder implements NodeBuilder
             $child = $shell->child((string)$key, $subType);
 
             if (! $keyType->accepts($key)) {
-                $children[$key] = Node::error($child, new InvalidTraversableKey($key, $keyType));
+                $children[$key] = Node::error($child, new InvalidArrayKey($key, $keyType));
             } else {
                 $children[$key] = $rootBuilder->build($child->withValue($val));
             }

--- a/src/Mapper/Tree/Builder/Node.php
+++ b/src/Mapper/Tree/Builder/Node.php
@@ -9,7 +9,6 @@ use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
 use CuyZ\Valinor\Mapper\Tree\Shell;
 use CuyZ\Valinor\Utility\ValueDumper;
-use Throwable;
 
 use function array_diff;
 use function array_keys;
@@ -36,7 +35,7 @@ final class Node
         return new self(value: $value, childrenCount: $childrenCount);
     }
 
-    public static function error(Shell $shell, Throwable&Message $error): self
+    public static function error(Shell $shell, Message $error): self
     {
         $nodeMessage = new NodeMessage(
             $error,

--- a/src/Mapper/Tree/Builder/ObjectNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ObjectNodeBuilder.php
@@ -68,9 +68,10 @@ final class ObjectNodeBuilder implements NodeBuilder
 
             try {
                 $object = $this->buildObject($builder, $children);
-            } catch (Message $exception) {
+            } catch (UserlandError|Message $exception) {
                 if ($exception instanceof UserlandError) {
-                    $exception = ($this->exceptionFilter)($exception->previous());
+                    // @phpstan-ignore argument.type (we know there always is a previous exception)
+                    $exception = ($this->exceptionFilter)($exception->getPrevious());
                 }
 
                 return Node::error($shell, $exception);

--- a/src/Mapper/Tree/Exception/CannotResolveTypeFromUnion.php
+++ b/src/Mapper/Tree/Exception/CannotResolveTypeFromUnion.php
@@ -5,19 +5,20 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
+use CuyZ\Valinor\Mapper\Tree\Message\HasCode;
 use CuyZ\Valinor\Mapper\Tree\Message\HasParameters;
 use CuyZ\Valinor\Type\Types\UnionType;
-use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\TypeHelper;
-use RuntimeException;
 
 use function array_map;
 use function implode;
 
 /** @internal */
-final class CannotResolveTypeFromUnion extends RuntimeException implements ErrorMessage, HasParameters
+final class CannotResolveTypeFromUnion implements ErrorMessage, HasCode, HasParameters
 {
     private string $body;
+
+    private string $code = '1607027306';
 
     /** @var array<string, string> */
     private array $parameters;
@@ -40,13 +41,16 @@ final class CannotResolveTypeFromUnion extends RuntimeException implements Error
                 ? 'Invalid value {source_value}.'
                 : 'Value {source_value} does not match any of {allowed_types}.';
         }
-
-        parent::__construct(StringFormatter::for($this), 1607027306);
     }
 
     public function body(): string
     {
         return $this->body;
+    }
+
+    public function code(): string
+    {
+        return $this->code;
     }
 
     public function parameters(): array

--- a/src/Mapper/Tree/Exception/InvalidArrayKey.php
+++ b/src/Mapper/Tree/Exception/InvalidArrayKey.php
@@ -5,17 +5,18 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
+use CuyZ\Valinor\Mapper\Tree\Message\HasCode;
 use CuyZ\Valinor\Mapper\Tree\Message\HasParameters;
 use CuyZ\Valinor\Type\Types\ArrayKeyType;
-use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\TypeHelper;
 use CuyZ\Valinor\Utility\ValueDumper;
-use RuntimeException;
 
 /** @internal */
-final class InvalidTraversableKey extends RuntimeException implements ErrorMessage, HasParameters
+final class InvalidArrayKey implements ErrorMessage, HasCode, HasParameters
 {
     private string $body = 'Key {key} does not match type {expected_type}.';
+
+    private string $code = '1630946163';
 
     /** @var array<string, string> */
     private array $parameters;
@@ -26,13 +27,16 @@ final class InvalidTraversableKey extends RuntimeException implements ErrorMessa
             'key' => ValueDumper::dump($key),
             'expected_type' => TypeHelper::dump($type),
         ];
-
-        parent::__construct(StringFormatter::for($this), 1630946163);
     }
 
     public function body(): string
     {
         return $this->body;
+    }
+
+    public function code(): string
+    {
+        return $this->code;
     }
 
     public function parameters(): array

--- a/src/Mapper/Tree/Exception/InvalidListKey.php
+++ b/src/Mapper/Tree/Exception/InvalidListKey.php
@@ -5,15 +5,16 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
+use CuyZ\Valinor\Mapper\Tree\Message\HasCode;
 use CuyZ\Valinor\Mapper\Tree\Message\HasParameters;
-use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\ValueDumper;
-use RuntimeException;
 
 /** @internal */
-final class InvalidListKey extends RuntimeException implements ErrorMessage, HasParameters
+final class InvalidListKey implements ErrorMessage, HasCode, HasParameters
 {
     private string $body = 'Invalid sequential key {key}, expected {expected}.';
+
+    private string $code = '1654273010';
 
     /** @var array<string, string> */
     private array $parameters;
@@ -24,13 +25,16 @@ final class InvalidListKey extends RuntimeException implements ErrorMessage, Has
             'key' => ValueDumper::dump($key),
             'expected' => (string)$expected,
         ];
-
-        parent::__construct(StringFormatter::for($this), 1654273010);
     }
 
     public function body(): string
     {
         return $this->body;
+    }
+
+    public function code(): string
+    {
+        return $this->code;
     }
 
     public function parameters(): array

--- a/src/Mapper/Tree/Exception/InvalidNodeValue.php
+++ b/src/Mapper/Tree/Exception/InvalidNodeValue.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
+use CuyZ\Valinor\Mapper\Tree\Message\HasCode;
 use CuyZ\Valinor\Mapper\Tree\Message\HasParameters;
 use CuyZ\Valinor\Type\Type;
-use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\TypeHelper;
-use RuntimeException;
 
 /** @internal */
-final class InvalidNodeValue extends RuntimeException implements ErrorMessage, HasParameters
+final class InvalidNodeValue implements ErrorMessage, HasCode, HasParameters
 {
     private string $body;
+
+    private string $code = '1630678334';
 
     /** @var array<string, string> */
     private array $parameters;
@@ -28,13 +29,16 @@ final class InvalidNodeValue extends RuntimeException implements ErrorMessage, H
         $this->body = TypeHelper::containsObject($type)
             ? 'Invalid value {source_value}.'
             : 'Value {source_value} does not match type {expected_type}.';
-
-        parent::__construct(StringFormatter::for($this), 1630678334);
     }
 
     public function body(): string
     {
         return $this->body;
+    }
+
+    public function code(): string
+    {
+        return $this->code;
     }
 
     public function parameters(): array

--- a/src/Mapper/Tree/Exception/MissingNodeValue.php
+++ b/src/Mapper/Tree/Exception/MissingNodeValue.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
+use CuyZ\Valinor\Mapper\Tree\Message\HasCode;
 use CuyZ\Valinor\Mapper\Tree\Message\HasParameters;
 use CuyZ\Valinor\Type\Type;
-use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\TypeHelper;
-use RuntimeException;
 
 /** @internal */
-final class MissingNodeValue extends RuntimeException implements ErrorMessage, HasParameters
+final class MissingNodeValue implements ErrorMessage, HasCode, HasParameters
 {
     private string $body = 'Cannot be empty and must be filled with a value matching type {expected_type}.';
+
+    private string $code = '1655449641';
 
     /** @var array<string, string> */
     private array $parameters;
@@ -24,13 +25,16 @@ final class MissingNodeValue extends RuntimeException implements ErrorMessage, H
         $this->parameters = [
             'expected_type' => TypeHelper::dump($type),
         ];
-
-        parent::__construct(StringFormatter::for($this), 1655449641);
     }
 
     public function body(): string
     {
         return $this->body;
+    }
+
+    public function code(): string
+    {
+        return $this->code;
     }
 
     public function parameters(): array

--- a/src/Mapper/Tree/Exception/SourceIsEmptyArray.php
+++ b/src/Mapper/Tree/Exception/SourceIsEmptyArray.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
+use CuyZ\Valinor\Mapper\Tree\Message\HasCode;
 use CuyZ\Valinor\Mapper\Tree\Message\HasParameters;
 use CuyZ\Valinor\Type\Types\NonEmptyArrayType;
-use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\TypeHelper;
-use RuntimeException;
 
 /** @internal */
-final class SourceIsEmptyArray extends RuntimeException implements ErrorMessage, HasParameters
+final class SourceIsEmptyArray implements ErrorMessage, HasCode, HasParameters
 {
-    private string $body;
+    private string $body = 'Array cannot be empty and must contain values of type {expected_subtype}.';
+
+    private string $code = '1736015505';
 
     /** @var array<string, string> */
     private array $parameters;
@@ -24,15 +25,16 @@ final class SourceIsEmptyArray extends RuntimeException implements ErrorMessage,
         $this->parameters = [
             'expected_subtype' => TypeHelper::dump($type->subType()),
         ];
-
-        $this->body = 'Array cannot be empty and must contain values of type {expected_subtype}.';
-
-        parent::__construct(StringFormatter::for($this), 1736015505);
     }
 
     public function body(): string
     {
         return $this->body;
+    }
+
+    public function code(): string
+    {
+        return $this->code;
     }
 
     public function parameters(): array

--- a/src/Mapper/Tree/Exception/SourceIsEmptyList.php
+++ b/src/Mapper/Tree/Exception/SourceIsEmptyList.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
+use CuyZ\Valinor\Mapper\Tree\Message\HasCode;
 use CuyZ\Valinor\Mapper\Tree\Message\HasParameters;
 use CuyZ\Valinor\Type\Types\NonEmptyListType;
-use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\TypeHelper;
-use RuntimeException;
 
 /** @internal */
-final class SourceIsEmptyList extends RuntimeException implements ErrorMessage, HasParameters
+final class SourceIsEmptyList implements ErrorMessage, HasCode, HasParameters
 {
-    private string $body;
+    private string $body = 'List cannot be empty and must contain values of type {expected_subtype}.';
+
+    private string $code = '1736015714';
 
     /** @var array<string, string> */
     private array $parameters;
@@ -24,15 +25,16 @@ final class SourceIsEmptyList extends RuntimeException implements ErrorMessage, 
         $this->parameters = [
             'expected_subtype' => TypeHelper::dump($type->subType()),
         ];
-
-        $this->body = 'List cannot be empty and must contain values of type {expected_subtype}.';
-
-        parent::__construct(StringFormatter::for($this), 1736015714);
     }
 
     public function body(): string
     {
         return $this->body;
+    }
+
+    public function code(): string
+    {
+        return $this->code;
     }
 
     public function parameters(): array

--- a/src/Mapper/Tree/Exception/SourceIsNotNull.php
+++ b/src/Mapper/Tree/Exception/SourceIsNotNull.php
@@ -5,22 +5,22 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
-use RuntimeException;
+use CuyZ\Valinor\Mapper\Tree\Message\HasCode;
 
 /** @internal */
-final class SourceIsNotNull extends RuntimeException implements ErrorMessage
+final class SourceIsNotNull implements ErrorMessage, HasCode
 {
-    private string $body;
+    private string $body = 'Value {source_value} is not null.';
 
-    public function __construct()
-    {
-        $this->body = 'Value {source_value} is not null.';
-
-        parent::__construct($this->body, 1710263908);
-    }
+    private string $code = '1710263908';
 
     public function body(): string
     {
         return $this->body;
+    }
+
+    public function code(): string
+    {
+        return $this->code;
     }
 }

--- a/src/Mapper/Tree/Exception/SourceMustBeIterable.php
+++ b/src/Mapper/Tree/Exception/SourceMustBeIterable.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
+use CuyZ\Valinor\Mapper\Tree\Message\HasCode;
 use CuyZ\Valinor\Mapper\Tree\Message\HasParameters;
 use CuyZ\Valinor\Type\Type;
-use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\TypeHelper;
-use RuntimeException;
 
 /** @internal */
-final class SourceMustBeIterable extends RuntimeException implements ErrorMessage, HasParameters
+final class SourceMustBeIterable implements ErrorMessage, HasCode, HasParameters
 {
     private string $body;
+
+    private string $code = '1618739163';
 
     /** @var array<string, string> */
     private array $parameters;
@@ -34,13 +35,16 @@ final class SourceMustBeIterable extends RuntimeException implements ErrorMessag
                 ? 'Invalid value {source_value}.'
                 : 'Value {source_value} does not match type {expected_type}.';
         }
-
-        parent::__construct(StringFormatter::for($this), 1618739163);
     }
 
     public function body(): string
     {
         return $this->body;
+    }
+
+    public function code(): string
+    {
+        return $this->code;
     }
 
     public function parameters(): array

--- a/src/Mapper/Tree/Exception/TooManyResolvedTypesFromUnion.php
+++ b/src/Mapper/Tree/Exception/TooManyResolvedTypesFromUnion.php
@@ -5,19 +5,20 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
+use CuyZ\Valinor\Mapper\Tree\Message\HasCode;
 use CuyZ\Valinor\Mapper\Tree\Message\HasParameters;
 use CuyZ\Valinor\Type\Types\UnionType;
-use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\TypeHelper;
-use RuntimeException;
 
 use function array_map;
 use function implode;
 
 /** @internal */
-final class TooManyResolvedTypesFromUnion extends RuntimeException implements ErrorMessage, HasParameters
+final class TooManyResolvedTypesFromUnion implements ErrorMessage, HasCode, HasParameters
 {
     private string $body;
+
+    private string $code = '1710262975';
 
     /** @var array<string, string> */
     private array $parameters;
@@ -27,20 +28,23 @@ final class TooManyResolvedTypesFromUnion extends RuntimeException implements Er
         $this->parameters = [
             'allowed_types' => implode(
                 ', ',
-                array_map(TypeHelper::dump(...), $unionType->types())
+                array_map(TypeHelper::dump(...), $unionType->types()),
             ),
         ];
 
         $this->body = TypeHelper::containsObject($unionType)
             ? 'Invalid value {source_value}, it matches two or more types from union: cannot take a decision.'
             : 'Invalid value {source_value}, it matches two or more types from {allowed_types}: cannot take a decision.';
-
-        parent::__construct(StringFormatter::for($this), 1710262975);
     }
 
     public function body(): string
     {
         return $this->body;
+    }
+
+    public function code(): string
+    {
+        return $this->code;
     }
 
     public function parameters(): array

--- a/src/Mapper/Tree/Exception/UnexpectedKeysInSource.php
+++ b/src/Mapper/Tree/Exception/UnexpectedKeysInSource.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
+use CuyZ\Valinor\Mapper\Tree\Message\HasCode;
 use CuyZ\Valinor\Mapper\Tree\Message\HasParameters;
-use CuyZ\Valinor\Utility\String\StringFormatter;
-use RuntimeException;
 
 use function array_filter;
 use function array_keys;
@@ -15,9 +14,11 @@ use function implode;
 use function in_array;
 
 /** @internal */
-final class UnexpectedKeysInSource extends RuntimeException implements ErrorMessage, HasParameters
+final class UnexpectedKeysInSource implements ErrorMessage, HasCode, HasParameters
 {
     private string $body = 'Unexpected key(s) {keys}, expected {expected_keys}.';
+
+    private string $code = '1655117782';
 
     /** @var array<string, string> */
     private array $parameters;
@@ -30,20 +31,23 @@ final class UnexpectedKeysInSource extends RuntimeException implements ErrorMess
     {
         $superfluous = array_filter(
             array_keys($value),
-            fn (string $key) => ! in_array($key, $children, true)
+            fn (string $key) => ! in_array($key, $children, true),
         );
 
         $this->parameters = [
             'keys' => '`' . implode('`, `', $superfluous) . '`',
             'expected_keys' => '`' . implode('`, `', $children) . '`',
         ];
-
-        parent::__construct(StringFormatter::for($this), 1655117782);
     }
 
     public function body(): string
     {
         return $this->body;
+    }
+
+    public function code(): string
+    {
+        return $this->code;
     }
 
     public function parameters(): array

--- a/src/Mapper/Tree/Message/ErrorMessage.php
+++ b/src/Mapper/Tree/Message/ErrorMessage.php
@@ -4,7 +4,5 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper\Tree\Message;
 
-use Throwable;
-
 /** @api */
-interface ErrorMessage extends Message, Throwable {}
+interface ErrorMessage extends Message {}

--- a/src/Mapper/Tree/Message/MessageBuilder.php
+++ b/src/Mapper/Tree/Message/MessageBuilder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper\Tree\Message;
 
-use LanguageServerProtocol\MessageType;
 use RuntimeException;
 use Throwable;
 
@@ -42,11 +41,11 @@ final class MessageBuilder
     }
 
     /**
-     * @return self<ErrorMessage>
+     * @return self<ErrorMessage&Throwable>
      */
     public static function newError(string $body): self
     {
-        /** @var self<ErrorMessage> $instance */
+        /** @var self<ErrorMessage&Throwable> $instance */
         $instance = new self($body);
         $instance->isError = true;
 
@@ -155,7 +154,7 @@ final class MessageBuilder
         };
     }
 
-    private function buildErrorMessage(): ErrorMessage&HasCode&HasParameters
+    private function buildErrorMessage(): ErrorMessage&Throwable&HasCode&HasParameters
     {
         return new class ($this->body, $this->code, $this->parameters) extends RuntimeException implements ErrorMessage, HasCode, HasParameters {
             /**

--- a/src/Mapper/Tree/Message/NodeMessage.php
+++ b/src/Mapper/Tree/Message/NodeMessage.php
@@ -112,7 +112,7 @@ final class NodeMessage implements Message, HasCode, Stringable
 
     public function isError(): bool
     {
-        return $this->message instanceof Throwable;
+        return $this->message instanceof ErrorMessage;
     }
 
     public function code(): string

--- a/src/Mapper/Tree/Message/UserlandError.php
+++ b/src/Mapper/Tree/Message/UserlandError.php
@@ -8,23 +8,14 @@ use RuntimeException;
 use Throwable;
 
 /** @internal */
-final class UserlandError extends RuntimeException implements ErrorMessage
+final class UserlandError extends RuntimeException
 {
-    public static function from(Throwable $message): Message&Throwable
+    public static function from(Throwable $message): Throwable
     {
-        // @infection-ignore-all
-        return $message instanceof Message
-            ? $message
-            : new self('Invalid value.', 1657215570, $message);
-    }
+        if ($message instanceof ErrorMessage) {
+            return $message;
+        }
 
-    public function body(): string
-    {
-        return 'Invalid value.';
-    }
-
-    public function previous(): Throwable
-    {
-        return $this->getPrevious(); // @phpstan-ignore-line
+        return new self(previous: $message);
     }
 }

--- a/src/Utility/String/StringFormatter.php
+++ b/src/Utility/String/StringFormatter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Utility\String;
 
-use CuyZ\Valinor\Mapper\Tree\Message\HasParameters;
 use IntlException;
 use MessageFormatter;
 
@@ -26,11 +25,6 @@ final class StringFormatter
         return class_exists(MessageFormatter::class)
             ? self::formatWithIntl($locale, $body, $parameters)
             : self::formatWithRegex($body, $parameters);
-    }
-
-    public static function for(HasParameters $message): string
-    {
-        return self::formatWithRegex($message->body(), $message->parameters());
     }
 
     /**

--- a/tests/Unit/Utility/String/StringFormatterTest.php
+++ b/tests/Unit/Utility/String/StringFormatterTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Unit\Utility\String;
 
-use CuyZ\Valinor\Tests\Fake\Mapper\Tree\Message\FakeMessage;
 use CuyZ\Valinor\Utility\String\StringFormatter;
 use CuyZ\Valinor\Utility\String\StringFormatterError;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
@@ -45,15 +44,5 @@ final class StringFormatterTest extends TestCase
         $this->expectExceptionCode(1652901203);
 
         StringFormatter::format('en', 'some message with {invalid format}');
-    }
-
-    public function test_parameters_are_replaced_correctly(): void
-    {
-        $message = (new FakeMessage('some message with {valid_parameter}'))->withParameters([
-            'invalid )( parameter' => 'invalid value',
-            'valid_parameter' => 'valid value',
-        ]);
-
-        self::assertSame('some message with valid value', StringFormatter::for($message));
     }
 }


### PR DESCRIPTION
The error messages being exceptions do not add any value when using the
messages in a `MappingError`. Therefore, the backtrace creation is a
heavy, unnecessary, operation.

All internal messages have been changed to reflect this.

Throwing custom exceptions during object creations still works.