### PR TITLE
chore: refactor class and interface mapping process

### DIFF
--- a/src/Cache/Warmup/RecursiveCacheWarmupService.php
+++ b/src/Cache/Warmup/RecursiveCacheWarmupService.php
@@ -7,7 +7,7 @@ namespace CuyZ\Valinor\Cache\Warmup;
 use CuyZ\Valinor\Cache\Exception\InvalidSignatureToWarmup;
 use CuyZ\Valinor\Definition\Repository\ClassDefinitionRepository;
 use CuyZ\Valinor\Mapper\Object\Factory\ObjectBuilderFactory;
-use CuyZ\Valinor\Mapper\Tree\Builder\ObjectImplementations;
+use CuyZ\Valinor\Mapper\Tree\Builder\InterfaceInferringContainer;
 use CuyZ\Valinor\Type\ClassType;
 use CuyZ\Valinor\Type\Parser\Exception\InvalidType;
 use CuyZ\Valinor\Type\Parser\TypeParser;
@@ -25,7 +25,7 @@ final class RecursiveCacheWarmupService
 
     public function __construct(
         private TypeParser $parser,
-        private ObjectImplementations $implementations,
+        private InterfaceInferringContainer $interfaceInferringContainer,
         private ClassDefinitionRepository $classDefinitionRepository,
         private ObjectBuilderFactory $objectBuilderFactory
     ) {}
