### PR TITLE
feat: introduce mapper converters to apply custom logic during mapping

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -86,8 +86,9 @@ nav:
   - How-to:
       - Use custom object constructors: how-to/use-custom-object-constructors.md
       - Deal with dates: how-to/deal-with-dates.md
+      - Convert input during mapping: how-to/convert-input.md
+      - Import formatted source: how-to/import-formatted-source.md
       - Infer interfaces: how-to/infer-interfaces.md
-      - Transform input: how-to/transform-input.md
       - Map arguments of a callable: how-to/map-arguments-of-a-callable.md
       - Customize error messages: how-to/customize-error-messages.md
   - Serialization:

--- a/docs/pages/how-to/convert-input.md
+++ b/docs/pages/how-to/convert-input.md
@@ -1,0 +1,144 @@
+# Convert input during mapping
+
+This library can automatically map most inputs to the expected types, but
+sometimes it’s not enough, and custom logic must be applied to the data.
+
+This is where mapper converters come in: they allow users to hook into the
+mapping process and apply custom logic to the input, by defining a callable
+signature that properly describes when it should be called:
+
+- A first argument with a type matching the expected input being mapped
+- A return type representing the targeted mapped type
+
+These two types are enough for the library to know when to call the converters
+and can contain advanced type annotations for more specific use cases.
+
+Below is a basic example of a converter that converts string inputs to
+uppercase:
+
+```php
+(new \CuyZ\Valinor\MapperBuilder())
+    ->registerConverter(
+        fn (string $value): string => strtoupper($value)
+    )
+    ->mapper()
+    ->map('string', 'hello world'); // 'HELLO WORLD'
+```
+
+## Chaining converters
+
+Converters can be chained, allowing multiple transformations to be applied to a
+value. A second `callable` parameter can be declared, allowing the current
+converter to call the next one in the chain.
+
+A priority can be given to a converter to control the order in which converters
+are applied. The higher the priority, the earlier the converter will be
+executed. The default priority is 0.
+
+```php
+(new \CuyZ\Valinor\MapperBuilder())
+    ->registerConverter(
+        fn (string $value, callable $next): string => $next(strtoupper($value))
+    )
+    ->registerConverter(
+        fn (string $value, callable $next): string => $next($value . '!'),
+        priority: -10,
+    )
+    ->registerConverter(
+        fn (string $value, callable $next): string => $next($value . '?'),
+        priority: 10,
+    )
+    ->mapper()
+    ->map('string', 'hello world'); // 'HELLO WORLD?!'
+```
+
+## Common converters examples
+
+### Converting keys format from `snake_case` to `camelCase`
+
+The following example is a classical use case where the input array keys are in
+`snake_case` format, but the target object properties are in `camelCase` format.
+A converter is used to convert the keys before mapping the values to the object.
+
+```php
+(new \CuyZ\Valinor\MapperBuilder())
+    ->registerConverter(
+        /**
+         * Note that this converter will only be called when the input is an
+         * array and the target type is an object.
+         */
+        function (array $values, callable $next): object {
+            $camelCaseConverted = array_combine(
+                array_map(
+                    fn ($key) => lcfirst(str_replace('_', '', ucwords($key, '_'))),
+                    array_keys($values),
+                ),
+                $values,
+            );
+
+            return $next($camelCaseConverted);
+        }
+    )
+    ->mapper()
+    ->map(User::class, [
+        // Note that the input keys have the `snake_case` format, but the
+        // properties of `User` have the `camelCase` format.
+        'user_name' => 'John Doe',
+        'birth_date' => '1971-11-08T00:00:00+00:00',
+    ]);
+
+final readonly class User
+{
+    public string $userName;
+    public DateTimeInterface $birthDate;
+}
+```
+
+### Renaming keys to match property names
+
+The example below shows how to rename keys in the input array to match the
+target object properties.
+
+```php
+function renameKeys(array $values, array $keyReplacements): array
+{
+    return array_combine(
+        array_map(
+            fn ($key) => $keyReplacements[$key] ?? $key,
+            array_keys($values),
+        ),
+        $values,
+    );
+}
+
+(new \CuyZ\Valinor\MapperBuilder())
+    ->registerConverter(
+        /**
+         * Note that this converter will only be called when the input is an
+         * array and the target type is an `Address`.
+         */
+        function (array $values, callable $next): Address {
+            $convertedValues = renameKeys($values, [
+                'avenue' => 'street',
+                'town' => 'city',
+            ]);
+
+            return $next($convertedValues);
+        }
+    )
+    ->mapper()
+    ->map(Address::class, [
+        // The key `avenue` does not match the property name `street`
+        'avenue' => '221B Baker Street',
+        'zipCode' => 'NW1 6XE',
+        // The key `town` does not match the property name `city`
+        'town' => 'London',
+    ]);
+
+final readonly class Address
+{
+    public string $street;
+    public string $zipCode;
+    public string $city;
+}
+```

