### PR TITLE
feat!: change exposed error messages codes

### DIFF
--- a/docs/pages/project/upgrading.md
+++ b/docs/pages/project/upgrading.md
@@ -38,6 +38,30 @@ $type = $message->type();
 $type = $message->sourceValue();
 ```
 
+### Changes to messages codes
+
+Codes have been changed for all messages that can be thrown during mapping. They
+now are way more expressive. Here is the exhaustive list of changes and their
+replacements:
+
+- `1642183169` → `cannot_find_object_builder`
+- `1632903281` → `invalid_source`
+- `1607027306` → `cannot_resolve_type_from_union`
+- `1654273010` → `invalid_list_key`
+- `1630678334` → `invalid_value`
+- `1630946163` → `invalid_array_key`
+- `1655449641` → `missing_value`
+- `1736015505` → `value_is_empty_array`
+- `1736015714` → `value_is_empty_list`
+- `1710263908` → `value_is_not_null`
+- `1618739163` → `value_is_not_iterable`
+- `1710262975` → `too_many_resolved_types_from_union`
+- `1655117782` → `unexpected_keys`
+- `1630686564` → `cannot_parse_datetime_format`
+
+Note that a lot of error messages related to invalid scalar values mapping now
+have a specific code, where it used to be `unknown`.
+
 ### Full list of breaking changes
 
 - Removed `\CuyZ\Valinor\Mapper\MappingError::node()`

--- a/src/Mapper/Object/Exception/CannotFindObjectBuilder.php
+++ b/src/Mapper/Object/Exception/CannotFindObjectBuilder.php
@@ -19,7 +19,7 @@ final class CannotFindObjectBuilder implements ErrorMessage, HasCode, HasParamet
 {
     private string $body = 'Value {source_value} does not match any of {allowed_types}.';
 
-    private string $code = '1642183169';
+    private string $code = 'cannot_find_object_builder';
 
     /** @var array<string, string> */
     private array $parameters;

--- a/src/Mapper/Object/Exception/CannotParseToDateTime.php
+++ b/src/Mapper/Object/Exception/CannotParseToDateTime.php
@@ -37,7 +37,7 @@ final class CannotParseToDateTime extends RuntimeException implements ErrorMessa
 
     public function code(): string
     {
-        return '1630686564';
+        return 'cannot_parse_datetime_format';
     }
 
     public function parameters(): array

--- a/src/Mapper/Object/Exception/InvalidSource.php
+++ b/src/Mapper/Object/Exception/InvalidSource.php
@@ -15,7 +15,7 @@ final class InvalidSource implements ErrorMessage, HasCode, HasParameters
 {
     private string $body;
 
-    private string $code = '1632903281';
+    private string $code = 'invalid_source';
 
     /** @var array<string, string> */
     private array $parameters;

--- a/src/Mapper/Object/Factory/DateTimeZoneObjectBuilderFactory.php
+++ b/src/Mapper/Object/Factory/DateTimeZoneObjectBuilderFactory.php
@@ -67,7 +67,9 @@ final class DateTimeZoneObjectBuilderFactory implements ObjectBuilderFactory
             try {
                 return new DateTimeZone($timezone);
             } catch (Exception) {
-                throw MessageBuilder::newError('Value {source_value} is not a valid timezone.')->build();
+                throw MessageBuilder::newError('Value {source_value} is not a valid timezone.')
+                    ->withCode('invalid_timezone')
+                    ->build();
             }
         };
 

--- a/src/Mapper/Tree/Exception/CannotResolveTypeFromUnion.php
+++ b/src/Mapper/Tree/Exception/CannotResolveTypeFromUnion.php
@@ -18,7 +18,7 @@ final class CannotResolveTypeFromUnion implements ErrorMessage, HasCode, HasPara
 {
     private string $body;
 
-    private string $code = '1607027306';
+    private string $code = 'cannot_resolve_type_from_union';
 
     /** @var array<string, string> */
     private array $parameters;

--- a/src/Mapper/Tree/Exception/InvalidArrayKey.php
+++ b/src/Mapper/Tree/Exception/InvalidArrayKey.php
@@ -16,7 +16,7 @@ final class InvalidArrayKey implements ErrorMessage, HasCode, HasParameters
 {
     private string $body = 'Key {key} does not match type {expected_type}.';
 
-    private string $code = '1630946163';
+    private string $code = 'invalid_array_key';
 
     /** @var array<string, string> */
     private array $parameters;

--- a/src/Mapper/Tree/Exception/InvalidListKey.php
+++ b/src/Mapper/Tree/Exception/InvalidListKey.php
@@ -14,7 +14,7 @@ final class InvalidListKey implements ErrorMessage, HasCode, HasParameters
 {
     private string $body = 'Invalid sequential key {key}, expected {expected}.';
 
-    private string $code = '1654273010';
+    private string $code = 'invalid_list_key';
 
     /** @var array<string, string> */
     private array $parameters;

--- a/src/Mapper/Tree/Exception/InvalidNodeValue.php
+++ b/src/Mapper/Tree/Exception/InvalidNodeValue.php
@@ -15,7 +15,7 @@ final class InvalidNodeValue implements ErrorMessage, HasCode, HasParameters
 {
     private string $body;
 
-    private string $code = '1630678334';
+    private string $code = 'invalid_value';
 
     /** @var array<string, string> */
     private array $parameters;

--- a/src/Mapper/Tree/Exception/MissingNodeValue.php
+++ b/src/Mapper/Tree/Exception/MissingNodeValue.php
@@ -15,7 +15,7 @@ final class MissingNodeValue implements ErrorMessage, HasCode, HasParameters
 {
     private string $body = 'Cannot be empty and must be filled with a value matching type {expected_type}.';
 
-    private string $code = '1655449641';
+    private string $code = 'missing_value';
 
     /** @var array<string, string> */
     private array $parameters;

--- a/src/Mapper/Tree/Exception/SourceIsEmptyArray.php
+++ b/src/Mapper/Tree/Exception/SourceIsEmptyArray.php
@@ -15,7 +15,7 @@ final class SourceIsEmptyArray implements ErrorMessage, HasCode, HasParameters
 {
     private string $body = 'Array cannot be empty and must contain values of type {expected_subtype}.';
 
-    private string $code = '1736015505';
+    private string $code = 'value_is_empty_array';
 
     /** @var array<string, string> */
     private array $parameters;

--- a/src/Mapper/Tree/Exception/SourceIsEmptyList.php
+++ b/src/Mapper/Tree/Exception/SourceIsEmptyList.php
@@ -15,7 +15,7 @@ final class SourceIsEmptyList implements ErrorMessage, HasCode, HasParameters
 {
     private string $body = 'List cannot be empty and must contain values of type {expected_subtype}.';
 
-    private string $code = '1736015714';
+    private string $code = 'value_is_empty_list';
 
     /** @var array<string, string> */
     private array $parameters;

--- a/src/Mapper/Tree/Exception/SourceIsNotNull.php
+++ b/src/Mapper/Tree/Exception/SourceIsNotNull.php
@@ -12,7 +12,7 @@ final class SourceIsNotNull implements ErrorMessage, HasCode
 {
     private string $body = 'Value {source_value} is not null.';
 
-    private string $code = '1710263908';
+    private string $code = 'value_is_not_null';
 
     public function body(): string
     {

--- a/src/Mapper/Tree/Exception/SourceMustBeIterable.php
+++ b/src/Mapper/Tree/Exception/SourceMustBeIterable.php
@@ -15,7 +15,7 @@ final class SourceMustBeIterable implements ErrorMessage, HasCode, HasParameters
 {
     private string $body;
 
-    private string $code = '1618739163';
+    private string $code = 'value_is_not_iterable';
 
     /** @var array<string, string> */
     private array $parameters;

--- a/src/Mapper/Tree/Exception/TooManyResolvedTypesFromUnion.php
+++ b/src/Mapper/Tree/Exception/TooManyResolvedTypesFromUnion.php
@@ -18,7 +18,7 @@ final class TooManyResolvedTypesFromUnion implements ErrorMessage, HasCode, HasP
 {
     private string $body;
 
-    private string $code = '1710262975';
+    private string $code = 'too_many_resolved_types_from_union';
 
     /** @var array<string, string> */
     private array $parameters;

--- a/src/Mapper/Tree/Exception/UnexpectedKeysInSource.php
+++ b/src/Mapper/Tree/Exception/UnexpectedKeysInSource.php
@@ -18,7 +18,7 @@ final class UnexpectedKeysInSource implements ErrorMessage, HasCode, HasParamete
 {
     private string $body = 'Unexpected key(s) {keys}, expected {expected_keys}.';
 
-    private string $code = '1655117782';
+    private string $code = 'unexpected_keys';
 
     /** @var array<string, string> */
     private array $parameters;

--- a/src/Type/Types/ArrayKeyType.php
+++ b/src/Type/Types/ArrayKeyType.php
@@ -172,7 +172,9 @@ final class ArrayKeyType implements ScalarType
 
     public function errorMessage(): ErrorMessage
     {
-        return MessageBuilder::newError('Value {source_value} is not a valid array key.')->build();
+        return MessageBuilder::newError('Value {source_value} is not a valid array key.')
+            ->withCode('invalid_array_key')
+            ->build();
     }
 
     public function nativeType(): Type

--- a/src/Type/Types/BooleanValueType.php
+++ b/src/Type/Types/BooleanValueType.php
@@ -80,6 +80,7 @@ final class BooleanValueType implements BooleanType, FixedType
     public function errorMessage(): ErrorMessage
     {
         return MessageBuilder::newError('Value {source_value} does not match boolean value {expected_value}.')
+            ->withCode('invalid_boolean_value')
             ->withParameter('expected_value', $this->toString())
             ->build();
     }

--- a/src/Type/Types/ClassStringType.php
+++ b/src/Type/Types/ClassStringType.php
@@ -146,11 +146,14 @@ final class ClassStringType implements StringType, CompositeType
     {
         if ($this->subType) {
             return MessageBuilder::newError('Value {source_value} is not a valid class string of `{expected_class_type}`.')
+                ->withCode('invalid_class_string')
                 ->withParameter('expected_class_type', $this->subType->toString())
                 ->build();
         }
 
-        return MessageBuilder::newError('Value {source_value} is not a valid class string.')->build();
+        return MessageBuilder::newError('Value {source_value} is not a valid class string.')
+            ->withCode('invalid_class_string')
+            ->build();
     }
 
     public function subType(): ObjectType|UnionType|null

--- a/src/Type/Types/FloatValueType.php
+++ b/src/Type/Types/FloatValueType.php
@@ -57,6 +57,7 @@ final class FloatValueType implements FloatType, FixedType
     public function errorMessage(): ErrorMessage
     {
         return MessageBuilder::newError('Value {source_value} does not match float value {expected_value}.')
+            ->withCode('invalid_float_value')
             ->withParameter('expected_value', (string)$this->value)
             ->build();
     }

--- a/src/Type/Types/IntegerRangeType.php
+++ b/src/Type/Types/IntegerRangeType.php
@@ -113,6 +113,7 @@ final class IntegerRangeType implements IntegerType
     public function errorMessage(): ErrorMessage
     {
         return MessageBuilder::newError('Value {source_value} is not a valid integer between {min} and {max}.')
+            ->withCode('invalid_integer_range')
             ->withParameter('min', (string)$this->min)
             ->withParameter('max', (string)$this->max)
             ->build();

--- a/src/Type/Types/IntegerValueType.php
+++ b/src/Type/Types/IntegerValueType.php
@@ -62,6 +62,7 @@ final class IntegerValueType implements IntegerType, FixedType
     public function errorMessage(): ErrorMessage
     {
         return MessageBuilder::newError('Value {source_value} does not match integer value {expected_value}.')
+            ->withCode('invalid_integer_value')
             ->withParameter('expected_value', (string)$this->value)
             ->build();
     }

--- a/src/Type/Types/NativeBooleanType.php
+++ b/src/Type/Types/NativeBooleanType.php
@@ -64,7 +64,9 @@ final class NativeBooleanType implements BooleanType
 
     public function errorMessage(): ErrorMessage
     {
-        return MessageBuilder::newError('Value {source_value} is not a valid boolean.')->build();
+        return MessageBuilder::newError('Value {source_value} is not a valid boolean.')
+            ->withCode('invalid_boolean')
+            ->build();
     }
 
     public function nativeType(): NativeBooleanType

--- a/src/Type/Types/NativeFloatType.php
+++ b/src/Type/Types/NativeFloatType.php
@@ -55,7 +55,9 @@ final class NativeFloatType implements FloatType
 
     public function errorMessage(): ErrorMessage
     {
-        return MessageBuilder::newError('Value {source_value} is not a valid float.')->build();
+        return MessageBuilder::newError('Value {source_value} is not a valid float.')
+            ->withCode('invalid_float')
+            ->build();
     }
 
     public function nativeType(): NativeFloatType

--- a/src/Type/Types/NativeIntegerType.php
+++ b/src/Type/Types/NativeIntegerType.php
@@ -62,7 +62,9 @@ final class NativeIntegerType implements IntegerType
 
     public function errorMessage(): ErrorMessage
     {
-        return MessageBuilder::newError('Value {source_value} is not a valid integer.')->build();
+        return MessageBuilder::newError('Value {source_value} is not a valid integer.')
+            ->withCode('invalid_integer')
+            ->build();
     }
 
     public function nativeType(): NativeIntegerType

--- a/src/Type/Types/NativeStringType.php
+++ b/src/Type/Types/NativeStringType.php
@@ -58,7 +58,9 @@ final class NativeStringType implements StringType
 
     public function errorMessage(): ErrorMessage
     {
-        return MessageBuilder::newError('Value {source_value} is not a valid string.')->build();
+        return MessageBuilder::newError('Value {source_value} is not a valid string.')
+            ->withCode('invalid_string')
+            ->build();
     }
 
     public function nativeType(): NativeStringType

--- a/src/Type/Types/NegativeIntegerType.php
+++ b/src/Type/Types/NegativeIntegerType.php
@@ -59,7 +59,9 @@ final class NegativeIntegerType implements IntegerType
 
     public function errorMessage(): ErrorMessage
     {
-        return MessageBuilder::newError('Value {source_value} is not a valid negative integer.')->build();
+        return MessageBuilder::newError('Value {source_value} is not a valid negative integer.')
+            ->withCode('invalid_negative_integer')
+            ->build();
     }
 
     public function nativeType(): NativeIntegerType

--- a/src/Type/Types/NonEmptyStringType.php
+++ b/src/Type/Types/NonEmptyStringType.php
@@ -58,7 +58,9 @@ final class NonEmptyStringType implements StringType
 
     public function errorMessage(): ErrorMessage
     {
-        return MessageBuilder::newError('Value {source_value} is not a valid non-empty string.')->build();
+        return MessageBuilder::newError('Value {source_value} is not a valid non-empty string.')
+            ->withCode('invalid_non_empty_string')
+            ->build();
     }
 
     public function nativeType(): NativeStringType

--- a/src/Type/Types/NonNegativeIntegerType.php
+++ b/src/Type/Types/NonNegativeIntegerType.php
@@ -61,7 +61,9 @@ final class NonNegativeIntegerType implements IntegerType
 
     public function errorMessage(): ErrorMessage
     {
-        return MessageBuilder::newError('Value {source_value} is not a valid non-negative integer.')->build();
+        return MessageBuilder::newError('Value {source_value} is not a valid non-negative integer.')
+            ->withCode('invalid_non_negative_integer')
+            ->build();
     }
 
     public function nativeType(): NativeIntegerType

--- a/src/Type/Types/NonPositiveIntegerType.php
+++ b/src/Type/Types/NonPositiveIntegerType.php
@@ -54,7 +54,9 @@ final class NonPositiveIntegerType implements IntegerType
 
     public function errorMessage(): ErrorMessage
     {
-        return MessageBuilder::newError('Value {source_value} is not a valid non-positive integer.')->build();
+        return MessageBuilder::newError('Value {source_value} is not a valid non-positive integer.')
+            ->withCode('invalid_non_positive_integer')
+            ->build();
     }
 
     public function nativeType(): NativeIntegerType

--- a/src/Type/Types/NumericStringType.php
+++ b/src/Type/Types/NumericStringType.php
@@ -62,7 +62,9 @@ final class NumericStringType implements StringType
 
     public function errorMessage(): ErrorMessage
     {
-        return MessageBuilder::newError('Value {source_value} is not a valid numeric string.')->build();
+        return MessageBuilder::newError('Value {source_value} is not a valid numeric string.')
+            ->withCode('invalid_numeric_string')
+            ->build();
     }
 
     public function nativeType(): NativeStringType

--- a/src/Type/Types/PositiveIntegerType.php
+++ b/src/Type/Types/PositiveIntegerType.php
@@ -65,7 +65,9 @@ final class PositiveIntegerType implements IntegerType
 
     public function errorMessage(): ErrorMessage
     {
-        return MessageBuilder::newError('Value {source_value} is not a valid positive integer.')->build();
+        return MessageBuilder::newError('Value {source_value} is not a valid positive integer.')
+            ->withCode('invalid_positive_integer')
+            ->build();
     }
 
     public function nativeType(): NativeIntegerType

--- a/src/Type/Types/StringValueType.php
+++ b/src/Type/Types/StringValueType.php
@@ -87,6 +87,7 @@ final class StringValueType implements StringType, FixedType
     public function errorMessage(): ErrorMessage
     {
         return MessageBuilder::newError('Value {source_value} does not match string value {expected_value}.')
+            ->withCode('invalid_string_value')
             ->withParameter('expected_value', ValueDumper::dump($this->value))
             ->build();
     }

--- a/tests/Integration/Mapping/Closure/ArgumentsMappingTest.php
+++ b/tests/Integration/Mapping/Closure/ArgumentsMappingTest.php
@@ -81,8 +81,8 @@ final class ArgumentsMappingTest extends IntegrationTestCase
             self::assertMatchesRegularExpression('/Could not map arguments of `[^`]+` with value array{foo: false, bar: false}. A total of 2 errors were encountered./', $exception->getMessage());
 
             self::assertMappingErrors($exception, [
-                'foo' => '[unknown] Value false is not a valid string.',
-                'bar' => '[unknown] Value false is not a valid integer.',
+                'foo' => '[invalid_string] Value false is not a valid string.',
+                'bar' => '[invalid_integer] Value false is not a valid integer.',
             ]);
         }
     }
