### PR TITLE
qa: Use runBare method now that runTest is made private

### DIFF
--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -38,14 +38,19 @@ abstract class IntegrationTestCase extends TestCase
             return;
         }
 
+        // If we are already running with a cache, avoid an endless loop by bailing out now.
+        if (isset($this->cacheToInject)) {
+            return;
+        }
+
         $cacheDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . bin2hex(random_bytes(16));
         $this->cacheToInject = new FileSystemCache($cacheDir);
 
         // First rerun of the test: the cache entries will be injected.
-        parent::runTest();
+        parent::runBare();
 
         // Second rerun of the test: the cache entries will be used and tested.
-        parent::runTest();
+        parent::runBare();
 
         $this->cacheToInject->clear();
     }


### PR DESCRIPTION
PHPUnit commit
https://github.com/sebastianbergmann/phpunit/commit/8f0f8205e3a38675392da55afc573c6bb6a43f4e makes the `runTest` method used by the integration tests private. `runBare` however is still public, so we can use that.

Because `runBare` will also call pre-test and post-test hooks, we have to be careful not to end in an infinite loop.

Thought: Tests should potentially be rewritten to be wrapped in a closure instead, which runs the test with and without cache. This however would take a lot more time to implement than this quick fix. This would break the dependency on PHPUnit internal code. We could then add a post-test hook to verify a cache was used.