### PR TITLE
fix: prevent undefined object type to match invalid types

### DIFF
--- a/src/Definition/Repository/Cache/Compiler/TypeCompiler.php
+++ b/src/Definition/Repository/Cache/Compiler/TypeCompiler.php
@@ -72,7 +72,6 @@ final class TypeCompiler
             case $type instanceof NonEmptyStringType:
             case $type instanceof NumericStringType:
             case $type instanceof UndefinedObjectType:
-            case $type instanceof CallableType:
             case $type instanceof MixedType:
             case $type instanceof ScalarConcreteType:
                 return "$class::get()";
@@ -188,6 +187,14 @@ final class TypeCompiler
                 $cases = implode(', ', $cases);
 
                 return "new $class($enumName, $pattern, [$cases])";
+            case $type instanceof CallableType:
+                $returnType = $this->compile($type->returnType);
+                $parameters = implode(', ', array_map(
+                    fn (Type $subType) => $this->compile($subType),
+                    $type->parameters,
+                ));
+
+                return "new $class([$parameters], $returnType)";
             case $type instanceof UnresolvableType:
                 $raw = var_export($type->toString(), true);
                 $message = var_export($type->message(), true);

--- a/src/Mapper/Tree/Builder/ValueConverterNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ValueConverterNodeBuilder.php
@@ -20,7 +20,7 @@ use Throwable;
 use function array_map;
 use function array_shift;
 use function is_float;
-use function is_nan;
+use function is_infinite;
 
 /** @internal */
 final class ValueConverterNodeBuilder implements NodeBuilder
