### PR TITLE
fix: properly extract `=` token when reading types

### DIFF
--- a/src/Type/Parser/Lexer/TokensExtractor.php
+++ b/src/Type/Parser/Lexer/TokensExtractor.php
@@ -27,6 +27,7 @@ final class TokensExtractor
         'Opening curly bracket' => '\{',
         'Closing curly bracket' => '\}',
         'Colon' => '\:',
+        'Equal' => '=',
         'Question mark' => '\?',
         'Comma' => ',',
         'Single quote' => "'",

--- a/tests/Functional/Definition/Repository/Reflection/TypeResolver/ClassLocalTypeAliasResolverTest.php
+++ b/tests/Functional/Definition/Repository/Reflection/TypeResolver/ClassLocalTypeAliasResolverTest.php
@@ -48,6 +48,18 @@ final class ClassLocalTypeAliasResolverTest extends TestCase
         yield 'PHPStan alias' => [
             'className' => (
                 /**
+                 * @phpstan-type PhpStanNonEmptyStringAlias=non-empty-string
+                 */
+                new class () {}
+            )::class,
+            [
+                'PhpStanNonEmptyStringAlias' => 'non-empty-string',
+            ]
+        ];
+
+        yield 'PHPStan alias with spaces between equal sign' => [
+            'className' => (
+                /**
                  * @phpstan-type PhpStanNonEmptyStringAlias = non-empty-string
                  */
                 new class () {}
@@ -58,6 +70,18 @@ final class ClassLocalTypeAliasResolverTest extends TestCase
         ];
 
         yield 'Psalm alias' => [
+            'className' => (
+                /**
+                 * @phpstan-type PsalmNonEmptyStringAlias=non-empty-string
+                 */
+                new class () {}
+            )::class,
+            [
+                'PsalmNonEmptyStringAlias' => 'non-empty-string',
+            ]
+        ];
+
+        yield 'Psalm alias with spaces between equal sign' => [
             'className' => (
                 /**
                  * @phpstan-type PsalmNonEmptyStringAlias = non-empty-string


### PR DESCRIPTION
Fixes #650