@@ -60,11 +60,11 @@ final class RecursiveCacheWarmupService
     {
         $interfaceName = $type->className();
 
-        if (! $this->implementations->has($interfaceName)) {
+        if (! $this->interfaceInferringContainer->has($interfaceName)) {
             return;
         }
 
-        $function = $this->implementations->function($interfaceName);
+        $function = $this->interfaceInferringContainer->inferFunctionFor($interfaceName);
 
         $this->warmupType($function->returnType);
 

--- a/src/Library/Container.php
+++ b/src/Library/Container.php
@@ -38,7 +38,7 @@ use CuyZ\Valinor\Mapper\Tree\Builder\ListNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\MixedNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\NodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\NullNodeBuilder;
-use CuyZ\Valinor\Mapper\Tree\Builder\ObjectImplementations;
+use CuyZ\Valinor\Mapper\Tree\Builder\InterfaceInferringContainer;
 use CuyZ\Valinor\Mapper\Tree\Builder\ObjectNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\ScalarNodeBuilder;
 use CuyZ\Valinor\Mapper\Tree\Builder\ShapedArrayNodeBuilder;
@@ -107,19 +107,16 @@ final class Container
                     new ObjectNodeBuilder(
                         $this->get(ClassDefinitionRepository::class),
                         $this->get(ObjectBuilderFactory::class),
+                        new InterfaceNodeBuilder(
+                            $this->get(InterfaceInferringContainer::class),
+                            new FunctionsContainer(
+                                $this->get(FunctionDefinitionRepository::class),
+                                $settings->customConstructors,
+                            ),
+                            $settings->exceptionFilter,
+                        ),
                         $settings->exceptionFilter,
                     ),
-                );
-
-                $builder = new InterfaceNodeBuilder(
-                    $builder,
-                    $this->get(ObjectImplementations::class),
-                    $this->get(ClassDefinitionRepository::class),
-                    new FunctionsContainer(
-                        $this->get(FunctionDefinitionRepository::class),
-                        $settings->customConstructors,
-                    ),
-                    $settings->exceptionFilter,
                 );
 
                 return new ValueConverterNodeBuilder(
@@ -136,7 +133,7 @@ final class Container
                 $settings->convertersSortedByPriority(),
             ),
 
-            ObjectImplementations::class => fn () => new ObjectImplementations(
+            InterfaceInferringContainer::class => fn () => new InterfaceInferringContainer(
                 new FunctionsContainer(
                     $this->get(FunctionDefinitionRepository::class),
                     $settings->inferredMapping,
@@ -244,7 +241,7 @@ final class Container
             TypeDumper::class => fn () => new TypeDumper(
                 $this->get(ClassDefinitionRepository::class),
                 $this->get(ObjectBuilderFactory::class),
-                $this->get(ObjectImplementations::class),
+                $this->get(InterfaceInferringContainer::class),
                 new FunctionsContainer(
                     $this->get(FunctionDefinitionRepository::class),
                     $settings->customConstructors,
@@ -253,7 +250,7 @@ final class Container
 
             RecursiveCacheWarmupService::class => fn () => new RecursiveCacheWarmupService(
                 $this->get(TypeParser::class),
-                $this->get(ObjectImplementations::class),
+                $this->get(InterfaceInferringContainer::class),
                 $this->get(ClassDefinitionRepository::class),
                 $this->get(ObjectBuilderFactory::class),
             ),

--- a/src/Mapper/Object/Arguments.php
+++ b/src/Mapper/Object/Arguments.php
@@ -9,6 +9,9 @@ use CuyZ\Valinor\Definition\ParameterDefinition;
 use CuyZ\Valinor\Definition\Parameters;
 use CuyZ\Valinor\Definition\Properties;
 use CuyZ\Valinor\Definition\PropertyDefinition;
+use CuyZ\Valinor\Type\Types\ShapedArrayElement;
+use CuyZ\Valinor\Type\Types\ShapedArrayType;
+use CuyZ\Valinor\Type\Types\StringValueType;
 use IteratorAggregate;
 use Traversable;
 
@@ -69,6 +72,19 @@ final class Arguments implements IteratorAggregate, Countable
             ...$this->arguments,
             ...array_diff_key($other->arguments, $this->arguments)
         );
+    }
+
+    public function toShapedArray(): ShapedArrayType
+    {
+        return new ShapedArrayType(array_map(
+            static fn (Argument $argument) => new ShapedArrayElement(
+                key: new StringValueType($argument->name()),
+                type: $argument->type(),
+                optional: ! $argument->isRequired(),
+                attributes: $argument->attributes(),
+            ),
+            array_values($this->arguments),
+        ));
     }
 
     /**

--- a/src/Mapper/Object/FunctionObjectBuilder.php
+++ b/src/Mapper/Object/FunctionObjectBuilder.php
@@ -49,7 +49,7 @@ final class FunctionObjectBuilder implements ObjectBuilder
         return $this->arguments;
     }
 
-    public function build(array $arguments): object
+    public function buildObject(array $arguments): object
     {
         $parameters = $this->function->definition->parameters;
 

--- a/src/Mapper/Object/MethodArguments.php
+++ b/src/Mapper/Object/MethodArguments.php
@@ -30,7 +30,7 @@ final class MethodArguments implements IteratorAggregate
 
             if ($parameter->isVariadic) {
                 $this->arguments = [...$this->arguments, ...array_values($arguments[$name])]; // @phpstan-ignore-line we know that the argument is iterable
-            } else {
+            } elseif (array_key_exists($name, $arguments)) {
                 $this->arguments[] = $arguments[$name];
             }
         }

--- a/src/Mapper/Object/MethodObjectBuilder.php
+++ b/src/Mapper/Object/MethodObjectBuilder.php
@@ -24,7 +24,7 @@ final class MethodObjectBuilder implements ObjectBuilder
         return $this->arguments ??= Arguments::fromParameters($this->parameters);
     }
 
-    public function build(array $arguments): object
+    public function buildObject(array $arguments): object
     {
         $methodName = $this->methodName;
         $arguments = new MethodArguments($this->parameters, $arguments);

--- a/src/Mapper/Object/NativeConstructorObjectBuilder.php
+++ b/src/Mapper/Object/NativeConstructorObjectBuilder.php
@@ -20,7 +20,7 @@ final class NativeConstructorObjectBuilder implements ObjectBuilder
         return $this->arguments ??= Arguments::fromParameters($this->class->methods->constructor()->parameters);
     }
 
-    public function build(array $arguments): object
+    public function buildObject(array $arguments): object
     {
         $className = $this->class->name;
         $arguments = new MethodArguments($this->class->methods->constructor()->parameters, $arguments);

--- a/src/Mapper/Object/NativeEnumObjectBuilder.php
+++ b/src/Mapper/Object/NativeEnumObjectBuilder.php
@@ -39,7 +39,7 @@ class NativeEnumObjectBuilder implements ObjectBuilder
         return $this->arguments;
     }
 
-    public function build(array $arguments): object
+    public function buildObject(array $arguments): object
     {
         return $this->enum->cases()[$arguments['value']];
     }

--- a/src/Mapper/Object/ObjectBuilder.php
+++ b/src/Mapper/Object/ObjectBuilder.php
@@ -12,7 +12,7 @@ interface ObjectBuilder
     /**
      * @param array<string, mixed> $arguments
      */
-    public function build(array $arguments): object;
+    public function buildObject(array $arguments): object;
 
     /**
      * @return non-empty-string

--- a/src/Mapper/Object/ReflectionObjectBuilder.php
+++ b/src/Mapper/Object/ReflectionObjectBuilder.php
@@ -20,7 +20,7 @@ final class ReflectionObjectBuilder implements ObjectBuilder
         return $this->arguments ??= Arguments::fromProperties($this->class->properties);
     }
 
-    public function build(array $arguments): object
+    public function buildObject(array $arguments): object
     {
         $object = new ($this->class->name)();
 

--- a/src/Mapper/Tree/Builder/Node.php
+++ b/src/Mapper/Tree/Builder/Node.php
@@ -4,17 +4,12 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper\Tree\Builder;
 
-use CuyZ\Valinor\Mapper\Tree\Exception\UnexpectedKeysInSource;
 use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
 use CuyZ\Valinor\Mapper\Tree\Shell;
-use CuyZ\Valinor\Utility\ValueDumper;
 
-use function array_diff;
-use function array_keys;
 use function array_merge;
 use function assert;
-use function is_array;
 
 /** @internal */
 final class Node
@@ -87,47 +82,19 @@ final class Node
         return $this->messages;
     }
 
+    public function appendMessage(NodeMessage $message): self
+    {
+        return new self(
+            value: null,
+            messages: [...$this->messages, $message],
+        );
+    }
+
     /**
      * @return non-negative-int
      */
     public function childrenCount(): int
     {
         return $this->childrenCount;
-    }
-
-    /**
-     * @param list<int|string> $children
-     */
-    public function checkUnexpectedKeys(Shell $shell, array $children): self
-    {
-        $value = $shell->value();
-
-        if ($shell->allowSuperfluousKeys || ! is_array($value)) {
-            return $this;
-        }
-
-        $diff = array_diff(array_keys($value), $children, $shell->allowedSuperfluousKeys);
-
-        if ($diff !== []) {
-            /** @var non-empty-list<int|string> $children */
-            $error = new UnexpectedKeysInSource($value, $children);
-
-            $nodeMessage = new NodeMessage(
-                $error,
-                $error->body(),
-                $shell->name,
-                $shell->path,
-                "`{$shell->type->toString()}`",
-                $shell->expectedSignature(),
-                ValueDumper::dump($shell->value()),
-            );
-
-            return new self(
-                value: null,
-                messages: array_merge($this->messages, [$nodeMessage])
-            );
-        }
-
-        return $this;
     }
 }

--- a/src/Mapper/Tree/Builder/ObjectNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ObjectNodeBuilder.php
@@ -8,7 +8,6 @@ use CuyZ\Valinor\Definition\Repository\ClassDefinitionRepository;
 use CuyZ\Valinor\Mapper\Object\ArgumentsValues;
 use CuyZ\Valinor\Mapper\Object\Exception\CannotFindObjectBuilder;
 use CuyZ\Valinor\Mapper\Object\Factory\ObjectBuilderFactory;
-use CuyZ\Valinor\Mapper\Object\ObjectBuilder;
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
 use CuyZ\Valinor\Mapper\Tree\Message\Message;
 use CuyZ\Valinor\Mapper\Tree\Message\UserlandError;
@@ -16,7 +15,6 @@ use CuyZ\Valinor\Mapper\Tree\Shell;
 use CuyZ\Valinor\Type\ObjectType;
 use Throwable;
 
-use function array_keys;
 use function assert;
 use function count;
 
@@ -26,40 +24,45 @@ final class ObjectNodeBuilder implements NodeBuilder
     public function __construct(
         private ClassDefinitionRepository $classDefinitionRepository,
         private ObjectBuilderFactory $objectBuilderFactory,
+        private InterfaceNodeBuilder $interfaceNodeBuilder,
         /** @var callable(Throwable): ErrorMessage */
         private mixed $exceptionFilter,
     ) {}
 
     public function build(Shell $shell): Node
     {
-        $type = $shell->type;
+        assert($shell->type instanceof ObjectType);
 
-        assert($type instanceof ObjectType);
-
-        if ($type->accepts($shell->value())) {
+        if ($shell->type->accepts($shell->value())) {
             return $shell->node($shell->value());
         }
 
-        if ($shell->allowUndefinedValues && $shell->value() === null) {
-            $shell = $shell->withValue([]);
-        } else {
-            $shell = $shell->transformIteratorToArray();
+        $class = $this->classDefinitionRepository->for($shell->type);
+
+        if ($this->interfaceNodeBuilder->canInferImplementation($class)) {
+            return $this->interfaceNodeBuilder->build($shell);
         }
 
-        $class = $this->classDefinitionRepository->for($type);
-        $builders = $this->objectBuilderFactory->for($class);
+        $objectBuilders = $this->objectBuilderFactory->for($class);
 
-        foreach ($builders as $builder) {
-            $argumentsValues = ArgumentsValues::forClass($builder->describeArguments(), $shell);
+        foreach ($objectBuilders as $objectBuilder) {
+            $arguments = $objectBuilder->describeArguments();
+            $argumentsValues = ArgumentsValues::forClass($shell, $arguments);
 
-            if ($argumentsValues->hasInvalidValue()) {
-                continue;
+            $valuesNode = $argumentsValues->shell->build();
+
+            if (! $valuesNode->isValid()) {
+                if (count($objectBuilders) > 1) {
+                    continue;
+                }
+
+                return $valuesNode;
             }
 
-            $children = $this->children($shell, $argumentsValues);
-
             try {
-                $object = $this->buildObject($builder, $children);
+                $values = $argumentsValues->transform($valuesNode->value());
+
+                $object = $objectBuilder->buildObject($values);
             } catch (UserlandError|Message $exception) {
                 if ($exception instanceof UserlandError) {
                     // @phpstan-ignore argument.type (we know there always is a previous exception)
@@ -69,72 +72,13 @@ final class ObjectNodeBuilder implements NodeBuilder
                 return $shell->error($exception);
             }
 
-            if ($object === null) {
-                if (count($builders) > 1) {
-                    continue;
-                }
+            $node = $argumentsValues->shell->node($object);
 
-                $node = $shell->errors($children);
-            } else {
-                $node = $shell->node($object);
-            }
-
-            if (! $argumentsValues->hadSingleArgument()) {
-                $node = $node->checkUnexpectedKeys($shell, array_keys($children));
-            }
-
-            if ($node->isValid() || count($builders) === 1) {
+            if ($node->isValid()) {
                 return $node;
             }
         }
 
         return $shell->error(new CannotFindObjectBuilder());
-    }
-
-    /**
-     * @return array<non-empty-string, Node>
-     */
-    private function children(Shell $shell, ArgumentsValues $arguments): array
-    {
-        $children = [];
-
-        foreach ($arguments as $argument) {
-            $name = $argument->name();
-            $type = $argument->type();
-
-            if ($arguments->hadSingleArgument()) {
-                $child = $shell->withType($type);
-            } else {
-                $child = $shell->child($name, $type);
-            }
-
-            $child = $child->withAttributes($argument->attributes());
-
-            if ($arguments->hasValue($name)) {
-                $child = $child->withValue($arguments->getValue($name));
-            }
-
-            $children[$name] = $child->build();
-        }
-
-        return $children;
-    }
-
-    /**
-     * @param array<non-empty-string, Node> $children
-     */
-    private function buildObject(ObjectBuilder $builder, array $children): ?object
-    {
-        $arguments = [];
-
-        foreach ($children as $name => $child) {
-            if (! $child->isValid()) {
-                return null;
-            }
-
-            $arguments[$name] = $child->value();
-        }
-
-        return $builder->build($arguments);
     }
 }

--- a/src/Mapper/Tree/Exception/CannotInferFinalClass.php
+++ b/src/Mapper/Tree/Exception/CannotInferFinalClass.php
@@ -5,14 +5,16 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
 use CuyZ\Valinor\Definition\FunctionDefinition;
-use CuyZ\Valinor\Type\ClassType;
 use RuntimeException;
 
 /** @internal */
 final class CannotInferFinalClass extends RuntimeException
 {
-    public function __construct(ClassType $class, FunctionDefinition $function)
+    /**
+     * @param class-string $className
+     */
+    public function __construct(string $className, FunctionDefinition $function)
     {
-        parent::__construct("Cannot infer final class `{$class->className()}` with function `$function->signature`.");
+        parent::__construct("Cannot infer final class `$className` with function `$function->signature`.");
     }
 }

--- a/src/Mapper/Tree/Shell.php
+++ b/src/Mapper/Tree/Shell.php
@@ -20,8 +20,6 @@ use CuyZ\Valinor\Utility\ValueDumper;
 
 use function assert;
 use function implode;
-use function is_array;
-use function is_iterable;
 
 /** @internal */
 final class Shell
@@ -83,6 +81,7 @@ final class Shell
         $self->type = $type;
         $self->path = $this->name === '' ? $name : "$this->path.$name";
         $self->hasValue = false;
+        $self->value = null;
         $self->attributes = Attributes::empty();
         $self->objectTrace = $this->objectTrace->markAsVisited($type);
         $self->childrenCount = 0;
@@ -160,13 +159,12 @@ final class Shell
         return $self;
     }
 
-    public function transformIteratorToArray(): self
+    public function allowSuperfluousKeys(): self
     {
-        if (is_iterable($this->value) && ! is_array($this->value)) {
-            return $this->withValue(iterator_to_array($this->value));
-        }
+        $self = clone $this;
+        $self->allowSuperfluousKeys = true;
 
-        return $this;
+        return $self;
     }
 
     public function expectedSignature(): string

--- a/src/Type/Dumper/TypeDumper.php
+++ b/src/Type/Dumper/TypeDumper.php
@@ -10,7 +10,7 @@ use CuyZ\Valinor\Mapper\Object\Argument;
 use CuyZ\Valinor\Mapper\Object\Arguments;
 use CuyZ\Valinor\Mapper\Object\Factory\ObjectBuilderFactory;
 use CuyZ\Valinor\Mapper\Object\ObjectBuilder;
-use CuyZ\Valinor\Mapper\Tree\Builder\ObjectImplementations;
+use CuyZ\Valinor\Mapper\Tree\Builder\InterfaceInferringContainer;
 use CuyZ\Valinor\Mapper\Tree\Exception\ObjectImplementationCallbackError;
 use CuyZ\Valinor\Type\FixedType;
 use CuyZ\Valinor\Type\ObjectType;
@@ -31,7 +31,7 @@ final class TypeDumper
     public function __construct(
         private readonly ClassDefinitionRepository $classDefinitionRepository,
         private readonly ObjectBuilderFactory $objectBuilderFactory,
-        private ObjectImplementations $implementations,
+        private InterfaceInferringContainer $interfaceInferringContainer,
         private FunctionsContainer $constructors,
     ) {}
 
@@ -122,15 +122,15 @@ final class TypeDumper
             return $this->fromObjectType($type, $context);
         }
 
-        if (! $this->implementations->has($type->className())) {
+        if (! $this->interfaceInferringContainer->has($type->className())) {
             return $context->write('*unknown*');
         }
 
-        $function = $this->implementations->function($type->className());
+        $function = $this->interfaceInferringContainer->inferFunctionFor($type->className());
         $interfaceArguments = Arguments::fromParameters($function->parameters);
 
         try {
-            $classTypes = $this->implementations->implementations($type->className());
+            $classTypes = $this->interfaceInferringContainer->classImplementationsFor($type->className());
         } catch (ObjectImplementationCallbackError) {
             return $context->write('*unknown*');
         }

--- a/src/Utility/Polyfill.php
+++ b/src/Utility/Polyfill.php
@@ -22,6 +22,23 @@ final class Polyfill
 
         return true;
     }
+
+    /**
+     * PHP8.4 use native function `array_find` instead.
+     *
+     * @param array<mixed> $array
+     */
+    public static function array_any(array $array, callable $callback): bool
+    {
+        foreach ($array as $key => $value) {
+            if ($callback($value, $key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * PHP8.4 use native function `array_find` instead.
      *

--- a/tests/Fake/Mapper/Object/FakeObjectBuilder.php
+++ b/tests/Fake/Mapper/Object/FakeObjectBuilder.php
@@ -15,7 +15,7 @@ final class FakeObjectBuilder implements ObjectBuilder
         return new Arguments();
     }
 
-    public function build(array $arguments): object
+    public function buildObject(array $arguments): object
     {
         return new stdClass();
     }

--- a/tests/Integration/Mapping/InterfaceInferringMappingTest.php
+++ b/tests/Integration/Mapping/InterfaceInferringMappingTest.php
@@ -349,7 +349,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
             ->map(SomeInterface::class, []);
     }
 
-    public function test_invalid_source_throws_exception(): void
+    public function test_invalid_scalar_source_throws_exception(): void
     {
         try {
             $this->mapperBuilder()
@@ -362,7 +362,26 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
                 ->map(SomeInterface::class, 42);
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[invalid_source] Value 42 does not match `array{type: string, key: int, valueA: string}`.",
+                '*root*' => "[value_is_not_iterable] Value 42 does not match `array{type: string, key: int, valueA: string}`.",
+            ]);
+        }
+    }
+
+    public function test_invalid_source_throws_exception(): void
+    {
+        try {
+            $this->mapperBuilder()
+                ->infer(
+                    SomeInterface::class,
+                    /** @return class-string<SomeClassThatInheritsInterfaceA> */
+                    fn (string $type, int $key) => SomeClassThatInheritsInterfaceA::class
+                )
+                ->mapper()
+                ->map(SomeInterface::class, ['type' => 42, 'key' => true]);
+        } catch (MappingError $exception) {
+            self::assertMappingErrors($exception, [
+                'type' => "[invalid_string] Value 42 is not a valid string.",
+                'key' => "[invalid_integer] Value true is not a valid integer.",
             ]);
         }
     }
@@ -380,7 +399,7 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
                 ->map(SomeInterface::class, 'foo');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                'key' => "[invalid_integer] Value 'foo' is not a valid integer.",
+                '*root*' => "[invalid_integer] Value 'foo' is not a valid integer.",
             ]);
         }
     }

--- a/tests/Integration/Mapping/Object/ObjectValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/ObjectValuesMappingTest.php
@@ -48,7 +48,7 @@ final class ObjectValuesMappingTest extends IntegrationTestCase
                 $this->mapperBuilder()->mapper()->map($class, $source);
             } catch (MappingError $exception) {
                 self::assertMappingErrors($exception, [
-                    '*root*' => "[cannot_find_object_builder] Value 'foo' does not match `array{object: string|array{value: string}, string: string}`.",
+                    '*root*' => "[value_is_not_iterable] Value 'foo' does not match `array{object: string|array{value: string}, string: string}`.",
                 ]);
             }
         }