@@ -100,8 +100,8 @@ final class ValueConverterNodeBuilder implements NodeBuilder
             $arguments = [$shell->value()];
 
             if ($converter->parameters->count() > 1) {
-                $arguments[] = function (mixed $value = NAN) use ($stack, $shell, $rootBuilder) {
-                    if (! is_float($value) || ! is_nan($value)) {
+                $arguments[] = function (mixed $value = INF) use ($stack, $shell, $rootBuilder) {
+                    if (! is_float($value) || ! is_infinite($value)) {
                         $shell = $shell->withValue($value);
                     }
 

--- a/src/Type/Parser/Exception/Callable/ExpectedClosingParenthesisAfterCallable.php
+++ b/src/Type/Parser/Exception/Callable/ExpectedClosingParenthesisAfterCallable.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Type\Parser\Exception\Callable;
+
+use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
+use CuyZ\Valinor\Type\Type;
+use RuntimeException;
+
+/** @internal */
+final class ExpectedClosingParenthesisAfterCallable extends RuntimeException implements InvalidType
+{
+    /**
+     * @param non-empty-list<Type> $parameters
+     */
+    public function __construct(array $parameters)
+    {
+        $parameters = implode(', ', array_map(fn (Type $type) => $type->toString(), $parameters));
+
+        parent::__construct(
+            "Expected closing parenthesis after `callable($parameters`.",
+            1759257335,
+        );
+    }
+}

--- a/src/Type/Parser/Exception/Callable/ExpectedColonAfterCallableClosingParenthesis.php
+++ b/src/Type/Parser/Exception/Callable/ExpectedColonAfterCallableClosingParenthesis.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Type\Parser\Exception\Callable;
+
+use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
+use CuyZ\Valinor\Type\Type;
+use RuntimeException;
+
+/** @internal */
+final class ExpectedColonAfterCallableClosingParenthesis extends RuntimeException implements InvalidType
+{
+    /**
+     * @param list<Type> $parameters
+     */
+    public function __construct(array $parameters)
+    {
+        $parameters = implode(', ', array_map(fn (Type $type) => $type->toString(), $parameters));
+
+        parent::__construct(
+            "Expected `:` to define return type after `callable($parameters)`.",
+            1759260180,
+        );
+    }
+}

--- a/src/Type/Parser/Exception/Callable/ExpectedReturnTypeAfterCallableColon.php
+++ b/src/Type/Parser/Exception/Callable/ExpectedReturnTypeAfterCallableColon.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Type\Parser\Exception\Callable;
+
+use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
+use CuyZ\Valinor\Type\Type;
+use RuntimeException;
+
+/** @internal */
+final class ExpectedReturnTypeAfterCallableColon extends RuntimeException implements InvalidType
+{
+    /**
+     * @param list<Type> $parameters
+     */
+    public function __construct(array $parameters)
+    {
+        $parameters = implode(', ', array_map(fn (Type $type) => $type->toString(), $parameters));
+
+        parent::__construct(
+            "Expected return type after `callable($parameters):`.",
+            1759265272,
+        );
+    }
+}

--- a/src/Type/Parser/Exception/Callable/ExpectedTypeForCallable.php
+++ b/src/Type/Parser/Exception/Callable/ExpectedTypeForCallable.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Type\Parser\Exception\Callable;
+
+use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
+use RuntimeException;
+
+/** @internal */
+final class ExpectedTypeForCallable extends RuntimeException implements InvalidType
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'Expected type after `callable(`.',
+            1759257024,
+        );
+    }
+}

--- a/src/Type/Parser/Exception/Callable/UnexpectedTokenAfterCallableClosingParenthesis.php
+++ b/src/Type/Parser/Exception/Callable/UnexpectedTokenAfterCallableClosingParenthesis.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Type\Parser\Exception\Callable;
+
+use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
+use CuyZ\Valinor\Type\Parser\Lexer\Token\Token;
+use CuyZ\Valinor\Type\Type;
+use RuntimeException;
+
+/** @internal */
+final class UnexpectedTokenAfterCallableClosingParenthesis extends RuntimeException implements InvalidType
+{
+    /**
+     * @param list<Type> $parameters
+     */
+    public function __construct(array $parameters, Token $token)
+    {
+        $parameters = implode(', ', array_map(fn (Type $type) => $type->toString(), $parameters));
+
+        parent::__construct(
+            "Expected `:` to define return type after `callable($parameters)`, got `{$token->symbol()}`.",
+            1759265303,
+        );
+    }
+}

--- a/src/Type/Parser/Lexer/NativeLexer.php
+++ b/src/Type/Parser/Lexer/NativeLexer.php
@@ -9,6 +9,7 @@ use CuyZ\Valinor\Type\Parser\Lexer\Token\CallableToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\ClassStringToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\ClosingBracketToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\ClosingCurlyBracketToken;
+use CuyZ\Valinor\Type\Parser\Lexer\Token\ClosingParenthesisToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\ClosingSquareBracketToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\ColonToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\CommaToken;
@@ -21,6 +22,7 @@ use CuyZ\Valinor\Type\Parser\Lexer\Token\ListToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\NullableToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\OpeningBracketToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\OpeningCurlyBracketToken;
+use CuyZ\Valinor\Type\Parser\Lexer\Token\OpeningParenthesisToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\OpeningSquareBracketToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\StringValueToken;
 use CuyZ\Valinor\Type\Parser\Lexer\Token\Token;
@@ -59,6 +61,8 @@ final class NativeLexer implements TypeLexer
         return match (strtolower($symbol)) {
             '|' => UnionToken::get(),
             '&' => IntersectionToken::get(),
+            '(' => OpeningParenthesisToken::get(),
+            ')' => ClosingParenthesisToken::get(),
             '<' => OpeningBracketToken::get(),
             '>' => ClosingBracketToken::get(),
             '[' => OpeningSquareBracketToken::get(),

--- a/src/Type/Parser/Lexer/Token/CallableToken.php
+++ b/src/Type/Parser/Lexer/Token/CallableToken.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Parser\Lexer\Token;
 
+use CuyZ\Valinor\Type\Parser\Exception\Callable\ExpectedClosingParenthesisAfterCallable;
+use CuyZ\Valinor\Type\Parser\Exception\Callable\ExpectedColonAfterCallableClosingParenthesis;
+use CuyZ\Valinor\Type\Parser\Exception\Callable\ExpectedReturnTypeAfterCallableColon;
+use CuyZ\Valinor\Type\Parser\Exception\Callable\ExpectedTypeForCallable;
+use CuyZ\Valinor\Type\Parser\Exception\Callable\UnexpectedTokenAfterCallableClosingParenthesis;
 use CuyZ\Valinor\Type\Parser\Lexer\TokenStream;
 use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\CallableType;
@@ -16,7 +21,47 @@ final class CallableToken implements TraversingToken
 
     public function traverse(TokenStream $stream): Type
     {
-        return CallableType::get();
+        if ($stream->done() || ! $stream->next() instanceof OpeningParenthesisToken) {
+            return CallableType::default();
+        }
+
+        $stream->forward();
+
+        if ($stream->done()) {
+            throw new ExpectedTypeForCallable();
+        }
+
+        $parameters = [];
+
+        while (! $stream->next() instanceof ClosingParenthesisToken) {
+            $parameters[] = $stream->read();
+
+            if (! $stream->done() && $stream->next() instanceof CommaToken) {
+                $stream->forward();
+            }
+
+            if ($stream->done()) {
+                throw new ExpectedClosingParenthesisAfterCallable($parameters);
+            }
+        }
+
+        $stream->forward();
+
+        if ($stream->done()) {
+            throw new ExpectedColonAfterCallableClosingParenthesis($parameters);
+        }
+
+        if (! ($next = $stream->forward()) instanceof ColonToken) {
+            throw new UnexpectedTokenAfterCallableClosingParenthesis($parameters, $next);
+        }
+
+        if ($stream->done()) {
+            throw new ExpectedReturnTypeAfterCallableColon($parameters);
+        }
+
+        $returnType = $stream->read();
+
+        return new CallableType($parameters, $returnType);
     }
 
     public function symbol(): string

--- a/src/Type/Parser/Lexer/Token/ClosingParenthesisToken.php
+++ b/src/Type/Parser/Lexer/Token/ClosingParenthesisToken.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Type\Parser\Lexer\Token;
+
+use CuyZ\Valinor\Utility\IsSingleton;
+
+/** @internal */
+final class ClosingParenthesisToken implements Token
+{
+    use IsSingleton;
+
+    public function symbol(): string
+    {
+        return ')';
+    }
+}

--- a/src/Type/Parser/Lexer/Token/OpeningParenthesisToken.php
+++ b/src/Type/Parser/Lexer/Token/OpeningParenthesisToken.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Type\Parser\Lexer\Token;
+
+use CuyZ\Valinor\Utility\IsSingleton;
+
+/** @internal */
+final class OpeningParenthesisToken implements Token
+{
+    use IsSingleton;
+
+    public function symbol(): string
+    {
+        return '(';
+    }
+}

--- a/src/Type/Parser/Lexer/TokensExtractor.php
+++ b/src/Type/Parser/Lexer/TokensExtractor.php
@@ -21,6 +21,8 @@ final class TokensExtractor
         'Whitespace' => '\s+',
         'Union' => '\|',
         'Intersection' => '&',
+        'Opening parenthesis' => '\(',
+        'Closing parenthesis' => '\)',
         'Opening bracket' => '\<',
         'Closing bracket' => '\>',
         'Opening square bracket' => '\[',

--- a/src/Type/Types/UndefinedObjectType.php
+++ b/src/Type/Types/UndefinedObjectType.php
@@ -6,7 +6,6 @@ namespace CuyZ\Valinor\Type\Types;
 
 use CuyZ\Valinor\Compiler\Native\ComplianceNode;
 use CuyZ\Valinor\Compiler\Node;
-use CuyZ\Valinor\Type\ObjectType;
 use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Utility\IsSingleton;
 
@@ -34,8 +33,6 @@ final class UndefinedObjectType implements Type
         }
 
         return $other instanceof self
-            || $other instanceof ObjectType
-            || $other instanceof IntersectionType
             || $other instanceof MixedType;
     }
 

