### PR TITLE
misc!: remove `MapperBuilder::enableFlexibleCasting()`

### DIFF
--- a/docs/pages/project/upgrading.md
+++ b/docs/pages/project/upgrading.md
@@ -115,6 +115,16 @@ the file watching feature: before, the cache entries were sometimes not
 invalidated properly when files changed during development. This should now be
 better.
 
+### Removed `MapperBuilder::enableFlexibleCasting()`
+
+This method is removed in favor of three distinct modes:
+
+- [`MapperBuilder::allowScalarValueCasting()`](../usage/type-strictness-and-flexibility.md#allowing-scalar-value-casting)
+- [`MapperBuilder::allowNonSequentialList()`](../usage/type-strictness-and-flexibility.md#allowing-non-sequential-lists)
+- [`MapperBuilder::allowUndefinedValues()`](../usage/type-strictness-and-flexibility.md#allowing-undefined-values)
+
+The methods above should be used to fit more specific use cases.
+
 ### Removed `MapperBuilder::alter()`
 
 This feature has been removed in favor of [mapper converters] which are more
@@ -155,6 +165,7 @@ List of affected constructors:
 
 - Removed `\Psr\SimpleCache\CacheInterface` dependency
 - Removed `\CuyZ\Valinor\MapperBuilder::alter()`
+- Removed `\CuyZ\Valinor\MapperBuilder::enableFlexibleCasting()`
 - Removed `\CuyZ\Valinor\MapperBuilder::registerTransformer()`
 - Removed `\CuyZ\Valinor\MapperBuilder::normalizer()`
 - Removed `\CuyZ\Valinor\Mapper\MappingError::node()`

--- a/src/MapperBuilder.php
+++ b/src/MapperBuilder.php
@@ -285,22 +285,6 @@ final class MapperBuilder
     }
 
     /**
-     * This setting will be removed in a future major version, as a replacement
-     * the following methods should be used:
-     *
-     * - @see allowScalarValueCasting()
-     * - @see allowNonSequentialList()
-     * - @see allowUndefinedValues()
-     */
-    public function enableFlexibleCasting(): self
-    {
-        return $this
-            ->allowScalarValueCasting()
-            ->allowNonSequentialList()
-            ->allowUndefinedValues();
-    }
-
-    /**
      * With this setting enabled, scalar types will accept castable values:
      *
      * - Integer types will accept any valid numeric value, for instance the

--- a/tests/Unit/MapperBuilderTest.php
+++ b/tests/Unit/MapperBuilderTest.php
@@ -25,30 +25,22 @@ final class MapperBuilderTest extends TestCase
 
     public function test_builder_methods_return_clone_of_builder_instance(): void
     {
-        $builderA = $this->mapperBuilder;
-        $builderB = $builderA->infer(DateTimeInterface::class, static fn () => DateTime::class);
-        $builderC = $builderA->registerConstructor(static fn (): stdClass => new stdClass());
-        $builderD = $builderA->enableFlexibleCasting();
-        $builderE = $builderA->allowScalarValueCasting();
-        $builderF = $builderA->allowNonSequentialList();
-        $builderG = $builderA->allowSuperfluousKeys();
-        $builderH = $builderA->allowPermissiveTypes();
-        $builderI = $builderA->registerConverter(fn (string $value) => $value);
-        $builderJ = $builderA->filterExceptions(fn () => new FakeErrorMessage());
-        $builderK = $builderA->withCache(new FakeCache());
-        $builderL = $builderA->supportDateFormats('Y-m-d');
+        $builders = [
+            $this->mapperBuilder->infer(DateTimeInterface::class, static fn () => DateTime::class),
+            $this->mapperBuilder->registerConstructor(static fn (): stdClass => new stdClass()),
+            $this->mapperBuilder->allowScalarValueCasting(),
+            $this->mapperBuilder->allowNonSequentialList(),
+            $this->mapperBuilder->allowSuperfluousKeys(),
+            $this->mapperBuilder->allowPermissiveTypes(),
+            $this->mapperBuilder->registerConverter(fn (string $value) => $value),
+            $this->mapperBuilder->filterExceptions(fn () => new FakeErrorMessage()),
+            $this->mapperBuilder->withCache(new FakeCache()),
+            $this->mapperBuilder->supportDateFormats('Y-m-d'),
+        ];
 
-        self::assertNotSame($builderA, $builderB);
-        self::assertNotSame($builderA, $builderC);
-        self::assertNotSame($builderA, $builderD);
-        self::assertNotSame($builderA, $builderE);
-        self::assertNotSame($builderA, $builderF);
-        self::assertNotSame($builderA, $builderG);
-        self::assertNotSame($builderA, $builderH);
-        self::assertNotSame($builderA, $builderI);
-        self::assertNotSame($builderA, $builderJ);
-        self::assertNotSame($builderA, $builderK);
-        self::assertNotSame($builderA, $builderL);
+        foreach ($builders as $builder) {
+            self::assertNotSame($this->mapperBuilder, $builder);
+        }
     }
 
     public function test_mapper_instance_is_the_same(): void


### PR DESCRIPTION
This method is removed in favor of three distinct modes:

- `MapperBuilder::allowScalarValueCasting()`
- `MapperBuilder::allowNonSequentialList()`
- `MapperBuilder::allowUndefinedValues()`

The methods above should be used to fit more specific use cases.