### PR TITLE
feat!: introduce `NormalizerBuilder` as the main entry for normalizers

### DIFF
--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -25,6 +25,10 @@ providing precise and human-readable error messages.
 The mapper can handle native PHP types as well as other advanced types supported
 by [PHPStan] and [Psalm] like shaped arrays, generics, integer ranges and more.
 
+The library also provides a normalization mechanism that can help transform any
+input into a data format (JSON, CSV, …), while preserving the original
+structure.
+
 ## Why?
 
 There are many benefits of using objects instead of plain arrays in a codebase:

--- a/docs/pages/other/app-and-framework-integration.md
+++ b/docs/pages/other/app-and-framework-integration.md
@@ -24,23 +24,28 @@ The documentation of this bundle can be found
 If the application does not have a dedicated framework integration, it is still
 possible to integrate this library manually.
 
-### Mapper registration
+### Mapper and normalizer registration
 
 The most important task of the integration is to correctly register the
-mapper(s) used in the application. Mapper instance(s) should be shared between
-services whenever possible; this is important because heavy operations are
-cached internally to improve performance during runtime.
+mapper(s) and normalizer(s) used in the application. Mapper instance(s) should
+be shared between services whenever possible; this is important because heavy
+operations are cached internally to improve performance during runtime.
 
 If the framework uses a service container, it should be configured in a way
-where the mapper(s) are registered as shared services. In other cases, direct
-instantiation of the mapper(s) should be avoided.
+where the mapper(s) and normalizer(s) are registered as shared services. In
+other cases, direct instantiation of these services should be avoided.
 
 ```php
 $mapperBuilder = new \CuyZ\Valinor\MapperBuilder();
+$normalizerBuilder = new \CuyZ\Valinor\NormalizerBuilder();
 
-// …customization of the mapper builder…
+// …customization of the mapper builder and normalization builder…
 
-$container->addSharedService('mapper', $mapperBuilder->mapper());
+$mapper = $mapperBuilder->mapper();
+$jsonNormalizer = $normalizerBuilder->normalizer(\CuyZ\Valinor\Normalizer\Format::json());
+
+$container->addSharedService('mapper', $mapper);
+$container->addSharedService('normalizer_json', $jsonNormalizer);
 ```
 
 ### Registering a cache
@@ -63,6 +68,7 @@ if ($isApplicationInDevelopmentEnvironment) {
 }
 
 $mapperBuilder = $mapperBuilder->withCache($cache);
+$normalizerBuilder = $normalizerBuilder->withCache($cache);
 ```
 
 ### Warming up the cache
@@ -75,9 +81,9 @@ should be given to the `warmup` method, as stated in the [cache warmup chapter].
 
 Concerning other configurations, such as [enabling flexible casting],
 [configuring supported date formats] or [registering custom constructors],
-an integration should be provided to configure the mapper builder in a
-convenient way — how it is done will mostly depend on the framework features and
-its main philosophy.
+an integration should be provided to configure the mapper/normalizer builder in
+a convenient way — how it is done will mostly depend on the framework features
+and its main philosophy.
 
 [performance chapter]: performance-and-caching.md
 [cache warmup chapter]: performance-and-caching.md#warming-up-cache

--- a/docs/pages/other/performance-and-caching.md
+++ b/docs/pages/other/performance-and-caching.md
@@ -14,6 +14,9 @@ application and invalidate cache entries when a PHP file is modified by a
 developer — preventing the library not behaving as expected when the signature
 of a property or a method changes.
 
+The same cache instance can be used by both the mapper builder and the
+normalizer builder.
+
 ```php
 $cache = new \CuyZ\Valinor\Cache\FileSystemCache('path/to/cache-directory');
 
@@ -25,6 +28,11 @@ if ($isApplicationInDevelopmentEnvironment) {
     ->withCache($cache)
     ->mapper()
     ->map(SomeClass::class, [/* … */]);
+    
+(new \CuyZ\Valinor\NormalizerBuilder())
+    ->withCache($cache)
+    ->normalizer(\CuyZ\Valinor\Normalizer\Format::json())
+    ->normalize($someData);
 ```
 
 ## Warming up cache

--- a/docs/pages/project/upgrading.md
+++ b/docs/pages/project/upgrading.md
@@ -62,6 +62,27 @@ replacements:
 Note that a lot of error messages related to invalid scalar values mapping now
 have a specific code, where it used to be `unknown`.
 
+### Introduced `NormalizerBuilder` as the main entry for normalizers
+
+The `NormalizerBuilder` class has been introduced and will now be the main entry
+to instantiate normalizers. Therefore, the methods in `MapperBuilder` that used
+to configure and return normalizers have been removed.
+
+This decision aims to make a clear distinction between the mapper and the
+normalizer configuration API, where confusion could arise when using both
+services.
+
+The `NormalizerBuilder` can be used like this:
+
+```php
+$normalizer = (new \CuyZ\Valinor\NormalizerBuilder())
+    ->registerTransformer(
+        fn (\DateTimeInterface $date) => $date->format('Y/m/d')
+    )
+    ->normalizer(\CuyZ\Valinor\Normalizer\Format::array())
+    ->normalize($someData);
+```
+
 ### Removed Simple Cache (PSR-16) handling
 
 The Simple Cache PSR requirement has been removed from the library. This means
@@ -123,6 +144,8 @@ List of affected constructors:
 ### Full list of breaking changes
 
 - Removed `\Psr\SimpleCache\CacheInterface` dependency
+- Removed `\CuyZ\Valinor\MapperBuilder::registerTransformer()`
+- Removed `\CuyZ\Valinor\MapperBuilder::normalizer()`
 - Removed `\CuyZ\Valinor\Mapper\MappingError::node()`
     * Use `\CuyZ\Valinor\Mapper\MappingError::messages()` instead
 - Removed `\CuyZ\Valinor\Mapper\Tree\Node`

--- a/docs/pages/serialization/common-transformers-examples.md
+++ b/docs/pages/serialization/common-transformers-examples.md
@@ -32,7 +32,7 @@ example below:
 <summary>Show code example — Global date format</summary>
 
 ```php
-(new \CuyZ\Valinor\MapperBuilder())
+(new \CuyZ\Valinor\NormalizerBuilder())
     ->registerTransformer(
         fn (\DateTimeInterface $date) => $date->format('Y/m/d')
     )
@@ -81,7 +81,7 @@ final readonly class Event
     ) {}
 }
 
