### PR TITLE
misc: mark exception as `@internal`

### DIFF
--- a/src/Mapper/Tree/Exception/ValueConverterHasNoArgument.php
+++ b/src/Mapper/Tree/Exception/ValueConverterHasNoArgument.php
@@ -7,7 +7,7 @@ namespace CuyZ\Valinor\Mapper\Tree\Exception;
 use CuyZ\Valinor\Definition\FunctionDefinition;
 use RuntimeException;
 
-/** @api */
+/** @internal */
 final class ValueConverterHasNoArgument extends RuntimeException
 {
     public function __construct(FunctionDefinition $function)


### PR DESCRIPTION
This was a mistake made during the creation of the exception.