--- a/docs/pages/how-to/import-formatted-source.md
+++ b/docs/pages/how-to/import-formatted-source.md
@@ -1,54 +1,53 @@
-# Transforming input
+# Import formatted source (JSON, YAML, …)
 
-Any source can be given to the mapper, be it an array, some JSON, YAML or even a
-file:
+Importing data from formatted source can be done using the `Source` helper,
+which will convert the data into a plain PHP structure before the mapping
+occurs.
+
+This library provides native conversion support for JSON, YAML and files:
 
 ```php
-$mapper = (new \CuyZ\Valinor\MapperBuilder())->mapper();
+$source = \CuyZ\Valinor\Mapper\Source\Source::json($jsonString);
 
-$mapper->map(
-    SomeClass::class,
-    \CuyZ\Valinor\Mapper\Source\Source::array($someData)
+// or…
+
+$source = \CuyZ\Valinor\Mapper\Source\Source::yaml($yamlString);
+
+// or…
+
+// File containing valid Json or Yaml content and with valid extension
+$source = \CuyZ\Valinor\Mapper\Source\Source::file(
+    new SplFileObject('path/to/my/file.json')
 );
 
-$mapper->map(
-    SomeClass::class,
-    \CuyZ\Valinor\Mapper\Source\Source::json($jsonString)
-);
-
-$mapper->map(
-    SomeClass::class,
-    \CuyZ\Valinor\Mapper\Source\Source::yaml($yamlString)
-);
-
-$mapper->map(
-    SomeClass::class,
-    // File containing valid Json or Yaml content and with valid extension
-    \CuyZ\Valinor\Mapper\Source\Source::file(
-        new SplFileObject('path/to/my/file.json')
-    )
-);
+(new \CuyZ\Valinor\MapperBuilder())
+    ->mapper()
+    ->map(SomeClass::class, $source);
 ```
 
-!!! info
+JSON or YAML given to a source may be invalid, in which case an exception can be
+caught and manipulated.
 
-    JSON or YAML given to a source may be invalid, in which case an exception 
-    can be caught and manipulated.
-
-    ```php
-    try {
-        $source = \CuyZ\Valinor\Mapper\Source\Source::json('invalid JSON');
-    } catch (\CuyZ\Valinor\Mapper\Source\Exception\InvalidSource $exception) {
-        // Let the application handle the exception in the desired way.
-        // It is possible to get the original source with `$exception->source()`
-    }
-    ```
+```php
+try {
+    $source = \CuyZ\Valinor\Mapper\Source\Source::json('invalid JSON');
+} catch (\CuyZ\Valinor\Mapper\Source\Exception\InvalidSource $exception) {
+    // Let the application handle the exception in the desired way.
+    // It is possible to get the original source with `$exception->source()`
+}
+```
 
 ## Modifiers
 
 Sometimes the source is not in the same format and/or organised in the same
 way as a value object. Modifiers can be used to change a source before the
 mapping occurs.
+
+!!! warning
+
+    The following modifiers may be removed in the future in favor of [mapper
+    converters](../how-to/convert-input.md), which should be used instead
+    whenever possible. Modifiers are still available for backward compatibility.
 
 ### Camel case keys
 