@@ -100,7 +100,7 @@ final class ArgumentsMappingTest extends IntegrationTestCase
             self::assertMatchesRegularExpression('/Could not map arguments of `[^`]+`. An error occurred at path foo: Value false is not a valid string./', $exception->getMessage());
 
             self::assertMappingErrors($exception, [
-                'foo' => '[unknown] Value false is not a valid string.',
+                'foo' => '[invalid_string] Value false is not a valid string.',
             ]);
         }
     }

--- a/tests/Integration/Mapping/ConstructorRegistrationMappingTest.php
+++ b/tests/Integration/Mapping/ConstructorRegistrationMappingTest.php
@@ -674,7 +674,7 @@ final class ConstructorRegistrationMappingTest extends IntegrationTestCase
                 ->map(stdClass::class, []);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1642183169] Value array (empty) does not match any of `string`, `array{bar: int, baz?: float}`.",
+                '*root*' => "[cannot_find_object_builder] Value array (empty) does not match any of `string`, `array{bar: int, baz?: float}`.",
             ]);
         }
     }

--- a/tests/Integration/Mapping/EnumConstructorRegistrationMappingTest.php
+++ b/tests/Integration/Mapping/EnumConstructorRegistrationMappingTest.php
@@ -123,7 +123,7 @@ class EnumConstructorRegistrationMappingTest extends IntegrationTestCase
                 ->map(BackedStringEnum::class, 'fiz');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1607027306] Value 'fiz' does not match any of 'foo', 'bar', 'baz'.",
