### PR TITLE
misc: add missing `@pure` annotations

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -37,6 +37,8 @@ parameters:
             identifier: possiblyImpure.new
         -
             identifier: impure.functionCall
+        -
+            identifier: impure.propertyAssign
 
 
     stubFiles:

--- a/src/Library/Settings.php
+++ b/src/Library/Settings.php
@@ -38,6 +38,7 @@ final class Settings
     /** @var list<callable> */
     public array $customConstructors = [];
 
+    /** @pure */
     public Cache $cache;
 
     /** @var non-empty-list<non-empty-string> */

--- a/src/Mapper/MappingError.php
+++ b/src/Mapper/MappingError.php
@@ -12,16 +12,22 @@ interface MappingError extends Throwable
 {
     /**
      * Container for all messages that were caught during the mapping process.
+     *
+     * @pure
      */
     public function messages(): Messages;
 
     /**
      * Returns the original type that the mapper was attempting to map to.
+     *
+     * @pure
      */
     public function type(): string;
 
     /**
      * Returns the original source value given to the mapper.
+     *
+     * @pure
      */
     public function source(): mixed;
 }

--- a/src/Mapper/Source/Source.php
+++ b/src/Mapper/Source/Source.php
@@ -24,6 +24,7 @@ final class Source implements IteratorAggregate
     ) {}
 
     /**
+     * @pure
      * @param iterable<mixed> $data
      */
     public static function iterable(iterable $data): Source
@@ -32,6 +33,7 @@ final class Source implements IteratorAggregate
     }
 
     /**
+     * @pure
      * @param array<mixed> $data
      */
     public static function array(array $data): Source
@@ -40,6 +42,7 @@ final class Source implements IteratorAggregate
     }
 
     /**
+     * @pure
      * @throws InvalidSource
      */
     public static function json(string $jsonSource): Source
@@ -48,6 +51,7 @@ final class Source implements IteratorAggregate
     }
 
     /**
+     * @pure
      * @throws InvalidSource
      */
     public static function yaml(string $yamlSource): Source
@@ -55,17 +59,20 @@ final class Source implements IteratorAggregate
         return new Source(new YamlSource($yamlSource));
     }
 
+    /** @pure */
     public static function file(SplFileObject $file): Source
     {
         return new Source(new FileSource($file));
     }
 
+    /** @pure */
     public function camelCaseKeys(): Source
     {
         return new Source(new CamelCaseKeys($this));
     }
 
     /**
+     * @pure
      * @param array<string> $map
      */
     public function map(array $map): Source

--- a/src/Mapper/Tree/Message/Formatter/AggregateMessageFormatter.php
+++ b/src/Mapper/Tree/Message/Formatter/AggregateMessageFormatter.php
@@ -17,6 +17,7 @@ final class AggregateMessageFormatter implements MessageFormatter
         $this->formatters = $formatters;
     }
 
