### PR TITLE
feat!: add type and source accessors to `MappingError`

### DIFF
--- a/docs/pages/project/upgrading.md
+++ b/docs/pages/project/upgrading.md
@@ -170,6 +170,8 @@ List of affected constructors:
 - Removed `\CuyZ\Valinor\MapperBuilder::normalizer()`
 - Removed `\CuyZ\Valinor\Mapper\MappingError::node()`
     * Use `\CuyZ\Valinor\Mapper\MappingError::messages()` instead
+- Added `\CuyZ\Valinor\Mapper\MappingError::type()`
+- Added `\CuyZ\Valinor\Mapper\MappingError::source()`
 - Removed `\CuyZ\Valinor\Mapper\Tree\Node`
 - Removed `\CuyZ\Valinor\Mapper\Tree\NodeTraverser`
 - Removed `\CuyZ\Valinor\Mapper\Tree\Message\Messages::flattenFromNode()`

--- a/src/Mapper/ArgumentsMapperError.php
+++ b/src/Mapper/ArgumentsMapperError.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper;
 
-use CuyZ\Valinor\Definition\FunctionDefinition;
 use CuyZ\Valinor\Mapper\Tree\Message\Messages;
 use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
 use CuyZ\Valinor\Utility\ValueDumper;
@@ -13,24 +12,30 @@ use RuntimeException;
 /** @internal */
 final class ArgumentsMapperError extends RuntimeException implements MappingError
 {
-    private Messages $errors;
+    private Messages $messages;
+
+    private string $type;
+
+    private mixed $source;
 
     /**
-     * @param non-empty-list<NodeMessage> $errors
+     * @param non-empty-list<NodeMessage> $messages
      */
-    public function __construct(mixed $source, FunctionDefinition $function, array $errors)
+    public function __construct(mixed $source, string $type, string $function, array $messages)
     {
-        $this->errors = new Messages(...$errors);
+        $this->messages = new Messages(...$messages);
+        $this->type = $type;
+        $this->source = $source;
 
-        $errorsCount = count($errors);
+        $errorsCount = count($messages);
 
         if ($errorsCount === 1) {
-            $body = $errors[0]
-                ->withBody("Could not map arguments of `$function->signature`. An error occurred at path {node_path}: {original_message}")
+            $body = $messages[0]
+                ->withBody("Could not map arguments of `$function`. An error occurred at path {node_path}: {original_message}")
                 ->toString();
         } else {
             $source = ValueDumper::dump($source);
-            $body = "Could not map arguments of `$function->signature` with value $source. A total of $errorsCount errors were encountered.";
+            $body = "Could not map arguments of `$function` with value $source. A total of $errorsCount errors were encountered.";
         }
 
         parent::__construct($body, 1671115362);
@@ -38,6 +43,16 @@ final class ArgumentsMapperError extends RuntimeException implements MappingErro
 
     public function messages(): Messages
     {
-        return $this->errors;
+        return $this->messages;
+    }
+
+    public function type(): string
+    {
+        return $this->type;
+    }
+
+    public function source(): mixed
+    {
+        return $this->source;
     }
 }

--- a/src/Mapper/MappingError.php
+++ b/src/Mapper/MappingError.php
@@ -10,5 +10,18 @@ use Throwable;
 /** @api */
 interface MappingError extends Throwable
 {
+    /**
+     * Container for all messages that were caught during the mapping process.
+     */
     public function messages(): Messages;
+
+    /**
+     * Returns the original type that the mapper was attempting to map to.
+     */
+    public function type(): string;
+
+    /**
+     * Returns the original source value given to the mapper.
+     */
+    public function source(): mixed;
 }

--- a/src/Mapper/TypeArgumentsMapper.php
+++ b/src/Mapper/TypeArgumentsMapper.php
@@ -66,6 +66,6 @@ final class TypeArgumentsMapper implements ArgumentsMapper
             }
         }
 
-        throw new ArgumentsMapperError($shell->value(), $function, $node->messages());
+        throw new ArgumentsMapperError($shell->value(), $type->toString(), $function->signature, $node->messages());
     }
 }

