### PR TITLE
Simplify ValueNode implementation

### DIFF
--- a/src/Compiler/Native/ValueNode.php
+++ b/src/Compiler/Native/ValueNode.php
@@ -30,14 +30,13 @@ final class ValueNode extends Node
         if (is_array($value)) {
             $compiler = $compiler->write('[');
 
-            while (key($value) !== null) {
-                $compiler = $compiler->write(var_export(key($value), true) . ' => ');
-                $compiler = $this->compileValue(current($value), $compiler);
+            $i = 0;
+            $numItems = count($value);
+            foreach($value as $key => $item) {
+                $compiler = $compiler->write(var_export($key, true) . ' => ');
+                $compiler = $this->compileValue($item, $compiler);
 
-                next($value);
-
-                // @phpstan-ignore notIdentical.alwaysTrue (calling `next($value)` is not detected properly by PHPStan)
-                if (key($value) !== null) {
+                if(++$i !== $numItems) {
                     $compiler = $compiler->write(', ');
                 }
             }

--- a/src/Compiler/Native/ValueNode.php
+++ b/src/Compiler/Native/ValueNode.php
@@ -7,9 +7,7 @@ namespace CuyZ\Valinor\Compiler\Native;
 use CuyZ\Valinor\Compiler\Compiler;
 use CuyZ\Valinor\Compiler\Node;
 
-use function current;
 use function is_array;
-use function key;
 use function var_export;
 
 /** @internal */
@@ -32,11 +30,11 @@ final class ValueNode extends Node
 
             $i = 0;
             $numItems = count($value);
-            foreach($value as $key => $item) {
+            foreach ($value as $key => $item) {
                 $compiler = $compiler->write(var_export($key, true) . ' => ');
                 $compiler = $this->compileValue($item, $compiler);
 
-                if(++$i !== $numItems) {
+                if (++$i !== $numItems) {
                     $compiler = $compiler->write(', ');
                 }
             }


### PR DESCRIPTION
the previous implementation was
- harder to read for the dev
- needed PHPStan ignores as hard to analyze
- produced 2 infection timed out mutants (because code was changed into endless loops)

the new impl fixes this problems