-(new \CuyZ\Valinor\MapperBuilder())
+(new \CuyZ\Valinor\NormalizerBuilder())
     ->normalizer(\CuyZ\Valinor\Normalizer\Format::array())
     ->normalize(
         new \My\App\Event(
@@ -133,7 +133,7 @@ final class CamelToSnakeCaseTransformer
     }
 }
 
-(new \CuyZ\Valinor\MapperBuilder())
+(new \CuyZ\Valinor\NormalizerBuilder())
     ->registerTransformer(new \My\App\CamelToSnakeCaseTransformer())
     ->normalizer(\CuyZ\Valinor\Normalizer\Format::array())
     ->normalize(
@@ -203,7 +203,7 @@ final readonly class Country
     ) {}
 }
 
-(new \CuyZ\Valinor\MapperBuilder())
+(new \CuyZ\Valinor\NormalizerBuilder())
     ->normalizer(\CuyZ\Valinor\Normalizer\Format::array())
     ->normalize(
         new \My\App\User(
@@ -267,7 +267,7 @@ final readonly class User
     ) {}
 }
 
-(new \CuyZ\Valinor\MapperBuilder())
+(new \CuyZ\Valinor\NormalizerBuilder())
     ->registerTransformer(
         fn (object $value, callable $next) => array_filter(
             $next(),
@@ -319,7 +319,7 @@ final readonly class Address
     ) {}
 }
 
-(new \CuyZ\Valinor\MapperBuilder())
+(new \CuyZ\Valinor\NormalizerBuilder())
     ->normalizer(\CuyZ\Valinor\Normalizer\Format::array())
     ->normalize(
         new Address(
@@ -367,7 +367,7 @@ final readonly class Address
     }
 }
 