+    /** @pure */
     public function format(NodeMessage $message): NodeMessage
     {
         foreach ($this->formatters as $formatter) {

--- a/src/Mapper/Tree/Message/Formatter/CallbackMessageFormatter.php
+++ b/src/Mapper/Tree/Message/Formatter/CallbackMessageFormatter.php
@@ -40,6 +40,7 @@ final class CallbackMessageFormatter implements MessageFormatter
         $this->callback = $callback;
     }
 
+    /** @pure */
     public function format(NodeMessage $message): NodeMessage
     {
         return ($this->callback)($message);

--- a/src/Mapper/Tree/Message/Formatter/LocaleMessageFormatter.php
+++ b/src/Mapper/Tree/Message/Formatter/LocaleMessageFormatter.php
@@ -11,6 +11,7 @@ final class LocaleMessageFormatter implements MessageFormatter
 {
     public function __construct(private string $locale) {}
 
+    /** @pure */
     public function format(NodeMessage $message): NodeMessage
     {
         return $message->withLocale($this->locale);

--- a/src/Mapper/Tree/Message/Formatter/MessageFormatter.php
+++ b/src/Mapper/Tree/Message/Formatter/MessageFormatter.php
@@ -9,5 +9,6 @@ use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
 /** @api */
 interface MessageFormatter
 {
+    /** @pure */
     public function format(NodeMessage $message): NodeMessage;
 }

--- a/src/Mapper/Tree/Message/Formatter/MessageMapFormatter.php
+++ b/src/Mapper/Tree/Message/Formatter/MessageMapFormatter.php
@@ -69,6 +69,7 @@ final class MessageMapFormatter implements MessageFormatter
         private array $map
     ) {}
 
+    /** @pure */
     public function format(NodeMessage $message): NodeMessage
     {
         $target = $this->target($message);

--- a/src/Mapper/Tree/Message/Formatter/TranslationMessageFormatter.php
+++ b/src/Mapper/Tree/Message/Formatter/TranslationMessageFormatter.php
@@ -35,6 +35,8 @@ final class TranslationMessageFormatter implements MessageFormatter
      *     'Valeur invalide {source_value}.',
      * );
      * ```
+     *
+     * @pure
      */
     public function withTranslation(string $locale, string $original, string $translation): self
     {
@@ -64,6 +66,7 @@ final class TranslationMessageFormatter implements MessageFormatter
      * $message = $formatter->format($message);
      * ```
      *
+     * @pure
      * @param array<string, array<string, string>> $translations
      */
     public function withTranslations(array $translations): self
@@ -75,6 +78,7 @@ final class TranslationMessageFormatter implements MessageFormatter
         return $clone;
     }
 
+    /** @pure */
     public function format(NodeMessage $message): NodeMessage
     {
         $body = $this->translations[$message->body()][$message->locale()] ?? null;

--- a/src/Mapper/Tree/Message/HasCode.php
+++ b/src/Mapper/Tree/Message/HasCode.php
@@ -12,5 +12,6 @@ namespace CuyZ\Valinor\Mapper\Tree\Message;
  */
 interface HasCode extends Message
 {
+    /** @pure */
     public function code(): string;
 }

--- a/src/Mapper/Tree/Message/HasParameters.php
+++ b/src/Mapper/Tree/Message/HasParameters.php
@@ -40,6 +40,7 @@ namespace CuyZ\Valinor\Mapper\Tree\Message;
 interface HasParameters extends Message
 {
     /**
+     * @pure
      * @return array<string, string>
      */
     public function parameters(): array;

--- a/src/Mapper/Tree/Message/Message.php
+++ b/src/Mapper/Tree/Message/Message.php
@@ -7,5 +7,6 @@ namespace CuyZ\Valinor\Mapper\Tree\Message;
 /** @api */
 interface Message
 {
+    /** @pure */
     public function body(): string;
 }

--- a/src/Mapper/Tree/Message/MessageBuilder.php
+++ b/src/Mapper/Tree/Message/MessageBuilder.php
@@ -33,6 +33,7 @@ final class MessageBuilder
     private function __construct(private string $body) {}
 
     /**
+     * @pure
      * @return self<Message>
      */
     public static function new(string $body): self
@@ -41,6 +42,7 @@ final class MessageBuilder
     }
 
     /**
+     * @pure
      * @return self<ErrorMessage&Throwable>
      */
     public static function newError(string $body): self
@@ -52,6 +54,7 @@ final class MessageBuilder
         return $instance;
     }
 
+    /** @pure */
     public static function from(Throwable $error): ErrorMessage
     {
         if ($error instanceof ErrorMessage) {
@@ -64,6 +67,7 @@ final class MessageBuilder
     }
 
     /**
+     * @pure
      * @return self<MessageType>
      */
     public function withBody(string $body): self
@@ -74,12 +78,14 @@ final class MessageBuilder
         return $clone;
     }
 
+    /** @pure */
     public function body(): string
     {
         return $this->body;
     }
 
     /**
+     * @pure
      * @return self<MessageType>
      */
     public function withCode(string $code): self
@@ -90,12 +96,14 @@ final class MessageBuilder
         return $clone;
     }
 
+    /** @pure */
     public function code(): string
     {
         return $this->code;
     }
 
     /**
+     * @pure
      * @return self<MessageType>
      */
     public function withParameter(string $name, string $value): self
@@ -107,6 +115,7 @@ final class MessageBuilder
     }
 
     /**
+     * @pure
      * @return array<string, string>
      */
     public function parameters(): array
@@ -115,6 +124,7 @@ final class MessageBuilder
     }
 
     /**
+     * @pure
      * @return MessageType&HasCode&HasParameters
      */
     public function build(): Message&HasCode&HasParameters

--- a/src/Mapper/Tree/Message/Messages.php
+++ b/src/Mapper/Tree/Message/Messages.php
@@ -65,6 +65,7 @@ final class Messages implements IteratorAggregate, Countable
         $this->messages = $messages;
     }
 