+                '*root*' => "[cannot_resolve_type_from_union] Value 'fiz' does not match any of 'foo', 'bar', 'baz'.",
             ]);
         }
     }
@@ -137,7 +137,7 @@ class EnumConstructorRegistrationMappingTest extends IntegrationTestCase
                 ->map(BackedStringEnum::class, 'fiz');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1607027306] Value 'fiz' does not match any of 'foo', 'bar', 'baz'.",
+                '*root*' => "[cannot_resolve_type_from_union] Value 'fiz' does not match any of 'foo', 'bar', 'baz'.",
             ]);
         }
     }

--- a/tests/Integration/Mapping/EnumValueOfMappingTest.php
+++ b/tests/Integration/Mapping/EnumValueOfMappingTest.php
@@ -69,7 +69,7 @@ final class EnumValueOfMappingTest extends IntegrationTestCase
                 ->map('array<value-of<' . SomeStringEnumForValueOf::class . '>, string>', ['oof' => 'foo']);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                'oof' => "[1630946163] Key 'oof' does not match type `'FOO'|'FOZ'|'BAZ'`.",
+                'oof' => "[invalid_array_key] Key 'oof' does not match type `'FOO'|'FOZ'|'BAZ'`.",
             ]);
         }
     }

--- a/tests/Integration/Mapping/InterfaceInferringMappingTest.php
+++ b/tests/Integration/Mapping/InterfaceInferringMappingTest.php
@@ -371,7 +371,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
                 ->map(SomeInterface::class, 42);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1632903281] Value 42 does not match type `array{type: string, key: int}`.",