-(new \CuyZ\Valinor\MapperBuilder())
+(new \CuyZ\Valinor\NormalizerBuilder())
     ->registerTransformer(function (object $object, callable $next) {
         return method_exists($object, 'normalize')
             ? $object->normalize()
@@ -432,7 +432,7 @@ final readonly class Address implements \My\App\HasVersionedNormalization
 
 function normalizeWithVersion(string $version): mixed
 {
-    return (new \CuyZ\Valinor\MapperBuilder())
+    return (new \CuyZ\Valinor\NormalizerBuilder())
         ->registerTransformer(
             fn (\My\App\HasVersionedNormalization $object) => $object->normalizeWithVersion($version)
         )

--- a/docs/pages/serialization/extending-normalizer.md
+++ b/docs/pages/serialization/extending-normalizer.md
@@ -2,7 +2,7 @@
 
 This library provides a normalizer out-of-the-box that can be used as-is, or
 extended to add custom logic. To do so, transformers must be registered within
-the `MapperBuilder`.
+the `NormalizerBuilder`.
 
 A transformer can be a callable (function, closure or a class implementing the
 `__invoke()` method), or an attribute that can target a class or a property.
@@ -18,7 +18,7 @@ will determine when it is used during normalization. In the example below, a
 global transformer is used to format any date found by the normalizer.
 
 ```php
-(new \CuyZ\Valinor\MapperBuilder())
+(new \CuyZ\Valinor\NormalizerBuilder())
     ->registerTransformer(
         fn (\DateTimeInterface $date) => $date->format('Y/m/d')
     )
@@ -41,7 +41,7 @@ must be declared in a transformer. This parameter — named `$next` by conventio
 — can be used whenever needed in the transformer logic.
 
 ```php
-(new \CuyZ\Valinor\MapperBuilder())
+(new \CuyZ\Valinor\NormalizerBuilder())
 
     // The type of the first parameter of the transformer will determine when it
     // is used during normalization.
@@ -113,7 +113,7 @@ final readonly class City
     ) {}
 }
 
-(new \CuyZ\Valinor\MapperBuilder())
+(new \CuyZ\Valinor\NormalizerBuilder())
     ->normalizer(\CuyZ\Valinor\Normalizer\Format::array())
     ->normalize(
         new \My\App\City(
@@ -160,7 +160,7 @@ final readonly class Address
     ) {}
 }
 
-(new \CuyZ\Valinor\MapperBuilder())
+(new \CuyZ\Valinor\NormalizerBuilder())
     ->normalizer(\CuyZ\Valinor\Normalizer\Format::array())
     ->normalize(
         new \My\App\Address(
@@ -183,7 +183,7 @@ When there is no control over the transformer attribute class, it is possible to
 register it using the `registerTransformer` method.
 
 ```php
-(new \CuyZ\Valinor\MapperBuilder())
+(new \CuyZ\Valinor\NormalizerBuilder())
     ->registerTransformer(\Some\External\TransformerAttribute::class)
     ->normalizer(\CuyZ\Valinor\Normalizer\Format::array())
     ->normalize(…);
@@ -203,7 +203,7 @@ final class SomeAttribute implements \My\App\SomeAttributeInterface {}
 #[\Attribute]
 final class SomeOtherAttribute implements \My\App\SomeAttributeInterface {}
 
-(new \CuyZ\Valinor\MapperBuilder())
+(new \CuyZ\Valinor\NormalizerBuilder())
     // Registers both `SomeAttribute` and `SomeOtherAttribute` attributes
     ->registerTransformer(\My\App\SomeAttributeInterface::class)
     ->normalizer(\CuyZ\Valinor\Normalizer\Format::array())

--- a/docs/pages/serialization/normalizer.md
+++ b/docs/pages/serialization/normalizer.md
@@ -12,7 +12,7 @@ Basic usage:
 ```php
 namespace My\App;
 
-$normalizer = (new \CuyZ\Valinor\MapperBuilder())
+$normalizer = (new \CuyZ\Valinor\NormalizerBuilder())
     ->normalizer(\CuyZ\Valinor\Normalizer\Format::array());
 
 $userAsArray = $normalizer->normalize(

--- a/docs/pages/serialization/normalizing-json.md
+++ b/docs/pages/serialization/normalizing-json.md
@@ -16,7 +16,7 @@ Basic usage:
 ```php
 namespace My\App;
 
-$normalizer = (new \CuyZ\Valinor\MapperBuilder())
+$normalizer = (new \CuyZ\Valinor\NormalizerBuilder())
     ->normalizer(\CuyZ\Valinor\Normalizer\Format::json());
 
 $userAsJson = $normalizer->normalize(
@@ -43,7 +43,7 @@ data to a PHP resource:
 ```php
 $file = fopen('path/to/some_file.json', 'w');
 
-$normalizer = (new \CuyZ\Valinor\MapperBuilder())
+$normalizer = (new \CuyZ\Valinor\NormalizerBuilder())
     ->normalizer(\CuyZ\Valinor\Normalizer\Format::json())
     ->streamTo($file);
 
@@ -63,7 +63,7 @@ $users = $database->execute('SELECT * FROM users');
 
 $file = fopen('path/to/some_file.json', 'w');
 
-$normalizer = (new \CuyZ\Valinor\MapperBuilder())
+$normalizer = (new \CuyZ\Valinor\NormalizerBuilder())
     ->normalizer(\CuyZ\Valinor\Normalizer\Format::json())
     ->streamTo($file);
 
@@ -84,7 +84,7 @@ This can be achieved by passing these flags to the
 ```php
 namespace My\App;
 
-$normalizer = (new \CuyZ\Valinor\MapperBuilder())
+$normalizer = (new \CuyZ\Valinor\NormalizerBuilder())
     ->normalizer(\CuyZ\Valinor\Normalizer\Format::json())
     ->withOptions(\JSON_PRESERVE_ZERO_FRACTION);
 

--- a/src/MapperBuilder.php
+++ b/src/MapperBuilder.php
@@ -10,8 +10,6 @@ use CuyZ\Valinor\Library\Settings;
 use CuyZ\Valinor\Mapper\ArgumentsMapper;
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
 use CuyZ\Valinor\Mapper\TreeMapper;
-use CuyZ\Valinor\Normalizer\Format;
-use CuyZ\Valinor\Normalizer\Normalizer;
 use Throwable;
 
 use function array_unique;
@@ -443,78 +441,6 @@ final class MapperBuilder
     }
 
     /**
-     * A transformer is responsible for transforming specific values during a
-     * normalization process.
-     *
-     * Transformers can be chained, the last registered one will take precedence
-     * over the previous ones.
-     *
-     * By specifying the type of its first parameter, the given callable will
-     * determine when the transformer is used. Advanced type annotations like
-     * `non-empty-string` can be used to target a more specific type.
-     *
-     * A second `callable` parameter may be declared, allowing to call the next
-     * transformer in the chain and get the modified value from it, before
-     * applying its own transformations.
-     *
-     * A priority can be given to a transformer, to make sure it is called
-     * before or after another one. The higher the priority, the sooner the
-     * transformer will be called. Default priority is 0.
-     *
-     * An attribute on a property or a class can act as a transformer if:
-     *  1. It defines a `normalize` or `normalizeKey` method.
-     *  2. It is registered using either the `registerTransformer()` method or
-     *     the following attribute: @see \CuyZ\Valinor\Normalizer\AsTransformer
-     *
-     * Example:
-     *
-     * ```php
-     * (new \CuyZ\Valinor\MapperBuilder())
-     *
-     *     // The type of the first parameter of the transformer will determine
-     *     // when it will be used by the normalizer.
-     *     ->registerTransformer(
-     *         fn (string $value, callable $next) => strtoupper($next())
-     *     )
-     *
-     *     // Transformers can be chained, the last registered one will take
-     *     // precedence over the previous ones, which can be called using the
-     *     // `$next` parameter.
-     *     ->registerTransformer(
-     *         fn (string $value, callable $next) => $next() . '!'
-     *     )
-     *
-     *     // A priority can be given to a transformer, to make sure it is
-     *     // called before or after another one.
-     *     ->registerTransformer(
-     *         fn (string $value, callable $next) => $next() . '?',
-     *         priority: -100 // Negative priority: transformer is called early
-     *     )
-     *
-     *     // External transformer attributes must be registered before they are
-     *     // used by the normalizer.
-     *     ->registerTransformer(\Some\External\TransformerAttribute::class)
-     *
-     *     ->normalizer()
-     *     ->normalize('Hello world'); // HELLO WORLD?!
-     * ```
-     *
-     * @param callable|class-string $transformer
-     */
-    public function registerTransformer(callable|string $transformer, int $priority = 0): self
-    {
-        $clone = clone $this;
-
-        if (is_callable($transformer)) {
-            $clone->settings->transformers[$priority][] = $transformer;
-        } else {
-            $clone->settings->transformerAttributes[$transformer] = null;
-        }
-
-        return $clone;
-    }
-
-    /**
      * Warms up the injected cache implementation with the provided class names.
      *
      * By passing a class which contains recursive objects, every nested object
@@ -537,17 +463,6 @@ final class MapperBuilder
     public function argumentsMapper(): ArgumentsMapper
     {
         return $this->container()->argumentsMapper();
-    }
-
-    /**
-     * @template T of Normalizer
-     *
-     * @param Format<T> $format
-     * @return T
-     */
-    public function normalizer(Format $format): Normalizer
-    {
-        return $this->container()->normalizer($format);
     }
 
     public function __clone()

--- a/src/NormalizerBuilder.php
+++ b/src/NormalizerBuilder.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor;
+
+use CuyZ\Valinor\Cache\Cache;
+use CuyZ\Valinor\Library\Container;
+use CuyZ\Valinor\Library\Settings;
+use CuyZ\Valinor\Normalizer\Format;
+use CuyZ\Valinor\Normalizer\Normalizer;
+
+/** @api */
+final class NormalizerBuilder
+{
+    private Settings $settings;
+
+    private Container $container;
+
+    public function __construct()
+    {
+        $this->settings = new Settings();
+    }
+
+    /**
+     * Inject a cache implementation that will be in charge of caching heavy
+     * data used by the normalizer. It is *strongly* recommended to use it when
+     * the application runs in a production environment.
+     *
+     * An implementation is provided out of the box, which writes cache entries
+     * in the file system.
+     *
+     * When the application runs in a development environment, the cache
+     * implementation should be decorated with `FileWatchingCache`. This service
+     * will watch the files of the application and invalidate cache entries when
+     * a PHP file is modified by a developer — preventing the library not
+     * behaving as expected when the signature of a property or a method changes.
+     *
+     * ```php
+     * $cache = new \CuyZ\Valinor\Cache\FileSystemCache('path/to/cache-dir');
+     *
+     * if ($isApplicationInDevelopmentEnvironment) {
+     *     $cache = new \CuyZ\Valinor\Cache\FileWatchingCache($cache);
+     * }
+     *
+     * (new \CuyZ\Valinor\NormalizerBuilder())
+     *     ->withCache($cache)
+     *     ->normalizer(\CuyZ\Valinor\Normalizer\Format::json())
+     *     ->normalize($someData);
+     * ```
+     */
+    public function withCache(Cache $cache): self
+    {
+        $clone = clone $this;
+        $clone->settings->cache = $cache;
+
+        return $clone;
+    }
+
+    /**
+     * A transformer is responsible for transforming specific values during a
+     * normalization process.
+     *
+     * Transformers can be chained, the last registered one will take precedence
+     * over the previous ones.
+     *
+     * By specifying the type of its first parameter, the given callable will
+     * determine when the transformer is used. Advanced type annotations like
+     * `non-empty-string` can be used to target a more specific type.
+     *
+     * A second `callable` parameter may be declared, allowing to call the next
+     * transformer in the chain and get the modified value from it, before
+     * applying its own transformations.
+     *
+     * A priority can be given to a transformer, to make sure it is called
+     * before or after another one. The higher the priority, the sooner the
+     * transformer will be called. Default priority is 0.
+     *
+     * An attribute on a property or a class can act as a transformer if:
+     *  1. It defines a `normalize` or `normalizeKey` method.
+     *  2. It is registered using either the `registerTransformer()` method or
+     *     the following attribute: @see \CuyZ\Valinor\Normalizer\AsTransformer
+     *
+     * Example:
+     *
+     * ```php
+     * (new \CuyZ\Valinor\NormalizerBuilder())
+     *
+     *     // The type of the first parameter of the transformer will determine
+     *     // when it will be used by the normalizer.
+     *     ->registerTransformer(
+     *         fn (string $value, callable $next) => strtoupper($next())
+     *     )
+     *
+     *     // Transformers can be chained, the last registered one will take
+     *     // precedence over the previous ones, which can be called using the
+     *     // `$next` parameter.
+     *     ->registerTransformer(
+     *         fn (string $value, callable $next) => $next() . '!'
+     *     )
+     *
+     *     // A priority can be given to a transformer, to make sure it is
+     *     // called before or after another one.
+     *     ->registerTransformer(
+     *         fn (string $value, callable $next) => $next() . '?',
+     *         priority: -100 // Negative priority: transformer is called early
+     *     )
+     *
+     *     // External transformer attributes must be registered before they are
+     *     // used by the normalizer.
+     *     ->registerTransformer(\Some\External\TransformerAttribute::class)
+     *
+     *     ->normalizer(\CuyZ\Valinor\Normalizer\Format::json())
+     *     ->normalize('Hello world'); // HELLO WORLD?!
+     * ```
+     *
+     * @param callable|class-string $transformer
+     */
+    public function registerTransformer(callable|string $transformer, int $priority = 0): self
+    {
+        $clone = clone $this;
+
+        if (is_callable($transformer)) {
+            $clone->settings->transformers[$priority][] = $transformer;
+        } else {
+            $clone->settings->transformerAttributes[$transformer] = null;
+        }
+
+        return $clone;
+    }
+
+    /**
+     * @template T of Normalizer
+     *
+     * @param Format<T> $format
+     * @return T
+     */
+    public function normalizer(Format $format): Normalizer
+    {
+        return $this->container()->normalizer($format);
+    }
+
+    public function __clone()
+    {
+        $this->settings = clone $this->settings;
+        unset($this->container);
+    }
+
+    private function container(): Container
+    {
+        return ($this->container ??= new Container($this->settings));
+    }
+}

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -10,6 +10,7 @@ use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Mapper\Tree\Message\DefaultMessage;
 use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
 use CuyZ\Valinor\MapperBuilder;
+use CuyZ\Valinor\NormalizerBuilder;
 use CuyZ\Valinor\Tests\Integration\Mapping\Namespace\NamespacedInterfaceInferringTest;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
@@ -62,13 +63,30 @@ abstract class IntegrationTestCase extends TestCase
 
     /**
      * This method *must* be used by every integration test in replacement of a
-     * direct creation of a MapperBuilder instance. The goal is to ensure that
+     * direct creation of a `MapperBuilder` instance. The goal is to ensure that
      * a test is run twice: once without a cache and once with the internal
      * filesystem cache injected.
      */
     protected function mapperBuilder(): MapperBuilder
     {
         $builder = new MapperBuilder();
+
+        if (isset($this->cacheToInject)) {
+            $builder = $builder->withCache($this->cacheToInject);
+        }
+
+        return $builder;
+    }
+
+    /**
+     * This method *must* be used by every integration test in replacement of a
+     * direct creation of a `NormalizerBuilder` instance. The goal is to ensure
+     * that a test is run twice: once without a cache and once with the internal
+     * filesystem cache injected.
+     */
+    protected function normalizerBuilder(): NormalizerBuilder
+    {
+        $builder = new NormalizerBuilder();
 
         if (isset($this->cacheToInject)) {
             $builder = $builder->withCache($this->cacheToInject);

--- a/tests/Integration/NonRegression/NormalizeEnumDoesNotBreakMapperTest.php
+++ b/tests/Integration/NonRegression/NormalizeEnumDoesNotBreakMapperTest.php
@@ -19,11 +19,13 @@ final class NormalizeEnumDoesNotBreakMapperTest extends IntegrationTestCase
      */
     public function test_normalizing_enum_and_then_map_value_on_same_enum_class_does_not_break(): void
     {
-        $mapperBuilder = $this->mapperBuilder();
+        $this->normalizerBuilder()
+            ->normalizer(Format::array())
+            ->normalize(BackedStringEnum::FOO);
 
-        $mapperBuilder->normalizer(Format::array())->normalize(BackedStringEnum::FOO);
-
-        $result = $mapperBuilder->mapper()->map(BackedStringEnum::class, 'foo');
+        $result = $this->mapperBuilder()
+            ->mapper()
+            ->map(BackedStringEnum::class, 'foo');
 
         self::assertSame(BackedStringEnum::FOO, $result);
     }

--- a/tests/Integration/Normalizer/AsTransformerAttributeTest.php
+++ b/tests/Integration/Normalizer/AsTransformerAttributeTest.php
@@ -22,7 +22,7 @@ final class AsTransformerAttributeTest extends IntegrationTestCase
             ) {}
         };
 
-        $result = $this->mapperBuilder()
+        $result = $this->normalizerBuilder()
             ->normalizer(Format::array())
             ->normalize($class);
 
@@ -37,7 +37,7 @@ final class AsTransformerAttributeTest extends IntegrationTestCase
             ) {}
         };
 
-        $result = $this->mapperBuilder()
+        $result = $this->normalizerBuilder()
             ->normalizer(Format::array())
             ->normalize($class);
 
@@ -53,7 +53,7 @@ final class AsTransformerAttributeTest extends IntegrationTestCase
             ) {}
         };
 
-        $result = $this->mapperBuilder()
+        $result = $this->normalizerBuilder()
             ->normalizer(Format::array())
             ->normalize($class);
 

--- a/tests/Integration/Normalizer/CommonExamples/CustomObjectNormalizationTest.php
+++ b/tests/Integration/Normalizer/CommonExamples/CustomObjectNormalizationTest.php
@@ -13,7 +13,7 @@ final class CustomObjectNormalizationTest extends IntegrationTestCase
 {
     public function test_custom_object_normalization_works_properly(): void
     {
-        $result = $this->mapperBuilder()
+        $result = $this->normalizerBuilder()
             ->registerTransformer(
                 fn (HasCustomNormalization $object) => $object->normalize(),
             )

--- a/tests/Integration/Normalizer/CommonExamples/DateFormatFromAttributeTest.php
+++ b/tests/Integration/Normalizer/CommonExamples/DateFormatFromAttributeTest.php
@@ -14,7 +14,7 @@ final class DateFormatFromAttributeTest extends IntegrationTestCase
 {
     public function test_date_format_attribute_works_properly(): void
     {
-        $result = $this->mapperBuilder()
+        $result = $this->normalizerBuilder()
             ->registerTransformer(DateTimeFormat::class)
             ->normalizer(Format::array())
             ->normalize(new class (

--- a/tests/Integration/Normalizer/CommonExamples/DateFormatFromGlobalTransformerTest.php
+++ b/tests/Integration/Normalizer/CommonExamples/DateFormatFromGlobalTransformerTest.php
@@ -13,7 +13,7 @@ final class DateFormatFromGlobalTransformerTest extends IntegrationTestCase
 {
     public function test_date_format_from_global_transformer_works_properly(): void
     {
-        $result = $this->mapperBuilder()
+        $result = $this->normalizerBuilder()
             ->registerTransformer(
                 fn (DateTimeInterface $date) => $date->format('Y/m/d'),
             )

--- a/tests/Integration/Normalizer/CommonExamples/IgnoreAttributeTest.php
+++ b/tests/Integration/Normalizer/CommonExamples/IgnoreAttributeTest.php
@@ -12,7 +12,7 @@ final class IgnoreAttributeTest extends IntegrationTestCase
 {
     public function test_ignore_attribute_works_properly(): void
     {
-        $result = $this->mapperBuilder()
+        $result = $this->normalizerBuilder()
             ->registerTransformer(
                 fn (object $value, callable $next) => array_filter(
                     // @phpstan-ignore argument.type (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)

--- a/tests/Integration/Normalizer/CommonExamples/ObjectKeysToSnakeCaseFromAttributeTest.php
+++ b/tests/Integration/Normalizer/CommonExamples/ObjectKeysToSnakeCaseFromAttributeTest.php
@@ -12,7 +12,7 @@ final class ObjectKeysToSnakeCaseFromAttributeTest extends IntegrationTestCase
 {
     public function test_object_keys_are_converted_to_snake_case(): void
     {
-        $result = $this->mapperBuilder()
+        $result = $this->normalizerBuilder()
             ->registerTransformer(SnakeCaseProperties::class)
             ->normalizer(Format::array())
             ->normalize(new #[SnakeCaseProperties] class () {

--- a/tests/Integration/Normalizer/CommonExamples/ObjectKeysToSnakeCaseTest.php
+++ b/tests/Integration/Normalizer/CommonExamples/ObjectKeysToSnakeCaseTest.php
@@ -11,7 +11,7 @@ final class ObjectKeysToSnakeCaseTest extends IntegrationTestCase
 {
     public function test_object_keys_are_converted_to_snake_case(): void
     {
-        $result = $this->mapperBuilder()
+        $result = $this->normalizerBuilder()
             ->registerTransformer(
                 function (object $object, callable $next) {
                     /** @var callable(): array<mixed> $next */

--- a/tests/Integration/Normalizer/CommonExamples/RenamePropertyFromAttributeTest.php
+++ b/tests/Integration/Normalizer/CommonExamples/RenamePropertyFromAttributeTest.php
@@ -12,7 +12,7 @@ final class RenamePropertyFromAttributeTest extends IntegrationTestCase
 {
     public function test_rename_attribute_works_properly(): void
     {
-        $result = $this->mapperBuilder()
+        $result = $this->normalizerBuilder()
             ->registerTransformer(Rename::class)
             ->normalizer(Format::array())
             ->normalize(new class () {

--- a/tests/Integration/Normalizer/CommonExamples/UppercaseFromAttributeTest.php
+++ b/tests/Integration/Normalizer/CommonExamples/UppercaseFromAttributeTest.php
@@ -12,7 +12,7 @@ final class UppercaseFromAttributeTest extends IntegrationTestCase
 {
     public function test_uppercase_attribute_works_properly(): void
     {
-        $result = $this->mapperBuilder()
+        $result = $this->normalizerBuilder()
             ->registerTransformer(Uppercase::class)
             ->normalizer(Format::array())
             ->normalize(new class () {

--- a/tests/Integration/Normalizer/CommonExamples/VersionTransformerTest.php
+++ b/tests/Integration/Normalizer/CommonExamples/VersionTransformerTest.php
@@ -11,7 +11,7 @@ final class VersionTransformerTest extends IntegrationTestCase
 {
     public function test_version_transformer_works_properly(): void
     {
-        $normalizeWithVersion = fn (string $version) => $this->mapperBuilder()
+        $normalizeWithVersion = fn (string $version) => $this->normalizerBuilder()
             ->registerTransformer(
                 fn (HasVersionedNormalization $object, callable $next) => $object->normalizeWithVersion($version, $next),
             )

--- a/tests/Integration/Normalizer/NormalizerCompiledCodeTest.php
+++ b/tests/Integration/Normalizer/NormalizerCompiledCodeTest.php
@@ -6,8 +6,8 @@ namespace CuyZ\Valinor\Tests\Integration\Normalizer;
 
 use Attribute;
 use CuyZ\Valinor\Cache\FileSystemCache;
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Normalizer\Format;
+use CuyZ\Valinor\NormalizerBuilder;
 use DateTime;
 use DateTimeInterface;
 use IteratorAggregate;
@@ -40,7 +40,7 @@ final class NormalizerCompiledCodeTest extends TestCase
 
         $cache = new FileSystemCache($directory);
 
-        $builder = (new MapperBuilder())->withCache($cache);
+        $builder = (new NormalizerBuilder())->withCache($cache);
         $builder = $builder->registerTransformer(PrependToStringAttribute::class);
 
         foreach ($transformers as $transformer) {

--- a/tests/Integration/Normalizer/NormalizerTest.php
+++ b/tests/Integration/Normalizer/NormalizerTest.php
@@ -50,7 +50,7 @@ final class NormalizerTest extends IntegrationTestCase
         array $transformerAttributes = [],
         int $jsonEncodingOptions = JSON_THROW_ON_ERROR,
     ): void {
-        $builder = $this->mapperBuilder();
+        $builder = $this->normalizerBuilder();
 
         foreach ($transformers as $priority => $transformersList) {
             foreach ($transformersList as $transformer) {
@@ -1483,7 +1483,7 @@ final class NormalizerTest extends IntegrationTestCase
             }
         };
 
-        $arrayResult = $this->mapperBuilder()
+        $arrayResult = $this->normalizerBuilder()
             ->normalizer(Format::array())
             ->normalize($input);
 
@@ -1511,7 +1511,7 @@ final class NormalizerTest extends IntegrationTestCase
             }
         };
 
-        $arrayResult = $this->mapperBuilder()
+        $arrayResult = $this->normalizerBuilder()
             ->normalizer(Format::json())
             ->normalize($input);
 
@@ -1536,7 +1536,7 @@ final class NormalizerTest extends IntegrationTestCase
             'boolean' => true,
         ];
 
-        $arrayResult = $this->mapperBuilder()
+        $arrayResult = $this->normalizerBuilder()
             ->normalizer(Format::array())
             ->normalize($input);
 
@@ -1554,7 +1554,7 @@ final class NormalizerTest extends IntegrationTestCase
 
         $expected = '{"string":"foo","integer":42,"float":1337.404,"boolean":true}';
 
-        $jsonResult = $this->mapperBuilder()
+        $jsonResult = $this->normalizerBuilder()
             ->normalizer(Format::json())
             ->normalize($input);
 
@@ -1572,7 +1572,7 @@ final class NormalizerTest extends IntegrationTestCase
 
         $expected = '["foo",42,1337.404,true]';
 
-        $jsonResult = $this->mapperBuilder()
+        $jsonResult = $this->normalizerBuilder()
             ->normalizer(Format::json())
             ->normalize($input);
 
@@ -1590,7 +1590,7 @@ final class NormalizerTest extends IntegrationTestCase
 
         $expected = '["foo",42,1337.404,true]';
 
-        $jsonResult = $this->mapperBuilder()
+        $jsonResult = $this->normalizerBuilder()
             ->normalizer(Format::json())
             ->normalize($input);
 
@@ -1625,7 +1625,7 @@ final class NormalizerTest extends IntegrationTestCase
             'booleans' => [true, false],
         ];
 
-        $arrayResult = $this->mapperBuilder()
+        $arrayResult = $this->normalizerBuilder()
             ->normalizer(Format::array())
             ->normalize($input);
 
@@ -1655,7 +1655,7 @@ final class NormalizerTest extends IntegrationTestCase
 
         $expected = '{"strings":["foo","bar"],"integers":[42,1337],"floats":[42.5,1337.404],"booleans":[true,false]}';
 
-        $jsonResult = $this->mapperBuilder()
+        $jsonResult = $this->normalizerBuilder()
             ->normalizer(Format::json())
             ->normalize($input);
 
@@ -1664,7 +1664,7 @@ final class NormalizerTest extends IntegrationTestCase
 
     public function test_transformer_is_called_only_once_on_object_property_when_using_default_transformer(): void
     {
-        $result = $this->mapperBuilder()
+        $result = $this->normalizerBuilder()
             ->registerTransformer(
                 /** @phpstan-ignore binaryOp.invalid (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770) */
                 fn (string $value, callable $next) => $next() . '!',
@@ -1677,7 +1677,7 @@ final class NormalizerTest extends IntegrationTestCase
 
     public function test_no_priority_given_is_set_to_0(): void
     {
-        $result = $this->mapperBuilder()
+        $result = $this->normalizerBuilder()
             ->registerTransformer(
                 fn (object $object) => 'foo',
                 -2,
@@ -1710,7 +1710,7 @@ final class NormalizerTest extends IntegrationTestCase
         $objectB = new stdClass();
         $objectB->bar = 'bar';
 
-        $result = $this->mapperBuilder()
+        $result = $this->normalizerBuilder()
             ->normalizer(Format::array())
             ->normalize([$objectA, $objectB, $objectA]);
 
@@ -1731,7 +1731,7 @@ final class NormalizerTest extends IntegrationTestCase
             yield $objectA;
         })();
 
-        $result = $this->mapperBuilder()
+        $result = $this->normalizerBuilder()
             ->normalizer(Format::array())
             ->normalize($iterable);
 
@@ -1759,7 +1759,7 @@ final class NormalizerTest extends IntegrationTestCase
             }
         };
 
-        $result = $this->mapperBuilder()
+        $result = $this->normalizerBuilder()
             ->normalizer(Format::array())
             ->normalize($object);
 
@@ -1776,7 +1776,7 @@ final class NormalizerTest extends IntegrationTestCase
         $this->expectExceptionCode(1695064946);
         $this->expectExceptionMessageMatches('/Transformer must have at least one parameter, none given for `.*`\./');
 
-        $this->mapperBuilder()
+        $this->normalizerBuilder()
             ->registerTransformer(fn () => 42)
             ->normalizer(Format::array())
             ->normalize(new stdClass());
@@ -1788,7 +1788,7 @@ final class NormalizerTest extends IntegrationTestCase
         $this->expectExceptionCode(1695065433);
         $this->expectExceptionMessageMatches('/Transformer must have at most 2 parameters, 3 given for `.*`\./');
 
-        $this->mapperBuilder()
+        $this->normalizerBuilder()
             ->registerTransformer(fn (stdClass $object, callable $next, int $unexpectedParameter) => 42)
             ->normalizer(Format::array())
             ->normalize(new stdClass());
@@ -1800,7 +1800,7 @@ final class NormalizerTest extends IntegrationTestCase
         $this->expectExceptionCode(1695065710);
         $this->expectExceptionMessageMatches('/Transformer\'s second parameter must be a callable, `int` given for `.*`\./');
 
-        $this->mapperBuilder()
+        $this->normalizerBuilder()
             ->registerTransformer(fn (stdClass $object, int $unexpectedParameterType) => 42)
             ->normalizer(Format::array())
             ->normalize(new stdClass());
@@ -1815,7 +1815,7 @@ final class NormalizerTest extends IntegrationTestCase
                 return 42;
             }
         };
-        $this->mapperBuilder()
+        $this->normalizerBuilder()
             ->registerTransformer($class)
             ->normalizer(Format::array())
             ->normalize(new stdClass());
@@ -1831,7 +1831,7 @@ final class NormalizerTest extends IntegrationTestCase
 
         $class = new #[TransformerAttributeWithNoParameter] class () {};
 
-        $this->mapperBuilder()
+        $this->normalizerBuilder()
             ->registerTransformer(TransformerAttributeWithNoParameter::class)
             ->normalizer(Format::array())
             ->normalize($class);
@@ -1845,7 +1845,7 @@ final class NormalizerTest extends IntegrationTestCase
 
         $class = new #[TransformerAttributeWithTooManyParameters] class () {};
 
-        $this->mapperBuilder()
+        $this->normalizerBuilder()
             ->registerTransformer(TransformerAttributeWithTooManyParameters::class)
             ->normalizer(Format::array())
             ->normalize($class);
@@ -1859,7 +1859,7 @@ final class NormalizerTest extends IntegrationTestCase
 
         $class = new #[TransformerAttributeWithSecondParameterNotCallable] class () {};
 
-        $this->mapperBuilder()
+        $this->normalizerBuilder()
             ->registerTransformer(TransformerAttributeWithSecondParameterNotCallable::class)
             ->normalizer(Format::array())
             ->normalize($class);
@@ -1878,7 +1878,7 @@ final class NormalizerTest extends IntegrationTestCase
             ) {}
         };
 
-        $this->mapperBuilder()
+        $this->normalizerBuilder()
             ->registerTransformer(KeyTransformerAttributeWithTooManyParameters::class)
             ->normalizer(Format::array())
             ->normalize($class);
@@ -1897,7 +1897,7 @@ final class NormalizerTest extends IntegrationTestCase
             ) {}
         };
 
-        $this->mapperBuilder()
+        $this->normalizerBuilder()
             ->registerTransformer(KeyTransformerAttributeParameterNotStringOrInteger::class)
             ->normalizer(Format::array())
             ->normalize($class);
@@ -1914,7 +1914,7 @@ final class NormalizerTest extends IntegrationTestCase
         $a->b = $b;
         $b->a = $a;
 
-        $this->mapperBuilder()->normalizer(Format::array())->normalize($a);
+        $this->normalizerBuilder()->normalizer(Format::array())->normalize($a);
     }
 
     public function test_unhandled_type_throws_exception(): void
@@ -1923,7 +1923,7 @@ final class NormalizerTest extends IntegrationTestCase
         $this->expectExceptionCode(1695062925);
         $this->expectExceptionMessage('Value of type `Closure` cannot be normalized.');
 
-        $this->mapperBuilder()->normalizer(Format::array())->normalize(fn () => 42);
+        $this->normalizerBuilder()->normalizer(Format::array())->normalize(fn () => 42);
     }
 
     public function test_giving_invalid_resource_to_json_normalizer_throws_exception(): void
@@ -1932,12 +1932,12 @@ final class NormalizerTest extends IntegrationTestCase
         $this->expectExceptionMessage('Expected a valid resource, got string');
 
         // @phpstan-ignore-next-line
-        $this->mapperBuilder()->normalizer(Format::json())->streamTo('foo');
+        $this->normalizerBuilder()->normalizer(Format::json())->streamTo('foo');
     }
 
     public function test_json_transformer_will_always_throw_on_error(): void
     {
-        $normalizer = $this->mapperBuilder()->normalizer(Format::json());
+        $normalizer = $this->normalizerBuilder()->normalizer(Format::json());
         self::assertSame(JSON_THROW_ON_ERROR, (fn () => $this->jsonEncodingOptions)->call($normalizer));
 
         $normalizer = $normalizer->withOptions(JSON_HEX_TAG);
@@ -1949,7 +1949,7 @@ final class NormalizerTest extends IntegrationTestCase
 
     public function test_json_transformer_only_accepts_acceptable_json_options(): void
     {
-        $normalizer = $this->mapperBuilder()->normalizer(Format::json())->withOptions(JSON_PARTIAL_OUTPUT_ON_ERROR);
+        $normalizer = $this->normalizerBuilder()->normalizer(Format::json())->withOptions(JSON_PARTIAL_OUTPUT_ON_ERROR);
         self::assertSame(JSON_THROW_ON_ERROR, (fn () => $this->jsonEncodingOptions)->call($normalizer));
     }
 }

--- a/tests/Integration/Normalizer/StreamNormalizerTest.php
+++ b/tests/Integration/Normalizer/StreamNormalizerTest.php
@@ -17,7 +17,7 @@ final class StreamNormalizerTest extends IntegrationTestCase
         /** @var resource $resource */
         $resource = fopen('php://memory', 'r+');
 
-        $this->mapperBuilder()
+        $this->normalizerBuilder()
             ->normalizer(Format::json())
             ->streamTo($resource)
             ->normalize(['foo' => 'bar']);

--- a/tests/StaticAnalysis/PHPStan/v1/inferring-normalizer-types.php
+++ b/tests/StaticAnalysis/PHPStan/v1/inferring-normalizer-types.php
@@ -2,22 +2,23 @@
 
 namespace CuyZ\Valinor\Tests\StaticAnalysis;
 
-use CuyZ\Valinor\MapperBuilder;
 use CuyZ\Valinor\Normalizer\Format;
 use CuyZ\Valinor\Normalizer\Normalizer;
+
+use CuyZ\Valinor\NormalizerBuilder;
 
 use function PHPStan\Testing\assertType;
 
 function normalizer_with_array_format_is_inferred_properly(): void
 {
-    $result = (new MapperBuilder())->normalizer(Format::array())->normalize(['foo' => 'bar']);
+    $result = (new NormalizerBuilder())->normalizer(Format::array())->normalize(['foo' => 'bar']);
 
     assertType('array|bool|float|int|string|null', $result);
 }
 
 function normalize_with_covariant_template_is_inferred_properly(): void
 {
-    $normalizer = (new MapperBuilder())->normalizer(Format::array());
+    $normalizer = (new NormalizerBuilder())->normalizer(Format::array());
 
     normalizeWithMixedType($normalizer);
 }

--- a/tests/StaticAnalysis/inferring-normalizer-types.php
+++ b/tests/StaticAnalysis/inferring-normalizer-types.php
@@ -2,7 +2,7 @@
 
 namespace CuyZ\Valinor\Tests\StaticAnalysis;
 
-use CuyZ\Valinor\MapperBuilder;
+use CuyZ\Valinor\NormalizerBuilder;
 use CuyZ\Valinor\Normalizer\Format;
 use CuyZ\Valinor\Normalizer\Normalizer;
 
@@ -10,7 +10,7 @@ use function PHPStan\Testing\assertType;
 
 function normalizer_with_array_format_is_inferred_properly(): void
 {
-    $result = (new MapperBuilder())->normalizer(Format::array())->normalize(['foo' => 'bar']);
+    $result = (new NormalizerBuilder())->normalizer(Format::array())->normalize(['foo' => 'bar']);
 
     /** @psalm-check-type $result = array|bool|float|int|string|null */
     assertType('array<mixed>|bool|float|int|string|null', $result);
@@ -18,7 +18,7 @@ function normalizer_with_array_format_is_inferred_properly(): void
 
 function normalize_with_covariant_template_is_inferred_properly(): void
 {
-    $normalizer = (new MapperBuilder())->normalizer(Format::array());
+    $normalizer = (new NormalizerBuilder())->normalizer(Format::array());
 
     normalizeWithMixedType($normalizer);
 }

--- a/tests/Unit/MapperBuilderTest.php
+++ b/tests/Unit/MapperBuilderTest.php
@@ -35,7 +35,6 @@ final class MapperBuilderTest extends TestCase
         $builderH = $builderA->filterExceptions(fn () => new FakeErrorMessage());
         $builderI = $builderA->withCache(new FakeCache());
         $builderJ = $builderA->supportDateFormats('Y-m-d');
-        $builderK = $builderA->registerTransformer(fn (stdClass $object) => 'foo');
 
         self::assertNotSame($builderA, $builderB);
         self::assertNotSame($builderA, $builderC);
@@ -46,7 +45,6 @@ final class MapperBuilderTest extends TestCase
         self::assertNotSame($builderA, $builderH);
         self::assertNotSame($builderA, $builderI);
         self::assertNotSame($builderA, $builderJ);
-        self::assertNotSame($builderA, $builderK);
     }
 
     public function test_mapper_instance_is_the_same(): void
@@ -80,5 +78,21 @@ final class MapperBuilderTest extends TestCase
         $mapperBuilder = $this->mapperBuilder->supportDateFormats('Y-m-d', 'd/m/Y', 'Y-m-d');
 
         self::assertSame(['Y-m-d', 'd/m/Y'], $mapperBuilder->supportedDateFormats());
+    }
+
+    public function test_settings_are_cloned_when_configuring_mapper_builder(): void
+    {
+        $resultA = $this->mapperBuilder
+            ->alter(fn (string $value): string => strtoupper($value))
+            ->mapper()
+            ->map('string', 'foo');
+
+        $resultB = $this->mapperBuilder
+            ->alter(fn (string $value): string => $value . '!')
+            ->mapper()
+            ->map('string', 'foo');
+
+        self::assertSame('FOO', $resultA);
+        self::assertSame('foo!', $resultB);
     }
 }

--- a/tests/Unit/NormalizerBuilderTest.php
+++ b/tests/Unit/NormalizerBuilderTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Unit;
+
+use CuyZ\Valinor\Normalizer\Format;
+use CuyZ\Valinor\NormalizerBuilder;
+use CuyZ\Valinor\Tests\Fake\Cache\FakeCache;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+final class NormalizerBuilderTest extends TestCase
+{
+    private NormalizerBuilder $normalizerBuilder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->normalizerBuilder = new NormalizerBuilder();
+    }
+
+    public function test_builder_methods_return_clone_of_builder_instance(): void
+    {
+        $builderA = $this->normalizerBuilder;
+        $builderB = $builderA->withCache(new FakeCache());
+        $builderC = $builderA->registerTransformer(fn (stdClass $object) => 'foo');
+
+        self::assertNotSame($builderA, $builderB);
+        self::assertNotSame($builderA, $builderC);
+    }
+
+    public function test_normalizer_instance_is_the_same(): void
+    {
+        self::assertSame(
+            $this->normalizerBuilder->normalizer(Format::array()),
+            $this->normalizerBuilder->normalizer(Format::array()),
+        );
+    }
+
+    public function test_settings_are_cloned_when_configuring_normalizer_builder(): void
+    {
+        $resultA = $this->normalizerBuilder
+            ->registerTransformer(fn (string $value) => strtoupper($value))
+            ->normalizer(Format::array())
+            ->normalize('foo');
+
+        $resultB = $this->normalizerBuilder
+            ->registerTransformer(fn (string $value) => $value . '!')
+            ->normalizer(Format::array())
+            ->normalize('foo');
+
+        self::assertSame('FOO', $resultA);
+        self::assertSame('foo!', $resultB);
+    }
+}


### PR DESCRIPTION
The `NormalizerBuilder` class has been introduced and will now be the main entry to instantiate normalizers. Therefore, the methods in `MapperBuilder` that used to configure and return normalizers have been removed.

This decision aims to make a clear distinction between the mapper and the normalizer configuration API, where confusion could arise when using both.

The `NormalizerBuilder` can be used like this:

```php
$normalizer = (new \CuyZ\Valinor\NormalizerBuilder())
    ->registerTransformer(
        fn (\DateTimeInterface $date) => $date->format('Y/m/d')
    )
    ->normalizer(\CuyZ\Valinor\Normalizer\Format::array())
    ->normalize($someData);
```