--- a/src/Definition/FunctionsContainer.php
+++ b/src/Definition/FunctionsContainer.php
@@ -11,6 +11,7 @@ use Traversable;
 
 use function array_keys;
 use function count;
+use function iterator_to_array;
 
 /**
  * @internal
@@ -36,6 +37,14 @@ final class FunctionsContainer implements IteratorAggregate, Countable
     public function get(string|int $key): FunctionObject
     {
         return $this->function($key);
+    }
+
+    /**
+     * @return array<FunctionObject>
+     */
+    public function toArray(): array
+    {
+        return iterator_to_array($this);
     }
 
     public function getIterator(): Traversable

--- a/src/Library/Container.php
+++ b/src/Library/Container.php
@@ -45,6 +45,7 @@ use CuyZ\Valinor\Mapper\Tree\Builder\TypeNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\UndefinedObjectNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\UnionNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\ValueAlteringNodeBuilder;
+use CuyZ\Valinor\Mapper\Tree\Builder\ValueConverterNodeBuilder;
 use CuyZ\Valinor\Mapper\TreeMapper;
 use CuyZ\Valinor\Mapper\TypeArgumentsMapper;
 use CuyZ\Valinor\Mapper\TypeTreeMapper;
@@ -126,6 +127,16 @@ final class Container
                         new FunctionsContainer(
                             $this->get(FunctionDefinitionRepository::class),
                             $settings->valueModifier,
+                        ),
+                    );
+                }
+
+                if (count($settings->mapperConverters) > 0) {
+                    $builder = new ValueConverterNodeBuilder(
+                        $builder,
+                        new FunctionsContainer(
+                            $this->get(FunctionDefinitionRepository::class),
+                            $settings->convertersSortedByPriority(),
                         ),
                     );
                 }

--- a/src/Mapper/Tree/Builder/ValueConverterNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ValueConverterNodeBuilder.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Tree\Builder;
+
+use CuyZ\Valinor\Definition\FunctionObject;
+use CuyZ\Valinor\Definition\FunctionsContainer;
+use CuyZ\Valinor\Mapper\Tree\Exception\InvalidNodeDuringValueConversion;
+use CuyZ\Valinor\Mapper\Tree\Exception\ValueConverterHasNoArgument;
+use CuyZ\Valinor\Mapper\Tree\Shell;
+
+use function array_shift;
+use function is_float;
+use function is_nan;
+
+/** @internal */
+final class ValueConverterNodeBuilder implements NodeBuilder
+{
+    public function __construct(
+        private NodeBuilder $delegate,
+        private FunctionsContainer $functions,
+    ) {}
+
+    public function build(Shell $shell, RootNodeBuilder $rootBuilder): Node
+    {
+        try {
+            $result = $this->unstack($this->functions->toArray(), $shell, $rootBuilder);
+
+            return Node::new($result);
+        } catch (InvalidNodeDuringValueConversion $exception) {
+            return $exception->node;
+        }
+    }
+
+    /**
+     * @param array<FunctionObject> $stack
+     */
+    private function unstack(array $stack, Shell $shell, RootNodeBuilder $rootBuilder): mixed
+    {
+        while ($current = array_shift($stack)) {
+            if ($current->definition->parameters->count() === 0) {
+                throw new ValueConverterHasNoArgument($current->definition);
+            }
+
+            if (! $shell->type()->matches($current->definition->returnType)) {
+                continue;
+            }
+
+            if (! $current->definition->parameters->at(0)->type->accepts($shell->value())) {
+                continue;
+            }
+
+            $arguments = [$shell->value()];
+
+            if ($current->definition->parameters->count() >= 2) {
+                $arguments[] = function (mixed $value = NAN) use ($stack, $shell, $rootBuilder) {
+                    if (! is_float($value) || ! is_nan($value)) {
+                        $shell = $shell->withValue($value);
+                    }
+
+                    return $this->unstack($stack, $shell, $rootBuilder);
+                };
+            }
+
+            return ($current->callback)(...$arguments);
+        }
+
+        $node = $this->delegate->build($shell, $rootBuilder);
+
+        if (! $node->isValid()) {
+            throw new InvalidNodeDuringValueConversion($node);
+        }
+
+        return $node->value();
+    }
+}