@@ -94,7 +94,7 @@ final class ObjectValuesMappingTest extends IntegrationTestCase
             $this->mapperBuilder()->mapper()->map(stdClass::class, 'foo');
         } catch (MappingError $exception) {
             self::assertMappingErrors($exception, [
-                '*root*' => "[cannot_find_object_builder] Value 'foo' does not match `array{}`.",
+                '*root*' => "[value_is_not_iterable] Value 'foo' does not match `array{}`.",
             ]);
         }
     }

--- a/tests/Unit/Mapper/Object/MethodObjectBuilderTest.php
+++ b/tests/Unit/Mapper/Object/MethodObjectBuilderTest.php
@@ -40,7 +40,7 @@ final class MethodObjectBuilderTest extends TestCase
 
         $this->expectException(UserlandError::class);
 
-        $objectBuilder->build([]);
+        $objectBuilder->buildObject([]);
     }
 
     public function test_arguments_instance_stays_the_same(): void

--- a/tests/Unit/Mapper/Object/NativeConstructorObjectBuilderTest.php
+++ b/tests/Unit/Mapper/Object/NativeConstructorObjectBuilderTest.php
@@ -36,7 +36,7 @@ final class NativeConstructorObjectBuilderTest extends TestCase
 
         $class = FakeClassDefinition::fromReflection(new ReflectionClass($object));
         $objectBuilder = new NativeConstructorObjectBuilder($class);