+                '*root*' => "[invalid_source] Value 42 does not match type `array{type: string, key: int}`.",
             ]);
         }
     }
@@ -389,7 +389,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
                 ->map(SomeInterface::class, 'foo');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                'key' => "[unknown] Value 'foo' is not a valid integer.",
+                'key' => "[invalid_integer] Value 'foo' is not a valid integer.",
             ]);
         }
     }
@@ -410,7 +410,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
                 ]);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1655117782] Unexpected key(s) `superfluousValue`, expected `valueA`.",
+                '*root*' => "[unexpected_keys] Unexpected key(s) `superfluousValue`, expected `valueA`.",
             ]);
         }
     }

--- a/tests/Integration/Mapping/Object/ArrayValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ArrayValuesMappingTest.php
@@ -74,7 +74,7 @@ final class ArrayValuesMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('non-empty-array<string>', []);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => '[1736015505] Array cannot be empty and must contain values of type `string`.',
+                '*root*' => '[value_is_empty_array] Array cannot be empty and must contain values of type `string`.',
             ]);
         }
     }
@@ -85,7 +85,7 @@ final class ArrayValuesMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('array<int>', ['foo']);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '0' => "[unknown] Value 'foo' is not a valid integer.",
+                '0' => "[invalid_integer] Value 'foo' is not a valid integer.",
             ]);
         }
     }

--- a/tests/Integration/Mapping/Object/ConstantValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ConstantValuesMappingTest.php
@@ -71,7 +71,7 @@ final class ConstantValuesMappingTest extends IntegrationTestCase
                 ->map(ObjectWithConstants::class . '::CONST_WITH_STRING_*', 'some private string value');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1607027306] Value 'some private string value' does not match any of 'some string value', 'another string value'.",
+                '*root*' => "[cannot_resolve_type_from_union] Value 'some private string value' does not match any of 'some string value', 'another string value'.",
             ]);
         }
     }
@@ -84,7 +84,7 @@ final class ConstantValuesMappingTest extends IntegrationTestCase
                 ->map(ObjectWithConstants::class . '::CONST_WITH_STRING_*', 'some prefixed string value');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1607027306] Value 'some prefixed string value' does not match any of 'some string value', 'another string value'.",
+                '*root*' => "[cannot_resolve_type_from_union] Value 'some prefixed string value' does not match any of 'some string value', 'another string value'.",
             ]);
         }
     }