+    /** @pure */
     public function errors(): self
     {
         $clone = clone $this;
@@ -73,6 +74,7 @@ final class Messages implements IteratorAggregate, Countable
         return $clone;
     }
 
+    /** @pure */
     public function formatWith(MessageFormatter ...$formatters): self
     {
         $clone = clone $this;
@@ -82,6 +84,7 @@ final class Messages implements IteratorAggregate, Countable
     }
 
     /**
+     * @pure
      * @return list<NodeMessage>
      */
     public function toArray(): array
@@ -90,6 +93,7 @@ final class Messages implements IteratorAggregate, Countable
         return iterator_to_array($this);
     }
 
+    /** @pure */
     public function count(): int
     {
         return count($this->messages);

--- a/src/Mapper/Tree/Message/NodeMessage.php
+++ b/src/Mapper/Tree/Message/NodeMessage.php
@@ -30,6 +30,7 @@ final class NodeMessage implements Message, HasCode, Stringable
         private string $sourceValue,
     ) {}
 
+    /** @pure */
     public function withLocale(string $locale): self
     {
         $clone = clone $this;
@@ -38,6 +39,7 @@ final class NodeMessage implements Message, HasCode, Stringable
         return $clone;
     }
 
+    /** @pure */
     public function locale(): string
     {
         return $this->locale;
@@ -61,6 +63,8 @@ final class NodeMessage implements Message, HasCode, Stringable
      * ```php
      * $message = $message->withBody('new message for value: {source_value}');
      * ```
+     *
+     * @pure
      */
     public function withBody(string $body): self
     {
@@ -70,26 +74,31 @@ final class NodeMessage implements Message, HasCode, Stringable
         return $clone;
     }
 
+    /** @pure */
     public function body(): string
     {
         return $this->body;
     }
 
+    /** @pure */
     public function name(): string
     {
         return $this->name;
     }
 
+    /** @pure */
     public function path(): string
     {
         return $this->path;
     }
 
+    /** @pure */
     public function type(): string
     {
         return $this->type;
     }
 
+    /** @pure */
     public function sourceValue(): string
     {
         return $this->sourceValue;
@@ -99,6 +108,8 @@ final class NodeMessage implements Message, HasCode, Stringable
      * Adds a parameter that can replace a placeholder in the message body.
      *
      * @see self::withBody()
+     *
+     * @pure
      */
     public function withParameter(string $name, string $value): self
     {
@@ -108,16 +119,19 @@ final class NodeMessage implements Message, HasCode, Stringable
         return $clone;
     }
 
+    /** @pure */
     public function originalMessage(): Message
     {
         return $this->message;
     }
 
+    /** @pure */
     public function isError(): bool
     {
         return $this->message instanceof ErrorMessage;
     }
 
+    /** @pure */
     public function code(): string
     {
         if ($this->message instanceof HasCode) {
@@ -131,17 +145,20 @@ final class NodeMessage implements Message, HasCode, Stringable
         return 'unknown';
     }
 
+    /** @pure */
     public function toString(): string
     {
         return $this->format($this->body, $this->parameters());
     }
 
+    /** @pure */
     public function __toString(): string
     {
         return $this->toString();
     }
 
     /**
+     * @pure
      * @param array<string, string> $parameters
      */
     private function format(string $body, array $parameters): string

--- a/src/Mapper/TypeArgumentsMapper.php
+++ b/src/Mapper/TypeArgumentsMapper.php
@@ -25,9 +25,7 @@ final class TypeArgumentsMapper implements ArgumentsMapper
         private Settings $settings,
     ) {}
 
-    /**
-     * @pure
-     */
+    /** @pure */
     public function mapArguments(callable $callable, mixed $source): array
     {
         $function = $this->functionDefinitionRepository->for($callable);

--- a/src/Mapper/TypeTreeMapper.php
+++ b/src/Mapper/TypeTreeMapper.php
@@ -22,9 +22,7 @@ final class TypeTreeMapper implements TreeMapper
         private Settings $settings,
     ) {}
 
-    /**
-     * @pure
-     */
+    /** @pure */
     public function map(string $signature, mixed $source): mixed
     {
         try {

--- a/src/MapperBuilder.php
+++ b/src/MapperBuilder.php
@@ -55,6 +55,7 @@ final class MapperBuilder
      *     ]);
      * ```
      *
+     * @pure
      * @param interface-string|class-string $name
      * @param pure-callable $callback
      */
@@ -205,6 +206,7 @@ final class MapperBuilder
      * The constructor *must* be pure, its output must be deterministic.
      * @see https://en.wikipedia.org/wiki/Pure_function
      *
+     * @pure
      * @param pure-callable|class-string ...$constructors
      */
     public function registerConstructor(callable|string ...$constructors): self
@@ -236,6 +238,7 @@ final class MapperBuilder
      *     ->map(DateTimeInterface::class, 'Monday, 08-Nov-1971 13:37:42 UTC');
      * ```
      *
+     * @pure
      * @param non-empty-string $format
      * @param non-empty-string ...$formats
      */
@@ -253,6 +256,7 @@ final class MapperBuilder
      * By default, any valid timestamp or RFC 3339-formatted value are accepted.
      * Custom formats can be set using method `supportDateFormats()`.
      *
+     * @pure
      * @return non-empty-array<non-empty-string>
      */
     public function supportedDateFormats(): array
@@ -288,6 +292,8 @@ final class MapperBuilder
      *         // …
      *     ]);
      * ```
+     *
+     * @pure
      */
     public function withCache(Cache $cache): self
     {
@@ -323,6 +329,8 @@ final class MapperBuilder
      *         'active' => 1, // Will be cast to bool
      *     ]);
      * ```