--- a/src/Mapper/Tree/Exception/InvalidNodeDuringValueConversion.php
+++ b/src/Mapper/Tree/Exception/InvalidNodeDuringValueConversion.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Tree\Exception;
+
+use CuyZ\Valinor\Mapper\Tree\Builder\Node;
+use Exception;
+
+/** @internal */
+final class InvalidNodeDuringValueConversion extends Exception
+{
+    public function __construct(
+        public readonly Node $node,
+    ) {
+        // @infection-ignore-all
+        parent::__construct();
+    }
+}

--- a/src/Mapper/Tree/Exception/ValueConverterHasNoArgument.php
+++ b/src/Mapper/Tree/Exception/ValueConverterHasNoArgument.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Tree\Exception;
+
+use CuyZ\Valinor\Definition\FunctionDefinition;
+use RuntimeException;
+
+/** @api */
+final class ValueConverterHasNoArgument extends RuntimeException
+{
+    public function __construct(FunctionDefinition $function)
+    {
+        parent::__construct(
+            "The value converter `$function->signature` has no argument to convert the value to, a typed argument is required.",
+            1746449489,
+        );
+    }
+}

--- a/src/Normalizer/AsTransformer.php
+++ b/src/Normalizer/AsTransformer.php
@@ -10,7 +10,7 @@ use Attribute;
  * This attribute can be used to automatically register a transformer attribute.
  *
  * When there is no control over the transformer attribute class, the following
