### PR TITLE
misc!: add purity markers in `MapperBuilder` and `NormalizerBuilder`

### DIFF
--- a/docs/pages/other/static-analysis.md
+++ b/docs/pages/other/static-analysis.md
@@ -117,8 +117,15 @@ effects and will always return the same result for the same input. For more
 information, see the [definition of a pure function].
 
 It is recommended to keep purity in mind when applications are being developed,
-by using the `@pure` annotation that is handled by [PHPStan] and [Psalm]. There
-are cases where the purity analysis can return false-positives, which can be 
+by using the `@pure` annotation that is handled by [PHPStan] and [Psalm].
+
+Mapping user-provided data is, in itself, a potentially dangerous operation: by
+relying only on pure functions/types for mapping, you ensure that malicious user
+input won't cause side effects when `TreeMapper#map()` is called. You are free to
+suppress/ignore the given purity guidelines, at the cost of an expanded attack
+surface.
+
+There are cases where the purity analysis can return false-positives, which can be 
 easily ignored, for instance by using the
 [`@phpstan-ignore`](https://phpstan.org/user-guide/ignoring-errors#ignoring-in-code-using-phpdocs)
 and

--- a/docs/pages/other/static-analysis.md
+++ b/docs/pages/other/static-analysis.md
@@ -109,3 +109,38 @@ $arguments = (new \CuyZ\Valinor\MapperBuilder())
 // ✅ Arguments have a correct shape, no error reported
 echo $someFunction(...$arguments);
 ```
+
+## About mapper and normalizer purity
+
+The mapper and normalizer are designed to be pure, meaning they do not have side
+effects and will always return the same result for the same input. For more
+information, see the [definition of a pure function].
+
+It is recommended to keep purity in mind when applications are being developed,
+by using the `@pure` annotation that is handled by [PHPStan] and [Psalm]. There
+are cases where the purity analysis can return false-positives, which can be 
+easily ignored, for instance by using the
+[`@phpstan-ignore`](https://phpstan.org/user-guide/ignoring-errors#ignoring-in-code-using-phpdocs)
+and
+[`@psalm-suppress`](https://psalm.dev/docs/running_psalm/dealing_with_code_issues/#docblock-suppression)
+annotations.
+
+!!! note
+
+    If too many purity errors concerning the mapper or normalizer are reported,
+    this library provides a way to ignore them globally:
+
+    === "PHPStan"
+
+        ```yaml title="phpstan.neon"
+        includes:
+            - vendor/cuyz/valinor/qa/PHPStan/valinor-phpstan-suppress-pure-errors.php
+        ```
+
+    === "Psalm"
+
+        ```xml title="psalm.xml"
+        <xi:include href="vendor/cuyz/valinor/qa/Psalm/valinor-psalm-suppress-pure-errors.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+        ```
+
+[definition of a pure function]: https://en.wikipedia.org/wiki/Pure_function

--- a/docs/pages/other/static-analysis.md
+++ b/docs/pages/other/static-analysis.md
@@ -121,12 +121,12 @@ by using the `@pure` annotation that is handled by [PHPStan] and [Psalm].
 
 Mapping user-provided data is, in itself, a potentially dangerous operation: by
 relying only on pure functions/types for mapping, you ensure that malicious user
-input won't cause side effects when `TreeMapper#map()` is called. You are free to
-suppress/ignore the given purity guidelines, at the cost of an expanded attack
-surface.
+input won't cause side effects when `TreeMapper::map()` is called. You are free
+to suppress/ignore the given purity guidelines, at the cost of an expanded
+attack surface.
 
-There are cases where the purity analysis can return false-positives, which can be 
-easily ignored, for instance by using the
+There are cases where the purity analysis can return false-positives, which can
+be easily ignored, for instance by using the
 [`@phpstan-ignore`](https://phpstan.org/user-guide/ignoring-errors#ignoring-in-code-using-phpdocs)
 and
 [`@psalm-suppress`](https://psalm.dev/docs/running_psalm/dealing_with_code_issues/#docblock-suppression)

--- a/docs/pages/project/changelog.md
+++ b/docs/pages/project/changelog.md
@@ -7,6 +7,10 @@ hide:
 
 Below are listed the changelogs for all released versions of the library.
 
+## Version 2
+
+- [`2.0.0` — 20th of June 2025](changelog/version-2.0.0.md)
+
 ## Version 1
 
 - [`1.17.0` — 20th of June 2025](changelog/version-1.17.0.md)

--- a/docs/pages/project/changelog/version-2.0.0.md
+++ b/docs/pages/project/changelog/version-2.0.0.md
@@ -1,0 +1,141 @@
+# Changelog 2.0.0 — 20th of June 2025
+
+!!! info inline end "[See release on GitHub]"
+    [See release on GitHub]: https://github.com/CuyZ/Valinor/releases/tag/2.0.0
+
+First release of the v2 series! 🎉
+
+This release introduces some new features but also backward compatibility breaks
+that are detailed [in the upgrading chapter]: it is strongly recommended to read
+it carefully before upgrading.
+
+[in the upgrading chapter]: ../upgrading.md#upgrade-from-1x-to-2x
+
+## Notable new features
+
+**Mapper converters introduction**
+
+A mapper converter allows users to hook into the mapping process and apply 
+custom logic to the input, by defining a callable signature that properly
+describes when it should be called:
+
+- A first argument with a type matching the expected input being mapped
+- A return type representing the targeted mapped type
+
+These two types are enough for the library to know when to call the converter
+and can contain advanced type annotations for more specific use cases.
+
+Below is a basic example of a converter that converts string inputs to
+uppercase:
+
+```php
+(new \CuyZ\Valinor\MapperBuilder())
+    ->registerConverter(
+        fn (string $value): string => strtoupper($value)
+    )
+    ->mapper()
+    ->map('string', 'hello world'); // 'HELLO WORLD'
+```
+
+Converters can be chained, allowing multiple transformations to be applied to a
+value. A second `callable` parameter can be declared, allowing the current
+converter to call the next one in the chain.
+
+A priority can be given to a converter to control the order in which converters
+are applied. The higher the priority, the earlier the converter will be
+executed. The default priority is 0.
+
+```php
+(new \CuyZ\Valinor\MapperBuilder())
+    ->registerConverter(
+        function(string $value, callable $next): string {
+            return $next(strtoupper($value));
+        }
+    )
+    ->registerConverter(
+        function(string $value, callable $next): string {
+            return $next($value . '!');
+        },
+        priority: -10,
+    )
+    ->registerConverter(
+        function(string $value, callable $next): string {
+            return $next($value . '?');
+        },
+        priority: 10,
+    )
+    ->mapper()
+    ->map('string', 'hello world'); // 'HELLO WORLD?!'
+```
+
+More information can be found in the [mapper converter
+chapter](../../how-to/convert-input.md).
+
+**`NormalizerBuilder` introduction**
+
+The `NormalizerBuilder` class has been introduced and will now be the main entry
+to instantiate normalizers. Therefore, the methods in`MapperBuilder` that used
+to configure and return normalizers have been removed.
+
+This decision aims to make a clear distinction between the mapper and the 
+normalizer configuration API, where confusion could arise when using both.
+
+The `NormalizerBuilder` can be used like this:
+
+```php
+$normalizer = (new \CuyZ\Valinor\NormalizerBuilder())
+    ->registerTransformer(
+        fn (\DateTimeInterface $date) => $date->format('Y/m/d')
+    )
+    ->normalizer(\CuyZ\Valinor\Normalizer\Format::array())
+    ->normalize($someData);
+```
+
+**Changes to messages/errors handling**
+
+Some changes have been made to the way messages and errors are handled.
+
+It is now easier to fetch messages when error(s) occur during mapping:
+
+```php
+try {
+    (new \CuyZ\Valinor\MapperBuilder())->mapper()->map(/* … */);
+} catch (\CuyZ\Valinor\Mapper\MappingError $error) {
+    // Before (1.x):
+    $messages = \CuyZ\Valinor\Mapper\Tree\Message\Messages::flattenFromNode(
+        $error->node()
+    );
+    
+    // After (2.x):
+    $messages = $error->messages();
+}
+```
+
+## Upgrading from 1.x to 2.x
+
+[See the upgrading chapter](../upgrading.md#upgrade-from-1x-to-2x).
+
+### ⚠ BREAKING CHANGES
+
+* Add type and source accessors to `MappingError` ([783a24](https://github.com/CuyZ/Valinor/commit/783a2414a2e8c01a271c5301c04390ea01524ae0))
+* Change exposed error messages codes ([a712d5](https://github.com/CuyZ/Valinor/commit/a712d5ba516b5bcdc962fb6c63470da66245a92d))
+* Introduce `NormalizerBuilder` as the main entry for normalizers ([602a39](https://github.com/CuyZ/Valinor/commit/602a3998860cf88a600cea021777590b5bc9857f))
+* Introduce internal cache interface and remove PSR-16 dependency ([10d9aa](https://github.com/CuyZ/Valinor/commit/10d9aa9a6d40af6b3edc1a215fca4d1be8e5b7de))
+* Mark some class constructors as `@internal` ([3905ef](https://github.com/CuyZ/Valinor/commit/3905efac052c048f056714d1d1219c67b9abc392))
+* Remove `MapperBuilder::alter()` in favor of mapper converters ([158cf7](https://github.com/CuyZ/Valinor/commit/158cf70145c3809a1ec7606fda45cce0320e3e72))
+* Remove `MapperBuilder::enableFlexibleCasting()` ([1a805a](https://github.com/CuyZ/Valinor/commit/1a805a15d33a59f988f103e2920981f022f7a693))
+* Remove unused class `PrioritizedList` ([074ca4](https://github.com/CuyZ/Valinor/commit/074ca405a5ac3e724d2526ed7a2f50f683eed21e))
+* Remove unused interface `IdentifiableSource` ([74f63c](https://github.com/CuyZ/Valinor/commit/74f63cbfc140c737c2c58eb28be47b2dc6dcc10b))
+* Rename `MapperBuilder::warmup()` method to `warmupCacheFor()` ([d9094b](https://github.com/CuyZ/Valinor/commit/d9094b55270cccf3ff232d2698904603e2af278e))
+* Rework mapper node and messages handling ([07cdcf](https://github.com/CuyZ/Valinor/commit/07cdcf627b263177f1dba90fd5520c5aa5dbd48f))
+
+### Features
+
+* Allow `MapperBuilder` and `NormalizerBuilder` to clear cache ([1c2ac0](https://github.com/CuyZ/Valinor/commit/1c2ac0c22f4ce65ca13902e09a111faf4fc8c258))
+* Introduce mapper converters to apply custom logic during mapping ([0ad0f9](https://github.com/CuyZ/Valinor/commit/0ad0f99b23c9f6888e3c955da5c451c58f42a455))
+
+### Other
+
+* Remove `Throwable` inheritance from `ErrorMessage` ([3e6024](https://github.com/CuyZ/Valinor/commit/3e6024a5652f95fd76a9993e273bed4d80d0fbd7))
+* Remove old class doc block ([660356](https://github.com/CuyZ/Valinor/commit/660356273e5ccac11a17f6997f0e35e4168153ba))
+* Remove unused property ([5ce829](https://github.com/CuyZ/Valinor/commit/5ce829864c63a92ce71f2974a26c572d61a95728))

--- a/docs/pages/project/upgrading.md
+++ b/docs/pages/project/upgrading.md
@@ -11,6 +11,7 @@
 - [Removed Simple Cache (PSR-16) handling](#removed-simple-cache-psr-16-handling)
 - [Removed `MapperBuilder::enableFlexibleCasting()`](#removed-mapperbuilderenableflexiblecasting)
 - [Removed `MapperBuilder::alter()`](#removed-mapperbuilderalter)
+- [Add `@pure` markers to `MapperBuilder` and `NormalizerBuilder` methods](#add-pure-markers-to-mapperbuilder-and-normalizerbuilder-methods)
 - [Removed classes and interfaces](#removed-classes-and-interfaces)
 - [Class constructors marked as `@internal`](#class-constructors-marked-as-internal)
 
@@ -146,6 +147,43 @@ Note that the `MapperBuilder::alter()` was never really documented, so there are
 good chances that only a few users were using it.
 
 [mapper converters]: ../how-to/convert-input.md
+
+### Add `@pure` markers to `MapperBuilder` and `NormalizerBuilder` methods
+
+The `@pure` annotations were removed in a previous commit for the following
+reasons:
+
+> Due to the current overhead required to make PHPStan and Psalm work with the
+> pure feature, these requirements have been removed.
+>
+> Since PHPStan and Psalm are unfortunately unable to automatically detect
+> whether callable values provided to `MapperBuilder` are pure, users are forced
+> to manually add `@pure` annotations.
+>
+> This decision aims to strike a fair balance between the library's strictness
+> and user experience.
+
+After a discussion with `@pure` aficionados, the decision has been made to
+re-introduce them. This time, is is possible to easily suppress the errors
+reported by PHPStan and Psalm by using plugins provided out of the box by this
+library.
+
+To globally suppress these errors in PHPStan, the following line must be added
+to `phpstan.neon`:
+
+```yaml
+includes:
+    - vendor/cuyz/valinor/qa/PHPStan/valinor-phpstan-suppress-pure-errors.php
+```
+
+To globally suppress these errors in Psalm, the following line must be added to
+`psalm.xml`:
+
+```xml
+
+<xi:include href="qa/Psalm/valinor-psalm-suppress-pure-errors.xml"
+            xmlns:xi="http://www.w3.org/2001/XInclude"/>
+```
 
 ### Removed classes and interfaces
 

--- a/docs/pages/project/upgrading.md
+++ b/docs/pages/project/upgrading.md
@@ -2,6 +2,18 @@
 
 ## Upgrade from 1.x to 2.x
 
+**Summary**
+
+- [TL;DR — Full list of breaking changes](#full-list-of-breaking-changes)
+- [Changes to messages/errors handling](#changes-to-messageserrors-handling)
+- [Changes to messages codes](#changes-to-messages-codes)
+- [Introduced `NormalizerBuilder` as the main entry for normalizers](#introduced-normalizerbuilder-as-the-main-entry-for-normalizers)
+- [Removed Simple Cache (PSR-16) handling](#removed-simple-cache-psr-16-handling)
+- [Removed `MapperBuilder::enableFlexibleCasting()`](#removed-mapperbuilderenableflexiblecasting)
+- [Removed `MapperBuilder::alter()`](#removed-mapperbuilderalter)
+- [Removed classes and interfaces](#removed-classes-and-interfaces)
+- [Class constructors marked as `@internal`](#class-constructors-marked-as-internal)
+
 ### Changes to messages/errors handling
 
 Some changes have been made to the way messages and errors are handled.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,6 @@
 includes:
     - qa/PHPStan/valinor-phpstan-configuration.php
+    - qa/PHPStan/valinor-phpstan-suppress-pure-errors.php
     - vendor/phpstan/phpstan-strict-rules/rules.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
 
@@ -24,6 +25,19 @@ parameters:
         - '#Construct empty\(\) is not allowed\. Use more strict comparison\.#'
 
         - '#Method [\w\\:]+_data_provider\(\) return type has no value type specified in iterable type#'
+
+        # Although PHPStan has a quite strong purity inferring mechanism, some
+        # caveats remain and make it really hard to properly add `@pure` markers
+        # all over the codebase. For this reason, we suppress these errors.
+        -
+            identifier: possiblyImpure.functionCall
+        -
+            identifier: possiblyImpure.methodCall
+        -
+            identifier: possiblyImpure.new
+        -
+            identifier: impure.functionCall
+
 
     stubFiles:
         - qa/PHPStan/Stubs/vfs/vfsStreamAbstractContent.stub

--- a/qa/PHPStan/Extension/SuppressPureErrors.php
+++ b/qa/PHPStan/Extension/SuppressPureErrors.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\QA\PHPStan\Extension;
+
+use CuyZ\Valinor\MapperBuilder;
+use CuyZ\Valinor\NormalizerBuilder;
+use PhpParser\Node;
+use PHPStan\Analyser\Error;
+use PHPStan\Analyser\IgnoreErrorExtension;
+use PHPStan\Analyser\Scope;
+
+use function array_find;
+use function in_array;
+
+/**
+ * This extension should not be used by default, as it suppresses errors that
+ * are typically indicative of purity issues in the codebase. It is advised to
+ * first address the root causes of these errors before enabling this extension.
+ *
+ * When enabled, it will ignore all purity-related errors of method calls in the
+ * context of `MapperBuilder` and `NormalizerBuilder`.
+ */
+final class SuppressPureErrors implements IgnoreErrorExtension
+{
+    public function shouldIgnore(Error $error, Node $node, Scope $scope): bool
+    {
+        if ($error->getIdentifier() !== 'argument.type') {
+            return false;
+        }
+
+        if (! $node instanceof Node\Expr\MethodCall) {
+            return false;
+        }
+
+        $type = $scope->getType($node->var);
+
+        if (! $type->isObject()->yes()) {
+            return false;
+        }
+
+        if (! array_find($type->getObjectClassNames(), fn (string $className) => $className === MapperBuilder::class || $className === NormalizerBuilder::class)) {
+            return false;
+        }
+
+        if (! $node->name instanceof Node\Identifier) {
+            return false;
+        }
+
+        $methodName = $node->name->toString();
+
+        if (! in_array($methodName, [
+            'infer',
+            'registerConstructor',
+            'registerConverter',
+            'registerTransformer',
+        ], true)) {
+            return false;
+        }
+
+        if ($node->args === []) {
+            return false;
+        }
+
+        $callableArgumentIndex = [
+            'infer' => 1,
+            'registerConstructor' => 0,
+            'registerConverter' => 0,
+            'registerTransformer' => 0,
+        ][$methodName];
+
+        $argument = $node->args[$callableArgumentIndex];
+
+        if (! $argument instanceof Node\Arg) {
+            return false;
+        }
+
+        $argumentType = $scope->getType($argument->value);
+
+        if ($argumentType->isCallable()->yes()) {
+            return true;
+        }
+
+        if ($argumentType->isArray()->yes() && $argumentType->getIterableValueType()->isCallable()->yes()) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/qa/PHPStan/valinor-phpstan-suppress-pure-errors.php
+++ b/qa/PHPStan/valinor-phpstan-suppress-pure-errors.php
@@ -1,0 +1,14 @@
+<?php
+
+use CuyZ\Valinor\QA\PHPStan\Extension\SuppressPureErrors;
+
+require_once 'Extension/SuppressPureErrors.php';
+
+return [
+    'services' => [
+        [
+            'class' => SuppressPureErrors::class,
+            'tags' => ['phpstan.ignoreErrorExtension'],
+        ],
+    ],
+];

--- a/qa/Psalm/valinor-psalm-suppress-pure-errors.xml
+++ b/qa/Psalm/valinor-psalm-suppress-pure-errors.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issueHandlers xmlns="https://getpsalm.org/schema/config">
+    <InvalidArgument>
+        <errorLevel type="suppress">
+            <referencedFunction name="CuyZ\Valinor\NormalizerBuilder::registerTransformer"/>
+            <referencedFunction name="\CuyZ\Valinor\MapperBuilder::infer"/>
+            <referencedFunction name="\CuyZ\Valinor\MapperBuilder::registerConstructor"/>
+            <referencedFunction name="\CuyZ\Valinor\MapperBuilder::registerConverter"/>
+        </errorLevel>
+    </InvalidArgument>
+</issueHandlers>

--- a/src/Mapper/ArgumentsMapper.php
+++ b/src/Mapper/ArgumentsMapper.php
@@ -8,6 +8,8 @@ namespace CuyZ\Valinor\Mapper;
 interface ArgumentsMapper
 {
     /**
+     * @pure
+     *
      * @return array<string, mixed>
      *
      * @throws MappingError

--- a/src/Mapper/TreeMapper.php
+++ b/src/Mapper/TreeMapper.php
@@ -8,6 +8,8 @@ namespace CuyZ\Valinor\Mapper;
 interface TreeMapper
 {
     /**
+     * @pure
+     *
      * @template T of object
      *
      * @param string|class-string<T> $signature

--- a/src/Mapper/TypeArgumentsMapper.php
+++ b/src/Mapper/TypeArgumentsMapper.php
@@ -25,6 +25,9 @@ final class TypeArgumentsMapper implements ArgumentsMapper
         private Settings $settings,
     ) {}
 
+    /**
+     * @pure
+     */
     public function mapArguments(callable $callable, mixed $source): array
     {
         $function = $this->functionDefinitionRepository->for($callable);

--- a/src/Mapper/TypeTreeMapper.php
+++ b/src/Mapper/TypeTreeMapper.php
@@ -22,6 +22,9 @@ final class TypeTreeMapper implements TreeMapper
         private Settings $settings,
     ) {}
 
+    /**
+     * @pure
+     */
     public function map(string $signature, mixed $source): mixed
     {
         try {

--- a/src/MapperBuilder.php
+++ b/src/MapperBuilder.php
@@ -35,6 +35,9 @@ final class MapperBuilder
      * using the given source. These arguments can then be used to decide which
      * implementation should be used.
      *
+     * The callback *must* be pure, its output must be deterministic.
+     * @see https://en.wikipedia.org/wiki/Pure_function
+     *
      * Example:
      *
      * ```php
@@ -53,6 +56,7 @@ final class MapperBuilder
      * ```
      *
      * @param interface-string|class-string $name
+     * @param pure-callable $callback
      */
     public function infer(string $name, callable $callback): self
     {
@@ -198,7 +202,10 @@ final class MapperBuilder
      *     ]);
      * ```
      *
-     * @param callable|class-string ...$constructors
+     * The constructor *must* be pure, its output must be deterministic.
+     * @see https://en.wikipedia.org/wiki/Pure_function
+     *
+     * @param pure-callable|class-string ...$constructors
      */
     public function registerConstructor(callable|string ...$constructors): self
     {
@@ -474,6 +481,11 @@ final class MapperBuilder
      *     ->mapper()
      *     ->map('string', 'hello world'); // 'HELLO WORLD?!'
      * ```
+     *
+     * The converter *must* be pure, its output must be deterministic.
+     * @see https://en.wikipedia.org/wiki/Pure_function
+     *
+     * @param pure-callable $converter
      */
     public function registerConverter(callable $converter, int $priority = 0): self
     {

--- a/src/Normalizer/ArrayNormalizer.php
+++ b/src/Normalizer/ArrayNormalizer.php
@@ -21,6 +21,9 @@ final class ArrayNormalizer implements Normalizer
         private Transformer $transformer,
     ) {}
 
+    /**
+     * @pure
+     */
     public function normalize(mixed $value): mixed
     {
         /** @var array<mixed>|scalar|null */

--- a/src/Normalizer/JsonNormalizer.php
+++ b/src/Normalizer/JsonNormalizer.php
@@ -102,6 +102,9 @@ final class JsonNormalizer implements Normalizer
         return new self($this->transformer, $options);
     }
 
+    /**
+     * @pure
+     */
     public function normalize(mixed $value): string
     {
         $result = $this->transformer->transform($value);

--- a/src/Normalizer/Normalizer.php
+++ b/src/Normalizer/Normalizer.php
@@ -19,6 +19,7 @@ interface Normalizer
      * a data format (JSON, CSV, XML, etc.). The normalizer will take care of
      * recursively transforming the data into a format that can be serialized.
      *
+     * @pure
      * @return T
      */
     public function normalize(mixed $value): mixed;

--- a/src/Normalizer/StreamNormalizer.php
+++ b/src/Normalizer/StreamNormalizer.php
@@ -22,6 +22,9 @@ final class StreamNormalizer implements Normalizer
         private JsonFormatter $formatter,
     ) {}
 
+    /**
+     * @pure
+     */
     public function normalize(mixed $value): mixed
     {
         $result = $this->transformer->transform($value);

--- a/src/NormalizerBuilder.php
+++ b/src/NormalizerBuilder.php
@@ -114,7 +114,10 @@ final class NormalizerBuilder
      *     ->normalize('Hello world'); // HELLO WORLD?!
      * ```
      *
-     * @param callable|class-string $transformer
+     * The transformer *must* be pure, its output must be deterministic.
+     * @see https://en.wikipedia.org/wiki/Pure_function
+     *
+     * @param pure-callable|class-string $transformer
      */
     public function registerTransformer(callable|string $transformer, int $priority = 0): self
     {


### PR DESCRIPTION
The `@pure` annotations were removed in the previous commit b15d1a50c3783b47b743385431899f2696ffebd6 for the following reasons:

> Due to the current overhead required to make PHPStan and Psalm work
> with the pure feature, these requirements have been removed.
>
> Since PHPStan and Psalm are unfortunately unable to automatically
> detect whether callable values provided to `MapperBuilder` are pure,
> users are forced to manually add `@pure` annotations.
>
> This decision aims to strike a fair balance between the library's
> strictness and user experience.

After a discussion with `@pure` aficionados, the decision has been made to re-introduce them. This time, is is possible to easily suppress the errors reported by PHPStan and Psalm by using plugins provided out of the box by this library.

To globally suppress these errors in PHPStan, the following line must be added to `phpstan.neon`:

```yaml
includes:
    - vendor/cuyz/valinor/qa/PHPStan/valinor-phpstan-suppress-pure-errors.php
```

To globally suppress these errors in Psalm, the following line must be added to `psalm.xml`:

```xml
<xi:include href="qa/Psalm/valinor-psalm-suppress-pure-errors.xml"
            xmlns:xi="http://www.w3.org/2001/XInclude" />
```