### PR TITLE
misc: exclude unneeded methods when building class definition

### DIFF
--- a/tests/Fixture/Object/AbstractObjectWithInterface.php
+++ b/tests/Fixture/Object/AbstractObjectWithInterface.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Fixture\Object;
 
+use CuyZ\Valinor\Mapper\Object\Constructor;
+
 abstract class AbstractObjectWithInterface implements \JsonSerializable
 {
+    #[Constructor]
     public static function of(AbstractObjectWithInterface $value): void {}
 }

--- a/tests/Functional/Definition/Repository/Cache/Compiler/ClassDefinitionCompilerTest.php
+++ b/tests/Functional/Definition/Repository/Cache/Compiler/ClassDefinitionCompilerTest.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Definition\ClassDefinition;
 use CuyZ\Valinor\Definition\Repository\Cache\Compiler\ClassDefinitionCompiler;
 use CuyZ\Valinor\Definition\Repository\ClassDefinitionRepository;
 use CuyZ\Valinor\Definition\Repository\Reflection\ReflectionClassDefinitionRepository;
+use CuyZ\Valinor\Mapper\Object\Constructor;
 use CuyZ\Valinor\Tests\Fake\Definition\FakeClassDefinition;
 use CuyZ\Valinor\Tests\Fixture\Object\StringableObject;
 use CuyZ\Valinor\Type\Parser\Factory\LexingTypeParserFactory;
@@ -42,11 +43,13 @@ final class ClassDefinitionCompilerTest extends TestCase
             new class () {
                 public string $property = 'Some property default value';
 
+                #[Constructor]
                 public static function method(string $parameter = 'Some parameter default value', string ...$variadic): string
                 {
                     return $parameter . implode(' / ', $variadic);
                 }
 
+                #[Constructor]
                 public static function methodWithDefaultObjectValue(StringableObject $object = new StringableObject('bar')): StringableObject
                 {
                     return $object;


### PR DESCRIPTION
When building class definitions, only methods that will be used by the library are now included.

This change aims to increase performance when working with classes that declare a lot of methods that have no value in Valinor's definitions, for instance `\Carbon\Carbon`.

Fixes #667