+     *
+     * @pure
      */
     public function allowScalarValueCasting(): self
     {
@@ -349,6 +357,8 @@ final class MapperBuilder
      *
      * // => [0 => 42, 1 => 1337]
      * ```
+     *
+     * @pure
      */
     public function allowNonSequentialList(): self
     {
@@ -374,6 +384,8 @@ final class MapperBuilder
      *
      * // => ['name' => 'John Doe', 'age' => null]
      * ```
+     *
+     * @pure
      */
     public function allowUndefinedValues(): self
     {
@@ -399,6 +411,8 @@ final class MapperBuilder
      *         'city' => 'Paris', // Will be ignored
      *     ]);
      * ```
+     *
+     * @pure
      */
     public function allowSuperfluousKeys(): self
     {
@@ -420,6 +434,8 @@ final class MapperBuilder
      *         'data' => 42, // Could be any value
      *     ]);
      * ```
+     *
+     * @pure
      */
     public function allowPermissiveTypes(): self
     {
@@ -519,6 +535,7 @@ final class MapperBuilder
      * The converter *must* be pure, its output must be deterministic.
      * @see https://en.wikipedia.org/wiki/Pure_function
      *
+     * @pure
      * @param pure-callable|class-string $converter
      */
     public function registerConverter(callable|string $converter, int $priority = 0): self
@@ -567,6 +584,7 @@ final class MapperBuilder
      *     ]);
      * ```
      *
+     * @pure
      * @param callable(Throwable): ErrorMessage $filter
      */
     public function filterExceptions(callable $filter): self
@@ -623,11 +641,13 @@ final class MapperBuilder
         $this->settings->cache->clear();
     }
 
+    /** @pure */
     public function mapper(): TreeMapper
     {
         return $this->container()->treeMapper();
     }
 
+    /** @pure */
     public function argumentsMapper(): ArgumentsMapper
     {
         return $this->container()->argumentsMapper();

--- a/src/Normalizer/ArrayNormalizer.php
+++ b/src/Normalizer/ArrayNormalizer.php
@@ -21,9 +21,7 @@ final class ArrayNormalizer implements Normalizer
         private Transformer $transformer,
     ) {}
 
-    /**
-     * @pure
-     */
+    /** @pure */
     public function normalize(mixed $value): mixed
     {
         /** @var array<mixed>|scalar|null */

--- a/src/Normalizer/Format.php
+++ b/src/Normalizer/Format.php
@@ -45,6 +45,7 @@ final class Format
      * // ];
      * ```
      *
+     * @pure
      * @return self<ArrayNormalizer>
      */
     public static function array(): self