- * method can be used: @see \CuyZ\Valinor\MapperBuilder::registerTransformer
+ * method can be used: @see \CuyZ\Valinor\NormalizerBuilder::registerTransformer
  *
  * ```php
  * namespace My\App;

--- a/src/NormalizerBuilder.php
+++ b/src/NormalizerBuilder.php
@@ -121,9 +121,9 @@ final class NormalizerBuilder
         $clone = clone $this;
 
         if (is_callable($transformer)) {
-            $clone->settings->transformers[$priority][] = $transformer;
+            $clone->settings->normalizerTransformers[$priority][] = $transformer;
         } else {
-            $clone->settings->transformerAttributes[$transformer] = null;
+            $clone->settings->normalizerTransformerAttributes[$transformer] = null;
         }
 
         return $clone;

--- a/src/Type/Types/ArrayType.php
+++ b/src/Type/Types/ArrayType.php
@@ -62,6 +62,10 @@ final class ArrayType implements CompositeTraversableType
             return false;
         }
 
+        if ($this === self::native()) {
+            return true;
+        }
+
         return Polyfill::array_all(
             $value,
             fn (mixed $item, mixed $key) => $this->keyType->accepts($key) && $this->subType->accepts($item),

--- a/src/Type/Types/IterableType.php
+++ b/src/Type/Types/IterableType.php
@@ -50,6 +50,10 @@ final class IterableType implements CompositeTraversableType
             return false;
         }
 
+        if ($this === self::native()) {
+            return true;
+        }
+
         foreach ($value as $key => $item) {
             if (! $this->keyType->accepts($key)) {
                 return false;

--- a/src/Type/Types/ListType.php
+++ b/src/Type/Types/ListType.php
@@ -51,6 +51,10 @@ final class ListType implements CompositeTraversableType
             return false;
         }
 
+        if ($this === self::native()) {
+            return true;
+        }
+
         return Polyfill::array_all(
             $value,
             fn (mixed $item) => $this->subType->accepts($item),

--- a/src/Type/Types/NonEmptyArrayType.php
+++ b/src/Type/Types/NonEmptyArrayType.php
@@ -58,6 +58,10 @@ final class NonEmptyArrayType implements CompositeTraversableType
             return false;
         }
 
+        if ($this === self::native()) {
+            return true;
+        }
+
         return Polyfill::array_all(
             $value,
             fn (mixed $item, mixed $key) => $this->keyType->accepts($key) && $this->subType->accepts($item),

--- a/src/Type/Types/NonEmptyListType.php
+++ b/src/Type/Types/NonEmptyListType.php
@@ -57,6 +57,10 @@ final class NonEmptyListType implements CompositeTraversableType
             return false;
         }
 
+        if ($this === self::native()) {
+            return true;
+        }
+
         return Polyfill::array_all(
             $value,
             fn (mixed $item) => $this->subType->accepts($item),

--- a/tests/Functional/Cache/TypeFilesWatcherTest.php
+++ b/tests/Functional/Cache/TypeFilesWatcherTest.php
@@ -23,7 +23,7 @@ final class TypeFilesWatcherTest extends TestCase
             some_function_to_test_type_files_watcher(...),
             some_other_function_to_test_type_files_watcher(...),
         ];
-        $settings->transformers = [
+        $settings->normalizerTransformers = [
             [strtoupper(...)]
         ];
 

--- a/tests/Integration/Mapping/ValueConverterMappingTest.php
+++ b/tests/Integration/Mapping/ValueConverterMappingTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Mapping;
+
+use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\Mapper\Tree\Exception\ValueConverterHasNoArgument;
+use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class ValueConverterMappingTest extends IntegrationTestCase
+{
+    /**
+     * @param array<int, list<callable>> $convertersByPriority
+     */
+    #[DataProvider('value_is_converted_properly_data_provider')]
+    public function test_value_is_converted_properly(string $type, mixed $value, mixed $expectedResult, array $convertersByPriority): void
+    {
+        try {
+            $builder = $this->mapperBuilder();
+
+            foreach ($convertersByPriority as $priority => $converters) {
+                foreach ($converters as $converter) {
+                    $builder = $builder->registerConverter($converter, $priority);
+                }
+            }
+
+            $result = $builder
+                ->mapper()
+                ->map($type, $value);
+
+            self::assertSame($expectedResult, $result);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+    }
+
+    public static function value_is_converted_properly_data_provider(): iterable
+    {
+        yield 'string converted to uppercase' => [
+            'type' => 'string',
+            'value' => 'foo',
+            'expectedResult' => 'FOO',
+            'convertersByPriority' => [
+                [
+                    strtoupper(...),
+                ],
+            ],
+        ];
+
+        yield 'string with converter that calls next without value' => [
+            'type' => 'string',
+            'value' => 'foo',
+            'expectedResult' => 'foo!',
+            'convertersByPriority' => [
+                [
+                    fn (string $value, callable $next) => $next() . '!', // @phpstan-ignore binaryOp.invalid (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+                ],
+            ],
+        ];
+
+        yield 'string with prioritized converters' => [
+            'type' => 'string',
+            'value' => 'foo',
+            'expectedResult' => 'foo?!',
+            'convertersByPriority' => [
+                10 => [
+                    fn (string $value, callable $next): string => $next($value . '!'), // @phpstan-ignore return.type (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+                ],
+                50 => [
+                    fn (string $value, callable $next): string => $next($value . '?'), // @phpstan-ignore return.type (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+                ],
+            ],
+        ];
+
+        yield 'string with ignored converters' => [
+            'type' => 'string',
+            'value' => 'foo',
+            'expectedResult' => 'foo!',
+            'convertersByPriority' => [
+                [
+                    fn (int $value, callable $next): string => $next($value) . '?', // @phpstan-ignore binaryOp.invalid (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+                    fn (int $value, callable $next): int => $next($value + 1), // @phpstan-ignore return.type (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+                    fn (string $value, callable $next): string => $next($value . '!'), // @phpstan-ignore return.type (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+                    fn (int $value, callable $next): int => $next($value + 2), // @phpstan-ignore return.type (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+                    fn (int $value, callable $next): string => $next($value) . '#', // @phpstan-ignore binaryOp.invalid (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+                ],
+            ],
+        ];
+
+        yield 'string with converter that does not call next' => [
+            'type' => 'string',
+            'value' => 'foo',
+            'expectedResult' => 'foo!',
+            'convertersByPriority' => [
+                [
+                    fn (string $value): string => $value . '!',
+                    fn (string $value, callable $next): string => $next($value . '?'), // @phpstan-ignore return.type (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+                ],
+            ],
+        ];
+    }
+
+    public function test_converter_with_no_priority_has_priority_0_by_default(): void
+    {
+        $result = $this->mapperBuilder()
+            ->registerConverter(fn (string $value, callable $next) => $next($value . '!'), -1)
+            ->registerConverter(fn (string $value, callable $next) => $next($value . '?'))
+            ->registerConverter(fn (string $value, callable $next) => $next($value . '#'), 1)
+            ->mapper()
+            ->map('string', 'foo');
+
+        self::assertSame('foo#?!', $result);
+    }
+
+    public function test_converter_is_stopped_if_mapping_error_occurs(): void
+    {
+        try {
+            $this->mapperBuilder()
+                ->registerConverter(fn (string $value, callable $next) => $next(42))
+                ->mapper()
+                ->map('string', 'foo');
+        } catch (MappingError $exception) {
+            self::assertMappingErrors($exception, [
+                '*root*' => '[invalid_string] Value 42 is not a valid string.',
+            ]);
+        }
+    }
+
+    public function test_converter_with_no_argument_throws_exception(): void
+    {
+        $this->expectException(ValueConverterHasNoArgument::class);
+        $this->expectExceptionCode(1746449489);
+        $this->expectExceptionMessageMatches('/The value converter `.*` has no argument to convert the value to, a typed argument is required\./');
+
+        $this->mapperBuilder()
+            ->registerConverter(fn () => 'bar')
+            ->mapper()
+            ->map('string', 'foo');
+    }
+
+    public function test_can_convert_snake_case_to_camel_case_for_object(): void
+    {
+        $class = new class () {
+            public string $someValue;
+
+            /** @var array<string> */
+            public array $someOtherValue;
+        };
+
+        try {
+            $result = $this->mapperBuilder()
+                // @phpstan-ignore return.type (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+                ->registerConverter(fn (array $values, callable $next): object => $next(array_combine(
+                    array_map(
+                        fn ($key) => lcfirst(str_replace([' ', '_', '-'], '', ucwords($key, ' _-'))),
+                        array_keys($values),
+                    ),
+                    $values,
+                )))
+                ->mapper()
+                ->map($class::class, [
+                    'some_value' => 'foo',
+                    'some_other_value' => [
+                        'bar' => 'bar',
+                        'baz' => 'baz',
+                    ],
+                ]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame('foo', $result->someValue);
+        self::assertSame(['bar' => 'bar', 'baz' => 'baz'], $result->someOtherValue);
+    }
+
+    public function test_can_rename_keys_for_object(): void
+    {
+        $class = new class () {
+            public string $someValue;
+
+            public int $someOtherValue;
+        };
+
+        $renameKeys = fn (array $values, array $keyReplacements) => array_combine(
+            // @phpstan-ignore argument.type (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+            array_map(
+                fn ($key) => $keyReplacements[$key] ?? $key,
+                array_keys($values),
+            ),
+            $values,
+        );
+
+        try {
+            $result = $this->mapperBuilder()
+                // @phpstan-ignore return.type (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+                ->registerConverter(fn (array $values, callable $next): object => $next($renameKeys($values, [
+                    'aValue' => 'someValue',
+                    'anotherValue' => 'someOtherValue',
+                ])))
+                ->mapper()
+                ->map($class::class, [
+                    'aValue' => 'foo',
+                    'anotherValue' => 42,
+                ]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame('foo', $result->someValue);
+        self::assertSame(42, $result->someOtherValue);
+    }
+}

--- a/tests/Unit/Library/SettingsTest.php
+++ b/tests/Unit/Library/SettingsTest.php
@@ -21,7 +21,7 @@ final class SettingsTest extends TestCase
     {
         $settings = new Settings();
 
-        self::assertSame('0e872477364acb126c2c4951d1460c1c', $settings->hash());
+        self::assertSame('63967be2023dcf5b93fdef40e4265875', $settings->hash());
     }
 
     public function test_settings_hash(): void
@@ -36,10 +36,11 @@ final class SettingsTest extends TestCase
         $settings->enableFlexibleCasting = true;
         $settings->allowSuperfluousKeys = true;
         $settings->allowPermissiveTypes = true;
+        $settings->mapperConverters[] = [fn (mixed $value): mixed => $value];
         $settings->exceptionFilter = fn (Throwable $e) => throw $e;
-        $settings->transformers[] = [fn (mixed $value): mixed => $value];
-        $settings->transformerAttributes[stdClass::class] = null;
+        $settings->normalizerTransformers[] = [fn (mixed $value): mixed => $value];
+        $settings->normalizerTransformerAttributes[stdClass::class] = null;
 
-        self::assertSame('bfd48d697761ee6a98cbaa95b78b0fd3', $settings->hash());
+        self::assertSame('732220467cc428e74f1b22d1d4e294e3', $settings->hash());
     }
 }

--- a/tests/Unit/MapperBuilderTest.php
+++ b/tests/Unit/MapperBuilderTest.php
@@ -32,9 +32,10 @@ final class MapperBuilderTest extends TestCase
         $builderE = $builderA->enableFlexibleCasting();
         $builderF = $builderA->allowSuperfluousKeys();
         $builderG = $builderA->allowPermissiveTypes();
-        $builderH = $builderA->filterExceptions(fn () => new FakeErrorMessage());
-        $builderI = $builderA->withCache(new FakeCache());
-        $builderJ = $builderA->supportDateFormats('Y-m-d');
+        $builderH = $builderA->registerConverter(fn (string $value) => $value);
+        $builderI = $builderA->filterExceptions(fn () => new FakeErrorMessage());
+        $builderJ = $builderA->withCache(new FakeCache());
+        $builderK = $builderA->supportDateFormats('Y-m-d');
 
         self::assertNotSame($builderA, $builderB);
         self::assertNotSame($builderA, $builderC);
@@ -45,6 +46,7 @@ final class MapperBuilderTest extends TestCase
         self::assertNotSame($builderA, $builderH);
         self::assertNotSame($builderA, $builderI);
         self::assertNotSame($builderA, $builderJ);
+        self::assertNotSame($builderA, $builderK);
     }
 
     public function test_mapper_instance_is_the_same(): void


### PR DESCRIPTION
A mapper converter allows users to hook into the mapping process and apply custom logic to the input, by defining a callable signature that properly describes when it should be called:

- A first argument with a type matching the expected input being mapped
- A return type representing the targeted mapped type

These two types are enough for the library to know when to call the converter and can contain advanced type annotations for more specific use cases.

Below is a basic example of a converter that converts string inputs to uppercase:

```php
(new \CuyZ\Valinor\MapperBuilder())
    ->registerConverter(
        fn (string $value): string => strtoupper($value)
    )
    ->mapper()
    ->map('string', 'hello world'); // 'HELLO WORLD'
```

Converters can be chained, allowing multiple transformations to be applied to a value. A second `callable` parameter can be declared, allowing the current converter to call the next one in the chain.

A priority can be given to a converter to control the order in which converters are applied. The higher the priority, the earlier the converter will be executed. The default priority is 0.

```php
(new \CuyZ\Valinor\MapperBuilder())
    ->registerConverter(
        function(string $value, callable $next): string {
            return $next(strtoupper($value));
        }
    )
    ->registerConverter(
        function(string $value, callable $next): string {
            return $next($value . '!');
        },
        priority: -10,
    )
    ->registerConverter(
        function(string $value, callable $next): string {
            return $next($value . '?');
        },
        priority: 10,
    )
    ->mapper()
    ->map('string', 'hello world'); // 'HELLO WORLD?!'
```