--- a/src/Mapper/TypeTreeMapper.php
+++ b/src/Mapper/TypeTreeMapper.php
@@ -39,7 +39,7 @@ final class TypeTreeMapper implements TreeMapper
         }
 
         if (! $node->isValid()) {
-            throw new TypeTreeMapperError($source, $type, $node->messages());
+            throw new TypeTreeMapperError($source, $type->toString(), $node->messages());
         }
 
         return $node->value();

--- a/src/Mapper/TypeTreeMapperError.php
+++ b/src/Mapper/TypeTreeMapperError.php
@@ -6,32 +6,37 @@ namespace CuyZ\Valinor\Mapper;
 
 use CuyZ\Valinor\Mapper\Tree\Message\Messages;
 use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
-use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Utility\ValueDumper;
 use RuntimeException;
 
 /** @internal */
 final class TypeTreeMapperError extends RuntimeException implements MappingError
 {
-    private Messages $errors;
+    private Messages $messages;
+
+    private string $type;
+
+    private mixed $source;
 
     /**
-     * @param non-empty-list<NodeMessage> $errors
+     * @param non-empty-list<NodeMessage> $messages
      */
-    public function __construct(mixed $source, Type $type, array $errors)
+    public function __construct(mixed $source, string $type, array $messages)
     {
-        $this->errors = new Messages(...$errors);
+        $this->messages = new Messages(...$messages);
+        $this->type = $type;
+        $this->source = $source;
 
-        $errorsCount = count($errors);
+        $errorsCount = count($messages);
 
         if ($errorsCount === 1) {
-            $body = $errors[0]
-                ->withParameter('root_type', $type->toString())
+            $body = $messages[0]
+                ->withParameter('root_type', $type)
                 ->withBody("Could not map type `{root_type}`. An error occurred at path {node_path}: {original_message}")
                 ->toString();
         } else {
             $source = ValueDumper::dump($source);
-            $body = "Could not map type `{$type->toString()}` with value $source. A total of $errorsCount errors were encountered.";
+            $body = "Could not map type `$type` with value $source. A total of $errorsCount errors were encountered.";
         }
 
         parent::__construct($body, 1617193185);
@@ -39,6 +44,16 @@ final class TypeTreeMapperError extends RuntimeException implements MappingError
 
     public function messages(): Messages
     {
-        return $this->errors;
+        return $this->messages;
+    }
+
+    public function type(): string
+    {
+        return $this->type;
+    }
+
+    public function source(): mixed
+    {
+        return $this->source;
     }
 }

--- a/tests/Integration/Mapping/MappingErrorTest.php
+++ b/tests/Integration/Mapping/MappingErrorTest.php
@@ -37,4 +37,32 @@ final class MappingErrorTest extends IntegrationTestCase
 
         $this->mapperBuilder()->argumentsMapper()->mapArguments(fn (string $foo) => $foo, 42);
     }
+
+    public function test_type_and_source_are_accessible_from_the_mapping_error(): void
+    {
+        try {
+            $this->mapperBuilder()
+                ->mapper()
+                ->map('array<string>', ['foo', 42, 'bar']);
+
+            self::fail('No mapping error when one was expected');
+        } catch (MappingError $exception) {
+            self::assertSame('array<string>', $exception->type());
+            self::assertSame(['foo', 42, 'bar'], $exception->source());
+        }
+    }
+
+    public function test_type_and_source_are_accessible_from_the_arguments_mapping_error(): void
+    {
+        try {
+            $this->mapperBuilder()
+                ->argumentsMapper()
+                ->mapArguments(fn (string $foo) => $foo, 42);
+
+            self::fail('No mapping error when one was expected');
+        } catch (MappingError $exception) {
+            self::assertSame('array{foo: string}', $exception->type());
+            self::assertSame(42, $exception->source());
+        }
+    }
 }


### PR DESCRIPTION
Introduced `type()` and `source()` methods on `MappingError` to provide access to the original type and source value when a mapping error occurs.