### PR TITLE
qa: include uncovered code when running Infection

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Running mutation tests
         if: github.ref == 'refs/heads/master'
-        run: php vendor/bin/infection --threads=$(nproc)
+        run: php vendor/bin/infection --threads=$(nproc) --with-uncovered
         env:
           INFECTION_BADGE_API_KEY: ${{ secrets.INFECTION_BADGE_API_KEY }}
 
@@ -47,4 +47,4 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           git fetch --depth=1 origin $GITHUB_BASE_REF
-          php vendor/bin/infection --threads=$(nproc) --git-diff-lines --git-diff-base=origin/$GITHUB_BASE_REF --logger-github --ignore-msi-with-no-mutations --min-msi=100 --show-mutations --verbose
+          php vendor/bin/infection --threads=$(nproc) --git-diff-lines --git-diff-base=origin/$GITHUB_BASE_REF --logger-github --ignore-msi-with-no-mutations --with-uncovered --min-msi=100 --show-mutations --verbose

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
             "phpunit"
         ],
         "mutation": [
-            "infection --threads=max --git-diff-lines --min-msi=100"
+            "infection --threads=max --git-diff-lines --with-uncovered --min-msi=100"
         ],
         "doc": [
             "Composer\\Config::disableProcessTimeout",


### PR DESCRIPTION
Adds the `--with-uncovered` option when running Infection.

Reference: https://github.com/infection/infection/releases/tag/0.31.0