--- a/tests/Integration/Mapping/Object/DateTimeMappingTest.php
+++ b/tests/Integration/Mapping/Object/DateTimeMappingTest.php
@@ -18,7 +18,7 @@ final class DateTimeMappingTest extends IntegrationTestCase
                 ->map(DateTimeInterface::class, ['datetime' => '2022/08/05', 'timezone' => 'Europe/Paris']);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1607027306] Value array{datetime: '2022/08/05', timezone: 'Europe/Paris'} does not match any of `non-empty-string`, `int`, `float`.",
+                '*root*' => "[cannot_resolve_type_from_union] Value array{datetime: '2022/08/05', timezone: 'Europe/Paris'} does not match any of `non-empty-string`, `int`, `float`.",
             ]);
         }
     }
@@ -140,7 +140,7 @@ final class DateTimeMappingTest extends IntegrationTestCase
                 ->map(DateTimeInterface::class, 'invalid datetime');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1630686564] Value 'invalid datetime' does not match any of the following formats: `Y-m-d\TH:i:sP`, `Y-m-d\TH:i:s.uP`, `U`, `U.u`.",
+                '*root*' => "[cannot_parse_datetime_format] Value 'invalid datetime' does not match any of the following formats: `Y-m-d\TH:i:sP`, `Y-m-d\TH:i:s.uP`, `U`, `U.u`.",
             ]);
         }
     }
@@ -154,7 +154,7 @@ final class DateTimeMappingTest extends IntegrationTestCase
                 ->map(DateTimeInterface::class, 'invalid datetime');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1630686564] Value 'invalid datetime' does not match any of the following formats: `Y/m/d`.",
+                '*root*' => "[cannot_parse_datetime_format] Value 'invalid datetime' does not match any of the following formats: `Y/m/d`.",
             ]);
         }
     }
@@ -169,7 +169,7 @@ final class DateTimeMappingTest extends IntegrationTestCase
                 ->map(DateTimeInterface::class, '1971-11-08');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1630686564] Value '1971-11-08' does not match any of the following formats: `d/m/Y`.",
+                '*root*' => "[cannot_parse_datetime_format] Value '1971-11-08' does not match any of the following formats: `d/m/Y`.",
             ]);
         }
     }

--- a/tests/Integration/Mapping/Object/DateTimeZoneMappingTest.php
+++ b/tests/Integration/Mapping/Object/DateTimeZoneMappingTest.php
@@ -69,7 +69,7 @@ final class DateTimeZoneMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map(DateTimeZone::class, 'Jupiter/Europa');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[unknown] Value 'Jupiter/Europa' is not a valid timezone.",
+                '*root*' => "[invalid_timezone] Value 'Jupiter/Europa' is not a valid timezone.",
             ]);
         }
     }

--- a/tests/Integration/Mapping/Object/EnumValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/EnumValuesMappingTest.php
@@ -50,7 +50,7 @@ final class EnumValuesMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map(BackedStringEnum::class, new StringableObject('fiz'));
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => '[1607027306] Value object(' . StringableObject::class . ") does not match any of 'foo', 'bar', 'baz'.",
+                '*root*' => '[cannot_resolve_type_from_union] Value object(' . StringableObject::class . ") does not match any of 'foo', 'bar', 'baz'.",
             ]);
         }
     }
@@ -61,7 +61,7 @@ final class EnumValuesMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map(BackedIntegerEnum::class, '512');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1607027306] Value '512' does not match any of 42, 404, 1337.",
+                '*root*' => "[cannot_resolve_type_from_union] Value '512' does not match any of 42, 404, 1337.",
             ]);
         }
     }
@@ -72,7 +72,7 @@ final class EnumValuesMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map(PureEnum::class . '::FOO', 'fiz');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[unknown] Value 'fiz' does not match string value 'FOO'.",
+                '*root*' => "[invalid_string_value] Value 'fiz' does not match string value 'FOO'.",
             ]);
         }
     }
@@ -83,7 +83,7 @@ final class EnumValuesMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map(BackedIntegerEnum::class . '::FOO', '512');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[unknown] Value '512' does not match integer value 42.",
+                '*root*' => "[invalid_integer_value] Value '512' does not match integer value 42.",
             ]);
         }
     }
@@ -94,7 +94,7 @@ final class EnumValuesMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('array{foo: ' . PureEnum::class . '::FOO}', []);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                'foo' => '[1655449641] Cannot be empty and must be filled with a value matching type `FOO`.',
+                'foo' => '[missing_value] Cannot be empty and must be filled with a value matching type `FOO`.',
             ]);
         }
     }
@@ -105,7 +105,7 @@ final class EnumValuesMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('array{foo: ' . BackedIntegerEnum::class . '::FOO}', []);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                'foo' => '[1655449641] Cannot be empty and must be filled with a value matching type `42`.',
+                'foo' => '[missing_value] Cannot be empty and must be filled with a value matching type `42`.',
             ]);
         }
     }

--- a/tests/Integration/Mapping/Object/ListValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ListValuesMappingTest.php
@@ -56,7 +56,7 @@ final class ListValuesMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('non-empty-list<string>', []);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1736015714] List cannot be empty and must contain values of type `string`.",
+                '*root*' => "[value_is_empty_list] List cannot be empty and must contain values of type `string`.",
             ]);
         }
     }
@@ -70,7 +70,7 @@ final class ListValuesMappingTest extends IntegrationTestCase
             ]);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '2' => '[1654273010] Invalid sequential key 2, expected 1.',
+                '2' => '[invalid_list_key] Invalid sequential key 2, expected 1.',
             ]);
         }
     }
@@ -81,7 +81,7 @@ final class ListValuesMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('list<int>', ['foo']);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '0' => "[unknown] Value 'foo' is not a valid integer.",
+                '0' => "[invalid_integer] Value 'foo' is not a valid integer.",
             ]);
         }
     }

--- a/tests/Integration/Mapping/Object/NullableMappingTest.php
+++ b/tests/Integration/Mapping/Object/NullableMappingTest.php
@@ -40,7 +40,7 @@ final class NullableMappingTest extends IntegrationTestCase
             self::fail('No mapping error when one was expected');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1710263908] Value 'foo' is not null.",