--- a/tests/Functional/Definition/Repository/Cache/Compiler/TypeCompilerTest.php
+++ b/tests/Functional/Definition/Repository/Cache/Compiler/TypeCompilerTest.php
@@ -139,7 +139,8 @@ final class TypeCompilerTest extends TestCase
         yield [new ClassStringType()];
         yield [new ClassStringType(new NativeClassType(stdClass::class))];
         yield [new ClassStringType(new InterfaceType(DateTimeInterface::class))];
-        yield [new CallableType()];
+        yield [new CallableType([new NativeStringType(), new NativeIntegerType()], NativeBooleanType::get())];
+        ;
         yield [new UnresolvableType('some-type', 'some message')];
     }
 

--- a/tests/Unit/Type/Types/UndefinedObjectTypeTest.php
+++ b/tests/Unit/Type/Types/UndefinedObjectTypeTest.php
@@ -6,11 +6,9 @@ namespace CuyZ\Valinor\Tests\Unit\Type\Types;
 
 use CuyZ\Valinor\Compiler\Compiler;
 use CuyZ\Valinor\Compiler\Node;
-use CuyZ\Valinor\Tests\Fake\Type\FakeObjectType;
 use CuyZ\Valinor\Tests\Fake\Type\FakeType;
 use CuyZ\Valinor\Tests\Traits\TestIsSingleton;
 use CuyZ\Valinor\Type\Type;
-use CuyZ\Valinor\Type\Types\IntersectionType;
 use CuyZ\Valinor\Type\Types\MixedType;
 use CuyZ\Valinor\Type\Types\UndefinedObjectType;
 use CuyZ\Valinor\Type\Types\UnionType;
@@ -60,7 +58,6 @@ final class UndefinedObjectTypeTest extends TestCase
     public function test_matches_valid_types(): void
     {
         self::assertTrue($this->undefinedObjectType->matches(new UndefinedObjectType()));
-        self::assertTrue($this->undefinedObjectType->matches(new FakeObjectType()));
     }
 
     public function test_does_not_match_other_type(): void
@@ -72,7 +69,7 @@ final class UndefinedObjectTypeTest extends TestCase
     {
         $unionType = new UnionType(
             new FakeType(),
-            new FakeObjectType(),
+            new UndefinedObjectType(),
             new FakeType(),
         );
 
@@ -84,11 +81,6 @@ final class UndefinedObjectTypeTest extends TestCase
         $unionType = new UnionType(new FakeType(), new FakeType());
 
         self::assertFalse($this->undefinedObjectType->matches($unionType));
-    }
-
-    public function test_matches_intersection_type(): void
-    {
-        self::assertTrue($this->undefinedObjectType->matches(new IntersectionType(new FakeObjectType(), new FakeObjectType())));
     }
 
     public function test_matches_mixed_type(): void


### PR DESCRIPTION
Parameters and return types are now properly parsed.