-        $result = $objectBuilder->build([
+        $result = $objectBuilder->buildObject([
             'valueA' => 'valueA',
             'valueB' => 'valueB',
             'valueC' => 'valueC',
@@ -54,7 +54,7 @@ final class NativeConstructorObjectBuilderTest extends TestCase
 
         $this->expectException(UserlandError::class);
 
-        $objectBuilder->build([]);
+        $objectBuilder->buildObject([]);
     }
 }
 

--- a/tests/Unit/Mapper/Object/ReflectionObjectBuilderTest.php
+++ b/tests/Unit/Mapper/Object/ReflectionObjectBuilderTest.php
@@ -38,7 +38,7 @@ final class ReflectionObjectBuilderTest extends TestCase
 
         $class = FakeClassDefinition::fromReflection(new ReflectionClass($object));
         $objectBuilder = new ReflectionObjectBuilder($class);
-        $result = $objectBuilder->build([
+        $result = $objectBuilder->buildObject([
             'valueA' => 'valueA',
             'valueB' => 'valueB',
             'valueC' => 'valueC',


### PR DESCRIPTION
This refactor aims to ease the upcoming maintenance of the library, by making the class and interface node builders process smoother.

The main change is that these builders now share the same logic concerning the children nodes building. Instead of having their own logic, they convert the needed structures signatures to a shaped array, that is then given back to the mapping process. This way, this complex logic is now located in one place instead of three, allowing easier maintenance as well as more capabilities.