+                '*root*' => "[value_is_not_null] Value 'foo' is not null.",
             ]);
         }
     }

--- a/tests/Integration/Mapping/Object/ObjectValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ObjectValuesMappingTest.php
@@ -48,7 +48,7 @@ final class ObjectValuesMappingTest extends IntegrationTestCase
                 $this->mapperBuilder()->mapper()->map($class, $source);
             } catch (MappingError $exception) {
                 self::assertMappingErrors($exception, [
-                    '*root*' => "[1632903281] Value 'foo' does not match type `array{object: ?, string: string}`.",
+                    '*root*' => "[invalid_source] Value 'foo' does not match type `array{object: ?, string: string}`.",
                 ]);
             }
         }
@@ -66,8 +66,8 @@ final class ObjectValuesMappingTest extends IntegrationTestCase
             ]);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1655117782] Unexpected key(s) `unexpectedValueA`, `unexpectedValueB`, `42`, expected `stringA`, `stringB`.",
-                'stringA' => '[unknown] Value 42 is not a valid string.'
+                '*root*' => "[unexpected_keys] Unexpected key(s) `unexpectedValueA`, `unexpectedValueB`, `42`, expected `stringA`, `stringB`.",
+                'stringA' => '[invalid_string] Value 42 is not a valid string.'
             ]);
         }
     }
@@ -83,7 +83,7 @@ final class ObjectValuesMappingTest extends IntegrationTestCase
             ]));
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1655117782] Unexpected key(s) `unexpectedValue`, `42`, expected `stringA`, `stringB`.",
+                '*root*' => "[unexpected_keys] Unexpected key(s) `unexpectedValue`, `42`, expected `stringA`, `stringB`.",
             ]);
         }
     }
@@ -94,7 +94,7 @@ final class ObjectValuesMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map(stdClass::class, 'foo');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1632903281] Value 'foo' does not match type array.",
+                '*root*' => "[invalid_source] Value 'foo' does not match type array.",
             ]);
         }
     }
@@ -113,7 +113,7 @@ final class ObjectValuesMappingTest extends IntegrationTestCase
             );
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                'first.second' => "[unknown] Value 'foo' is not a valid float.",
+                'first.second' => "[invalid_float] Value 'foo' is not a valid float.",
             ]);
         }
     }

--- a/tests/Integration/Mapping/Object/ScalarValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ScalarValuesMappingTest.php
@@ -94,7 +94,7 @@ final class ScalarValuesMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map(SimpleObject::class, new stdClass());
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => '[unknown] Value object(stdClass) is not a valid string.',
+                '*root*' => '[invalid_string] Value object(stdClass) is not a valid string.',
             ]);
         }
     }
@@ -105,7 +105,7 @@ final class ScalarValuesMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('array-key', new stdClass());
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => '[unknown] Value object(stdClass) is not a valid array key.',
+                '*root*' => '[invalid_array_key] Value object(stdClass) is not a valid array key.',
             ]);
         }
     }

--- a/tests/Integration/Mapping/Object/ShapedArrayValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ShapedArrayValuesMappingTest.php
@@ -113,7 +113,7 @@ final class ShapedArrayValuesMappingTest extends IntegrationTestCase
             ]);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                'foo' => '[unknown] Value object(stdClass) is not a valid string.',
+                'foo' => '[invalid_string] Value object(stdClass) is not a valid string.',
             ]);
         }
     }
@@ -130,7 +130,7 @@ final class ShapedArrayValuesMappingTest extends IntegrationTestCase
             );
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                'bar' => "[1630946163] Key 'bar' does not match type `int`.",
+                'bar' => "[invalid_array_key] Key 'bar' does not match type `int`.",
             ]);
         }
     }
@@ -147,7 +147,7 @@ final class ShapedArrayValuesMappingTest extends IntegrationTestCase
             );
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                'bar' => "[unknown] Value 'bar' is not a valid integer.",
+                'bar' => "[invalid_integer] Value 'bar' is not a valid integer.",
             ]);
         }
     }

--- a/tests/Integration/Mapping/Object/UnionValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/UnionValuesMappingTest.php
@@ -90,7 +90,7 @@ final class UnionValuesMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('string|int', 42.404);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => '[1607027306] Value 42.404 does not match any of `string`, `int`.',
+                '*root*' => '[cannot_resolve_type_from_union] Value 42.404 does not match any of `string`, `int`.',
             ]);
         }
     }

--- a/tests/Integration/Mapping/Other/ArrayMappingTest.php
+++ b/tests/Integration/Mapping/Other/ArrayMappingTest.php
@@ -120,7 +120,7 @@ final class ArrayMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('array<int, string>', ['foo' => 'foo']);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                'foo' => "[1630946163] Key 'foo' does not match type `int`.",
+                'foo' => "[invalid_array_key] Key 'foo' does not match type `int`.",
             ]);
         }
     }
@@ -131,7 +131,7 @@ final class ArrayMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('array<positive-int, string>', [-42 => 'foo']);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '-42' => "[1630946163] Key -42 does not match type `positive-int`.",
+                '-42' => "[invalid_array_key] Key -42 does not match type `positive-int`.",
             ]);
         }
     }
@@ -142,7 +142,7 @@ final class ArrayMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('array<negative-int, string>', [42 => 'foo']);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '42' => '[1630946163] Key 42 does not match type `negative-int`.',
+                '42' => '[invalid_array_key] Key 42 does not match type `negative-int`.',
             ]);
         }
     }
@@ -153,7 +153,7 @@ final class ArrayMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('array<int<-42, 1337>, string>', [-404 => 'foo']);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '-404' => '[1630946163] Key -404 does not match type `int<-42, 1337>`.',
+                '-404' => '[invalid_array_key] Key -404 does not match type `int<-42, 1337>`.',
             ]);
         }
     }