@@ -76,6 +77,7 @@ final class Format
      * // {"name":"John Doe","age":42,"country":{"name":"France","code":"FR"}}
      * ```
      *
+     * @pure
      * @return self<JsonNormalizer>
      */
     public static function json(): self
@@ -89,6 +91,7 @@ final class Format
     private function __construct(private string $type) {}
 
     /**
+     * @pure
      * @return class-string<T>
      */
     public function type(): string

--- a/src/Normalizer/JsonNormalizer.php
+++ b/src/Normalizer/JsonNormalizer.php
@@ -96,15 +96,15 @@ final class JsonNormalizer implements Normalizer
      * // `$lowerManhattanAsJson` is a valid JSON string representing the data:
      * // {"longitude":40.7128,"latitude":-74.0000}
      * ```
+     *
+     * @pure
      */
     public function withOptions(int $options): self
     {
         return new self($this->transformer, $options);
     }
 
-    /**
-     * @pure
-     */
+    /** @pure */
     public function normalize(mixed $value): string
     {
         $result = $this->transformer->transform($value);
@@ -150,6 +150,7 @@ final class JsonNormalizer implements Normalizer
      * $normalizer->normalize($users);
      * ```
      *
+     * @pure
      * @param resource $resource
      */
     public function streamTo(mixed $resource): StreamNormalizer

--- a/src/Normalizer/StreamNormalizer.php
+++ b/src/Normalizer/StreamNormalizer.php
@@ -22,9 +22,7 @@ final class StreamNormalizer implements Normalizer
         private JsonFormatter $formatter,
     ) {}
 
-    /**
-     * @pure
-     */
+    /** @pure */
     public function normalize(mixed $value): mixed
     {
         $result = $this->transformer->transform($value);

--- a/src/NormalizerBuilder.php
+++ b/src/NormalizerBuilder.php
@@ -48,6 +48,8 @@ final class NormalizerBuilder
      *     ->normalizer(\CuyZ\Valinor\Normalizer\Format::json())
      *     ->normalize($someData);
      * ```
+     *
+     * @pure
      */
     public function withCache(Cache $cache): self
     {
@@ -117,6 +119,7 @@ final class NormalizerBuilder
      * The transformer *must* be pure, its output must be deterministic.
      * @see https://en.wikipedia.org/wiki/Pure_function
      *
+     * @pure
      * @param pure-callable|class-string $transformer
      */
     public function registerTransformer(callable|string $transformer, int $priority = 0): self
@@ -146,6 +149,8 @@ final class NormalizerBuilder
     }
 
     /**
+     * @pure
+     *
      * @template T of Normalizer
      *
      * @param Format<T> $format

--- a/tests/Integration/Cache/CacheClearTest.php
+++ b/tests/Integration/Cache/CacheClearTest.php
@@ -31,6 +31,7 @@ final class CacheClearTest extends IntegrationTestCase
 
         $mapperBuilder = $this->normalizerBuilder()->withCache($cache);
 
+        // @phpstan-ignore method.resultUnused
         $mapperBuilder->normalizer(Format::array())->normalize('foo');
 
         self::assertGreaterThan(0, $cache->countEntries());

--- a/tests/Integration/Normalizer/NormalizerCompiledCodeTest.php
+++ b/tests/Integration/Normalizer/NormalizerCompiledCodeTest.php
@@ -47,6 +47,7 @@ final class NormalizerCompiledCodeTest extends TestCase
             $builder = $builder->registerTransformer($transformer);
         }
 
+        // @phpstan-ignore method.resultUnused
         $builder->normalizer(Format::array())->normalize($input);
 
         $cacheFiles = glob($directory . DIRECTORY_SEPARATOR . 'transformer-*.php');

--- a/tests/Unit/Library/SettingsTest.php
+++ b/tests/Unit/Library/SettingsTest.php
@@ -21,7 +21,7 @@ final class SettingsTest extends TestCase
     {
         $settings = new Settings();
 
-        self::assertSame('e1444f06f600226026793343e0ecf6f2', $settings->hash());
+        self::assertSame('6d27310023a6a61d2f152cc17acddf46', $settings->hash());
     }
 
     public function test_settings_hash(): void
@@ -43,6 +43,6 @@ final class SettingsTest extends TestCase
         $settings->normalizerTransformers[] = [fn (mixed $value): mixed => $value];
         $settings->normalizerTransformerAttributes[stdClass::class] = null;
 
-        self::assertSame('f8446c8caa7e5c560429e691abdfdb97', $settings->hash());
+        self::assertSame('8028cb556ea668873fdeb8f25ad50ebc', $settings->hash());
     }
 }


### PR DESCRIPTION
These annotations will help codebases that use this library to properly handle purity analysis.