@@ -164,7 +164,7 @@ final class ArrayMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map("array<'foo'|'bar', string>", ['baz' => 'baz']);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                'baz' => "[1630946163] Key 'baz' does not match type `'foo'|'bar'`.",
+                'baz' => "[invalid_array_key] Key 'baz' does not match type `'foo'|'bar'`.",
             ]);
         }
     }
@@ -175,7 +175,7 @@ final class ArrayMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('array<42|1337, string>', [404 => 'baz']);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '404' => '[1630946163] Key 404 does not match type `42|1337`.',
+                '404' => '[invalid_array_key] Key 404 does not match type `42|1337`.',
             ]);
         }
     }
@@ -186,7 +186,7 @@ final class ArrayMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('array<non-empty-string, string>', ['' => 'foo']);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '' => "[1630946163] Key '' does not match type `non-empty-string`.",
+                '' => "[invalid_array_key] Key '' does not match type `non-empty-string`.",
             ]);
         }
     }
@@ -197,7 +197,7 @@ final class ArrayMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('array<class-string, string>', ['foo bar' => 'foo']);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                'foo bar' => "[1630946163] Key 'foo bar' does not match type `class-string`.",
+                'foo bar' => "[invalid_array_key] Key 'foo bar' does not match type `class-string`.",
             ]);
         }
     }

--- a/tests/Integration/Mapping/Other/PermissiveTypesMappingTest.php
+++ b/tests/Integration/Mapping/Other/PermissiveTypesMappingTest.php
@@ -54,7 +54,7 @@ final class PermissiveTypesMappingTest extends IntegrationTestCase
             $this->mapper->map('object', 'foo');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1630678334] Value 'foo' does not match type `object`.",
+                '*root*' => "[invalid_value] Value 'foo' does not match type `object`.",
             ]);
         }
     }

--- a/tests/Integration/Mapping/Other/ShapedArrayMappingTest.php
+++ b/tests/Integration/Mapping/Other/ShapedArrayMappingTest.php
@@ -53,7 +53,7 @@ final class ShapedArrayMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('array{foo: string, bar: int}', ['foo' => 'foo']);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                'bar' => "[1655449641] Cannot be empty and must be filled with a value matching type `int`.",
+                'bar' => "[missing_value] Cannot be empty and must be filled with a value matching type `int`.",
             ]);
         }
     }
@@ -70,8 +70,8 @@ final class ShapedArrayMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('array{foo: string, bar: int}', $source);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => '[1655117782] Unexpected key(s) `fiz`, expected `foo`, `bar`.',
-                'foo' => '[unknown] Value 404 is not a valid string.',
+                '*root*' => '[unexpected_keys] Unexpected key(s) `fiz`, expected `foo`, `bar`.',
+                'foo' => '[invalid_string] Value 404 is not a valid string.',
             ]);
         }
     }

--- a/tests/Integration/Mapping/Other/StrictMappingTest.php
+++ b/tests/Integration/Mapping/Other/StrictMappingTest.php
@@ -29,7 +29,7 @@ final class StrictMappingTest extends IntegrationTestCase
             ]);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                'bar' => '[1655449641] Cannot be empty and must be filled with a value matching type `string`.',
+                'bar' => '[missing_value] Cannot be empty and must be filled with a value matching type `string`.',
             ]);
         }
     }
@@ -85,7 +85,7 @@ final class StrictMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('int', null);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => '[unknown] Value null is not a valid integer.',
+                '*root*' => '[invalid_integer] Value null is not a valid integer.',
             ]);
         }
     }
@@ -96,7 +96,7 @@ final class StrictMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('float', 'foo');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[unknown] Value 'foo' is not a valid float.",
+                '*root*' => "[invalid_float] Value 'foo' is not a valid float.",
             ]);
         }
     }
@@ -107,7 +107,7 @@ final class StrictMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('42.404', 1337);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[unknown] Value 1337 does not match float value 42.404.",
+                '*root*' => "[invalid_float_value] Value 1337 does not match float value 42.404.",
             ]);
         }
     }
@@ -118,7 +118,7 @@ final class StrictMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('int', 'foo');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[unknown] Value 'foo' is not a valid integer.",
+                '*root*' => "[invalid_integer] Value 'foo' is not a valid integer.",
             ]);
         }
     }
@@ -129,7 +129,7 @@ final class StrictMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('42', 1337);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => '[unknown] Value 1337 does not match integer value 42.',
+                '*root*' => '[invalid_integer_value] Value 1337 does not match integer value 42.',
             ]);
         }
     }
@@ -140,7 +140,7 @@ final class StrictMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('int<42, 1337>', 'foo');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[unknown] Value 'foo' is not a valid integer between 42 and 1337.",
+                '*root*' => "[invalid_integer_range] Value 'foo' is not a valid integer between 42 and 1337.",
             ]);
         }
     }
@@ -151,7 +151,7 @@ final class StrictMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map(PureEnum::class, 'foo');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1607027306] Value 'foo' does not match any of 'FOO', 'BAR', 'BAZ'.",
+                '*root*' => "[cannot_resolve_type_from_union] Value 'foo' does not match any of 'FOO', 'BAR', 'BAZ'.",
             ]);
         }
     }
@@ -162,7 +162,7 @@ final class StrictMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map(BackedStringEnum::class, new stdClass());
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1607027306] Value object(stdClass) does not match any of 'foo', 'bar', 'baz'.",
+                '*root*' => "[cannot_resolve_type_from_union] Value object(stdClass) does not match any of 'foo', 'bar', 'baz'.",
             ]);
         }
     }
@@ -173,7 +173,7 @@ final class StrictMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map(BackedIntegerEnum::class, false);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1607027306] Value false does not match any of 42, 404, 1337.",
+                '*root*' => "[cannot_resolve_type_from_union] Value false does not match any of 42, 404, 1337.",
             ]);
         }
     }
@@ -184,7 +184,7 @@ final class StrictMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('bool|int|float', 'foo');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1607027306] Value 'foo' does not match any of `bool`, `int`, `float`.",
+                '*root*' => "[cannot_resolve_type_from_union] Value 'foo' does not match any of `bool`, `int`, `float`.",
             ]);
         }
     }
@@ -195,7 +195,7 @@ final class StrictMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('bool|int|float', '🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1607027306] Value '🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄…' does not match any of `bool`, `int`, `float`.",
+                '*root*' => "[cannot_resolve_type_from_union] Value '🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄🦄…' does not match any of `bool`, `int`, `float`.",
             ]);
         }
     }
@@ -206,7 +206,7 @@ final class StrictMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('bool|int|float', null);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1607027306] Cannot be empty and must be filled with a value matching any of `bool`, `int`, `float`.",
+                '*root*' => "[cannot_resolve_type_from_union] Cannot be empty and must be filled with a value matching any of `bool`, `int`, `float`.",
             ]);
         }
     }
@@ -217,7 +217,7 @@ final class StrictMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('array<float>', 'foo');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1618739163] Value 'foo' does not match type `array<float>`.",
+                '*root*' => "[value_is_not_iterable] Value 'foo' does not match type `array<float>`.",
             ]);
         }
     }
@@ -228,7 +228,7 @@ final class StrictMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('list<float>', 'foo');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1618739163] Value 'foo' does not match type `list<float>`.",
+                '*root*' => "[value_is_not_iterable] Value 'foo' does not match type `list<float>`.",
             ]);
         }
     }
@@ -239,7 +239,7 @@ final class StrictMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('array{foo: string}', 'foo');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1618739163] Value 'foo' does not match type `array{foo: string}`.",
+                '*root*' => "[value_is_not_iterable] Value 'foo' does not match type `array{foo: string}`.",
             ]);
         }
     }
@@ -250,7 +250,7 @@ final class StrictMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map('array{foo: stdClass}', 'foo');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1618739163] Invalid value 'foo'.",
+                '*root*' => "[value_is_not_iterable] Invalid value 'foo'.",
             ]);
         }
     }

--- a/tests/Integration/Mapping/SingleNodeMappingTest.php
+++ b/tests/Integration/Mapping/SingleNodeMappingTest.php
@@ -63,7 +63,7 @@ final class SingleNodeMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map(SimpleObject::class, ['value' => 42]);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                'value' => '[unknown] Value 42 is not a valid string.',
+                'value' => '[invalid_string] Value 42 is not a valid string.',
             ]);
         }
     }
@@ -74,7 +74,7 @@ final class SingleNodeMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map(SimpleObject::class, 42);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => '[unknown] Value 42 is not a valid string.',
+                '*root*' => '[invalid_string] Value 42 is not a valid string.',
             ]);
         }
     }

--- a/tests/Integration/Mapping/UnionMappingTest.php
+++ b/tests/Integration/Mapping/UnionMappingTest.php
@@ -307,7 +307,7 @@ final class UnionMappingTest extends IntegrationTestCase
             self::fail('No mapping error when one was expected');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1710262975] Invalid value 'foo', it matches two or more types from union: cannot take a decision.",
+                '*root*' => "[too_many_resolved_types_from_union] Invalid value 'foo', it matches two or more types from union: cannot take a decision.",
             ]);
         }
     }
@@ -326,7 +326,7 @@ final class UnionMappingTest extends IntegrationTestCase
             self::fail('No mapping error when one was expected');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1710262975] Invalid value array{string: 'foo'}, it matches two or more types from union: cannot take a decision.",
+                '*root*' => "[too_many_resolved_types_from_union] Invalid value array{string: 'foo'}, it matches two or more types from union: cannot take a decision.",
             ]);
         }
     }
@@ -344,7 +344,7 @@ final class UnionMappingTest extends IntegrationTestCase
             self::fail('No mapping error when one was expected');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1710262975] Invalid value array{0: 'foo', 1: 'bar'}, it matches two or more types from `array<string>`, `array<'foo'|'bar'>`: cannot take a decision.",
+                '*root*' => "[too_many_resolved_types_from_union] Invalid value array{0: 'foo', 1: 'bar'}, it matches two or more types from `array<string>`, `array<'foo'|'bar'>`: cannot take a decision.",
             ]);
         }
     }
@@ -362,7 +362,7 @@ final class UnionMappingTest extends IntegrationTestCase
             self::fail('No mapping error when one was expected');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[1710262975] Invalid value array{string: 'foo'}, it matches two or more types from union: cannot take a decision.",
+                '*root*' => "[too_many_resolved_types_from_union] Invalid value array{string: 'foo'}, it matches two or more types from union: cannot take a decision.",
             ]);
         }
     }

--- a/tests/Integration/Mapping/VariadicParameterMappingTest.php
+++ b/tests/Integration/Mapping/VariadicParameterMappingTest.php
@@ -43,8 +43,8 @@ final class VariadicParameterMappingTest extends IntegrationTestCase
                 ->map(SomeClassWithVariadicParametersInDocBlock::class, ['', '']);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '0' => "[unknown] Value '' is not a valid non-empty string.",
-                '1' => "[unknown] Value '' is not a valid non-empty string.",
+                '0' => "[invalid_non_empty_string] Value '' is not a valid non-empty string.",
+                '1' => "[invalid_non_empty_string] Value '' is not a valid non-empty string.",
             ]);
         }
     }


### PR DESCRIPTION
Codes have been changed for all messages that can be thrown during 
mapping. They now are way more expressive. Here is the exhaustive list
of changes and their replacements:

- `1642183169` → `cannot_find_object_builder`
- `1632903281` → `invalid_source`
- `1607027306` → `cannot_resolve_type_from_union`
- `1654273010` → `invalid_list_key`
- `1630678334` → `invalid_value`
- `1630946163` → `invalid_array_key`
- `1655449641` → `missing_value`
- `1736015505` → `value_is_empty_array`
- `1736015714` → `value_is_empty_list`
- `1710263908` → `value_is_not_null`
- `1618739163` → `value_is_not_iterable`
- `1710262975` → `too_many_resolved_types_from_union`
- `1655117782` → `unexpected_keys`
- `1630686564` → `cannot_parse_datetime_format`

Note that a lot of error messages related to invalid scalar values
mapping now have a specific code, where it used to be `unknown`.