### PR TITLE
fix: use converter only if its return type matches the current node

### DIFF
--- a/docs/pages/how-to/common-converters-examples.md
+++ b/docs/pages/how-to/common-converters-examples.md
@@ -44,6 +44,11 @@ final readonly class User
         /**
          * Note that this converter will only be called when the input is an
          * array and the target type is an object.
+         * 
+         * @template T of object
+         * @param array<mixed> $value
+         * @param callable(array<mixed>): T $next
+         * @return T
          */
         function (array $values, callable $next): object {
             $camelCaseConverted = array_combine(
@@ -81,8 +86,10 @@ namespace My\App;
 final class CamelCaseKeys
 {
     /**
+     * @template T of object
      * @param array<mixed> $value
-     * @param callable(array<mixed>): object $next
+     * @param callable(array<mixed>): T $next
+     * @return T
      */
     public function map(array $value, callable $next): object
     {
@@ -137,7 +144,13 @@ final readonly class Location
 
 (new \CuyZ\Valinor\MapperBuilder())
     ->registerConverter(
-        function (array $value, callable $next): mixed {
+        /**
+         * @template T of object
+         * @param array<mixed> $value
+         * @param callable(array<mixed>): T $next
+         * @return T
+         */
+        function (array $value, callable $next): object {
             $mapping = [
                 'town' => 'city',
                 'postalCode' => 'zipCode',
@@ -179,8 +192,10 @@ final class RenameKeys
     ) {}
 
     /**
+     * @template T of object
      * @param array<mixed> $value
-     * @param callable(array<mixed>): object $next
+     * @param callable(array<mixed>): T $next
+     * @return T
      */
     public function map(array $value, callable $next): object
     {
@@ -643,7 +658,7 @@ final class Explode
     ) {}
 
     /**
-     * @return array<mixed>
+     * @return list<string>
      */
     public function map(string $value): array
     {
@@ -655,7 +670,7 @@ final readonly class Product
 {
     public string $name;
 
-    /** @var list<non-empty-string> */
+    /** @var list<string> */
     #[\My\App\Explode(separator: ',')] public array $size;
 }
 
@@ -687,8 +702,9 @@ namespace My\App;
 final class ArrayToList
 {
     /**
-     * @param array<mixed> $value
-     * @return list<mixed>
+     * @template T
+     * @param non-empty-array<T> $value
+     * @return non-empty-list<T>
      */
     public function map(array $value): array
     {
@@ -733,8 +749,10 @@ namespace My\App;
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class JsonDecode
 {
-    /**
-     * @param callable(mixed): mixed $next
+     /**
+     * @template T
+     * @param callable(mixed): T $next
+     * @return T
      */
     public function map(string $value, callable $next): mixed
     {

--- a/src/Definition/FunctionDefinition.php
+++ b/src/Definition/FunctionDefinition.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Definition;
 
 use CuyZ\Valinor\Type\Type;
+use CuyZ\Valinor\Type\Types\Generics;
+use CuyZ\Valinor\Utility\TypeHelper;
 
 /** @internal */
 final class FunctionDefinition
@@ -22,6 +24,25 @@ final class FunctionDefinition
         public readonly bool $isStatic,
         public readonly bool $isClosure,
         public readonly Parameters $parameters,
-        public readonly Type $returnType
+        public readonly Type $returnType,
     ) {}
+
+    public function assignGenerics(Generics $generics): self
+    {
+        if ($generics->items === []) {
+            return $this;
+        }
+
+        return new self(
+            $this->name,
+            $this->signature,
+            $this->attributes,
+            $this->fileName,
+            $this->class,
+            $this->isStatic,
+            $this->isClosure,
+            $this->parameters->assignGenerics($generics),
+            TypeHelper::assignVacantTypes($this->returnType, $generics->items),
+        );
+    }
 }

--- a/src/Definition/ParameterDefinition.php
+++ b/src/Definition/ParameterDefinition.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Definition;
 
 use CuyZ\Valinor\Type\Type;
+use CuyZ\Valinor\Type\Types\Generics;
+use CuyZ\Valinor\Utility\TypeHelper;
 
 /** @internal */
 final class ParameterDefinition
@@ -21,4 +23,20 @@ final class ParameterDefinition
         public readonly mixed $defaultValue,
         public readonly Attributes $attributes
     ) {}
+
+    public function assignGenerics(Generics $generics): self
+    {
+        assert($generics->items !== []);
+
+        return new self(
+            $this->name,
+            $this->signature,
+            TypeHelper::assignVacantTypes($this->type, $generics->items),
+            $this->nativeType,
+            $this->isOptional,
+            $this->isVariadic,
+            $this->defaultValue,
+            $this->attributes
+        );
+    }
 }

--- a/src/Definition/Parameters.php
+++ b/src/Definition/Parameters.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Definition;
 
 use Countable;
+use CuyZ\Valinor\Type\Types\Generics;
 use IteratorAggregate;
 use Traversable;
 
+use function array_map;
 use function array_values;
 
 /**
@@ -43,6 +45,16 @@ final class Parameters implements IteratorAggregate, Countable
     public function at(int $index): ParameterDefinition
     {
         return array_values($this->parameters)[$index];
+    }
+
+    public function assignGenerics(Generics $generics): self
+    {
+        return new self(
+            ...array_map(
+                static fn (ParameterDefinition $parameter) => $parameter->assignGenerics($generics),
+                $this->parameters,
+            ),
+        );
     }
 
     /**

--- a/src/Mapper/Object/NativeEnumObjectBuilder.php
+++ b/src/Mapper/Object/NativeEnumObjectBuilder.php
@@ -24,9 +24,7 @@ class NativeEnumObjectBuilder implements ObjectBuilder
             $types[] = ValueTypeFactory::from($value);
         }
 
-        $argumentType = count($types) === 1
-            ? $types[0]
-            : new UnionType(...$types);
+        $argumentType = UnionType::from(...$types);
 
         $this->enum = $type;
         $this->arguments = new Arguments(

--- a/src/Mapper/Tree/Builder/InterfaceNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/InterfaceNodeBuilder.php
@@ -64,6 +64,7 @@ final class InterfaceNodeBuilder implements NodeBuilder
         return $shell
             ->withType($classType)
             ->withAllowedSuperfluousKeys($arguments->names())
+            ->shouldNotApplyConverters()
             ->build();
     }
 

--- a/src/Mapper/Tree/Builder/ObjectNodeBuilder.php
+++ b/src/Mapper/Tree/Builder/ObjectNodeBuilder.php
@@ -43,6 +43,7 @@ final class ObjectNodeBuilder implements NodeBuilder
             return $this->interfaceNodeBuilder->build($shell);
         }
 
+        $shell = $shell->shouldApplyConverters();
         $objectBuilders = $this->objectBuilderFactory->for($class);
 
         foreach ($objectBuilders as $objectBuilder) {

--- a/src/Mapper/Tree/Exception/ConverterHasInvalidReturnType.php
+++ b/src/Mapper/Tree/Exception/ConverterHasInvalidReturnType.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Tree\Exception;
+
+use CuyZ\Valinor\Definition\FunctionDefinition;
+use CuyZ\Valinor\Type\Types\UnresolvableType;
+use RuntimeException;
+
+use function assert;
+
+/** @internal */
+final class ConverterHasInvalidReturnType extends RuntimeException
+{
+    public function __construct(FunctionDefinition $function)
+    {
+        assert($function->returnType instanceof UnresolvableType);
+
+        parent::__construct($function->returnType->message());
+    }
+}

--- a/src/Mapper/Tree/Exception/InvalidNodeValue.php
+++ b/src/Mapper/Tree/Exception/InvalidNodeValue.php
@@ -6,6 +6,8 @@ namespace CuyZ\Valinor\Mapper\Tree\Exception;
 
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
 use CuyZ\Valinor\Mapper\Tree\Message\HasCode;
+use CuyZ\Valinor\Type\ScalarType;
+use CuyZ\Valinor\Type\Type;
 
 /** @internal */
 final class InvalidNodeValue implements ErrorMessage, HasCode
@@ -13,6 +15,15 @@ final class InvalidNodeValue implements ErrorMessage, HasCode
     private string $body = 'Value {source_value} does not match {expected_signature}.';
 
     private string $code = 'invalid_value';
+
+    public static function from(Type $type): ErrorMessage
+    {
+        if ($type instanceof ScalarType) {
+            return $type->errorMessage();
+        }
+
+        return new self();
+    }
 
     public function body(): string
     {

--- a/src/Mapper/Tree/RootNodeBuilder.php
+++ b/src/Mapper/Tree/RootNodeBuilder.php
@@ -35,6 +35,7 @@ final class RootNodeBuilder
             allowSuperfluousKeys: $this->settings->allowSuperfluousKeys,
             allowPermissiveTypes: $this->settings->allowPermissiveTypes,
             allowedSuperfluousKeys: [],
+            shouldApplyConverters: true,
             nodeBuilder: $this->nodeBuilder,
             typeDumper: $this->typeDumper,
             objectTrace: new ObjectTrace(),

--- a/src/Mapper/Tree/Shell.php
+++ b/src/Mapper/Tree/Shell.php
@@ -42,6 +42,7 @@ final class Shell
         public bool $allowPermissiveTypes,
         /** @var list<string> */
         public array $allowedSuperfluousKeys,
+        public bool $shouldApplyConverters,
         private NodeBuilder $nodeBuilder,
         private TypeDumper $typeDumper,
         private ObjectTrace $objectTrace, // Helps detecting circular dependencies
@@ -163,6 +164,24 @@ final class Shell
     {
         $self = clone $this;
         $self->allowSuperfluousKeys = true;
+
+        return $self;
+    }
+
+    public function shouldApplyConverters(): self
+    {
+        // @infection-ignore-all / We don't want to test the clone behavior
+        $self = clone $this;
+        $self->shouldApplyConverters = true;
+
+        return $self;
+    }
+
+    public function shouldNotApplyConverters(): self
+    {
+        // @infection-ignore-all / We don't want to test the clone behavior
+        $self = clone $this;
+        $self->shouldApplyConverters = false;
 
         return $self;
     }

--- a/src/Normalizer/Transformer/Compiler/TransformerDefinitionBuilder.php
+++ b/src/Normalizer/Transformer/Compiler/TransformerDefinitionBuilder.php
@@ -106,7 +106,6 @@ final class TransformerDefinitionBuilder
     private function typeFormatter(Type $type): TypeFormatter
     {
         return match (true) {
-            $type instanceof CompositeTraversableType => new TraversableFormatter($type->subType()),
             $type instanceof EnumType => new EnumFormatter($type),
             $type instanceof InterfaceType => new InterfaceFormatter($type),
             $type instanceof NativeClassType => match (true) {
@@ -121,6 +120,7 @@ final class TransformerDefinitionBuilder
             $type instanceof ScalarType => new ScalarFormatter(),
             $type instanceof ShapedArrayType => new ShapedArrayFormatter($type),
             $type instanceof UnionType => new UnionFormatter($type),
+            $type instanceof CompositeTraversableType => new TraversableFormatter($type->subType()),
             $type instanceof GenericType => $this->typeFormatter($type->innerType),
             default => new MixedFormatter(),
         };

--- a/src/Type/ScalarType.php
+++ b/src/Type/ScalarType.php
@@ -9,8 +9,21 @@ use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
 /** @internal */
 interface ScalarType extends Type
 {
+    /**
+     * Should return true if the value can be casted to this type.
+     *
+     * `42` can be cast to `string`
+     *      —> true
+     *
+     * `foo` can be cast to `int`
+     *      —> false
+     */
     public function canCast(mixed $value): bool;
 
+    /**
+     * Returns the given value casted to this type. Note that the method
+     * `canCast()` must have been called before.
+     */
     public function cast(mixed $value): bool|string|int|float;
 
     public function errorMessage(): ErrorMessage;

--- a/src/Type/Type.php
+++ b/src/Type/Type.php
@@ -5,15 +5,54 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Type;
 
 use CuyZ\Valinor\Compiler\Native\ComplianceNode;
+use CuyZ\Valinor\Type\Types\Generics;
 
 /** @internal */
 interface Type
 {
+    /**
+     * Should return `true` if the given value is strictly compatible with this
+     * type.
+     */
     public function accepts(mixed $value): bool;
 
+    /**
+     * Compiled version of the `accepts` method.
+     */
     public function compiledAccept(ComplianceNode $node): ComplianceNode;
 
+    /**
+     * Should return `true` if the given type is strictly compatible with this
+     * type.
+     *
+     * `non-empty-string` matches `string`
+     *      —> true, because all non-empty strings are strings
+     *
+     * `string` matches `non-empty-string`
+     *      —> false, because a string is not necessarily non-empty
+     *
+     * `list<string>` matches `array<scalar>`
+     *      —> true, because a list is an array *and* strings are scalars
+     *
+     * `array<string>` matches `list<scalar>`
+     *      —> false, because an array is not necessarily a list
+     */
     public function matches(self $other): bool;
+
+    /**
+     * Infers the generics of this type from the given type. If no generics can
+     * be inferred, the given generics are returned as-is.
+     *
+     * `array<T>` inferred from `array<string>`
+     *      —> T = string
+     *
+     * `array{foo: T, bar: int}` inferred from `array{foo: string, bar: int}`
+     *      —> T = string
+     *
+     * `T|string` inferred from `positive-int|non-empty-string`
+     *      —> T = positive-int
+     */
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics;
 
     public function nativeType(): Type;
 

--- a/src/Type/Types/ArrayKeyType.php
+++ b/src/Type/Types/ArrayKeyType.php
@@ -132,6 +132,18 @@ final class ArrayKeyType implements ScalarType, CompositeType, DumpableType
         return false;
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        if (! $other instanceof self) {
+            return $generics;
+        }
+
+        $selfTypes = UnionType::from(...$this->types);
+        $otherTypes = UnionType::from(...$other->types);
+
+        return $selfTypes->inferGenericsFrom($otherTypes, $generics);
+    }
+
     public function canCast(mixed $value): bool
     {
         foreach ($this->types as $type) {
@@ -185,11 +197,7 @@ final class ArrayKeyType implements ScalarType, CompositeType, DumpableType
             $types[$type->nativeType()->toString()] = $type->nativeType();
         }
 
-        if (count($types) === 1) {
-            return reset($types);
-        }
-
-        return new UnionType(...array_values($types));
+        return UnionType::from(...array_values($types));
     }
 
     public function dumpParts(): iterable

--- a/src/Type/Types/ArrayType.php
+++ b/src/Type/Types/ArrayType.php
@@ -91,6 +91,17 @@ final class ArrayType implements CompositeTraversableType, DumpableType
             && $this->subType->matches($other->subType());
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        if (! $other instanceof CompositeTraversableType) {
+            return $generics;
+        }
+
+        $generics = $this->keyType->inferGenericsFrom($other->keyType(), $generics);
+
+        return $this->subType->inferGenericsFrom($other->subType(), $generics);
+    }
+
     public function keyType(): ArrayKeyType
     {
         return $this->keyType;

--- a/src/Type/Types/BooleanValueType.php
+++ b/src/Type/Types/BooleanValueType.php
@@ -48,6 +48,11 @@ final class BooleanValueType implements BooleanType, FixedType
         return $other->accepts($this->value);
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
+    }
+
     public function canCast(mixed $value): bool
     {
         if ($value === $this->value) {

--- a/src/Type/Types/CallableType.php
+++ b/src/Type/Types/CallableType.php
@@ -84,6 +84,11 @@ final class CallableType implements CompositeType
         );
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
+    }
+
     public function nativeType(): Type
     {
         return $this;

--- a/src/Type/Types/ClassStringType.php
+++ b/src/Type/Types/ClassStringType.php
@@ -126,6 +126,18 @@ final class ClassStringType implements StringType, CompositeType
         return true;
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        if (! $other instanceof self) {
+            return $generics;
+        }
+
+        $selfTypes = UnionType::from(...$this->subTypes);
+        $otherTypes = UnionType::from(...$other->subTypes);
+
+        return $selfTypes->inferGenericsFrom($otherTypes, $generics);
+    }
+
     public function canCast(mixed $value): bool
     {
         return (is_string($value) || $value instanceof Stringable)

--- a/src/Type/Types/EnumType.php
+++ b/src/Type/Types/EnumType.php
@@ -133,6 +133,11 @@ final class EnumType implements ClassType
             || $other instanceof MixedType;
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
+    }
+
     /**
      * @return non-empty-string
      */

--- a/src/Type/Types/FloatValueType.php
+++ b/src/Type/Types/FloatValueType.php
@@ -34,6 +34,11 @@ final class FloatValueType implements FloatType, FixedType
         return $other->accepts($this->value);
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
+    }
+
     public function canCast(mixed $value): bool
     {
         return is_numeric($value) && (float)$value === $this->value;

--- a/src/Type/Types/GenericType.php
+++ b/src/Type/Types/GenericType.php
@@ -12,6 +12,7 @@ use CuyZ\Valinor\Type\VacantType;
 final class GenericType implements VacantType
 {
     public function __construct(
+        /** @var non-empty-string */
         public readonly string $symbol,
         public readonly Type $innerType,
     ) {}
@@ -29,6 +30,15 @@ final class GenericType implements VacantType
     public function matches(Type $other): bool
     {
         return $this->innerType->matches($other);
+    }
+
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        if ($other->matches($this->innerType)) {
+            return $generics->with($this, $other);
+        }
+
+        return $generics;
     }
 
     public function nativeType(): Type

--- a/src/Type/Types/Generics.php
+++ b/src/Type/Types/Generics.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Type\Types;
+
+use CuyZ\Valinor\Type\Type;
+
+/** @internal */
+final class Generics
+{
+    public function __construct(
+        /** @var array<non-empty-string, Type> */
+        public readonly array $items = [],
+    ) {}
+
+    public function with(GenericType $generic, Type $type): self
+    {
+        $name = $generic->symbol;
+
+        if (isset($this->items[$name])) {
+            $other = $this->items[$name];
+
+            if ($other->matches($type)) {
+                $type = $other;
+            } elseif (! $type->matches($other)) {
+                $type = UnionType::from($other, $type);
+            }
+        }
+
+        return new self([...$this->items, ...[$name => $type]]);
+    }
+}

--- a/src/Type/Types/IntegerRangeType.php
+++ b/src/Type/Types/IntegerRangeType.php
@@ -86,6 +86,11 @@ final class IntegerRangeType implements IntegerType
         return false;
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
+    }
+
     public function canCast(mixed $value): bool
     {
         if (is_string($value)) {

--- a/src/Type/Types/IntegerValueType.php
+++ b/src/Type/Types/IntegerValueType.php
@@ -39,6 +39,11 @@ final class IntegerValueType implements IntegerType, FixedType
         return $other->accepts($this->value);
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
+    }
+
     public function canCast(mixed $value): bool
     {
         if (is_string($value)) {

--- a/src/Type/Types/InterfaceType.php
+++ b/src/Type/Types/InterfaceType.php
@@ -59,6 +59,21 @@ final class InterfaceType implements ObjectType, ObjectWithGenericType
         return is_a($this->interfaceName, $other->className(), true);
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        if (! $other instanceof self) {
+            return $generics;
+        }
+
+        foreach ($this->generics as $key => $classGenerics) {
+            if (isset($other->generics[$key])) {
+                $generics = $classGenerics->inferGenericsFrom($other->generics[$key], $generics);
+            }
+        }
+
+        return $generics;
+    }
+
     public function traverse(): array
     {
         return $this->generics;

--- a/src/Type/Types/IntersectionType.php
+++ b/src/Type/Types/IntersectionType.php
@@ -84,6 +84,11 @@ final class IntersectionType implements CombiningType
         return true;
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
+    }
+
     public function isMatchedBy(Type $other): bool
     {
         foreach ($this->types as $type) {

--- a/src/Type/Types/IterableType.php
+++ b/src/Type/Types/IterableType.php
@@ -101,6 +101,17 @@ final class IterableType implements CompositeTraversableType, DumpableType
             && $this->subType->matches($other->subType());
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        if (! $other instanceof CompositeTraversableType) {
+            return $generics;
+        }
+
+        $generics = $this->keyType->inferGenericsFrom($other->keyType(), $generics);
+
+        return $this->subType->inferGenericsFrom($other->subType(), $generics);
+    }
+
     public function keyType(): ArrayKeyType
     {
         return $this->keyType;

--- a/src/Type/Types/ListType.php
+++ b/src/Type/Types/ListType.php
@@ -90,6 +90,15 @@ final class ListType implements CompositeTraversableType, DumpableType
         return false;
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        if (! $other instanceof CompositeTraversableType) {
+            return $generics;
+        }
+
+        return $this->subType->inferGenericsFrom($other->subType(), $generics);
+    }
+
     public function keyType(): ArrayKeyType
     {
         return ArrayKeyType::integer();

--- a/src/Type/Types/MixedType.php
+++ b/src/Type/Types/MixedType.php
@@ -29,6 +29,11 @@ final class MixedType implements Type
         return $other instanceof self;
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
+    }
+
     public function nativeType(): Type
     {
         return $this;

--- a/src/Type/Types/NativeBooleanType.php
+++ b/src/Type/Types/NativeBooleanType.php
@@ -41,6 +41,11 @@ final class NativeBooleanType implements BooleanType
             || $other instanceof MixedType;
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
+    }
+
     public function canCast(mixed $value): bool
     {
         return is_bool($value)

--- a/src/Type/Types/NativeClassType.php
+++ b/src/Type/Types/NativeClassType.php
@@ -62,6 +62,21 @@ final class NativeClassType implements ClassType, ObjectWithGenericType
         return is_a($this->className, $other->className(), true);
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        if (! $other instanceof self || $this->className !== $other->className) {
+            return $generics;
+        }
+
+        foreach ($this->generics as $key => $classGenerics) {
+            if (isset($other->generics[$key])) {
+                $generics = $classGenerics->inferGenericsFrom($other->generics[$key], $generics);
+            }
+        }
+
+        return $generics;
+    }
+
     public function traverse(): array
     {
         return $this->generics;

--- a/src/Type/Types/NativeFloatType.php
+++ b/src/Type/Types/NativeFloatType.php
@@ -42,6 +42,11 @@ final class NativeFloatType implements FloatType
             || $other instanceof MixedType;
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
+    }
+
     public function canCast(mixed $value): bool
     {
         return is_numeric($value);

--- a/src/Type/Types/NativeIntegerType.php
+++ b/src/Type/Types/NativeIntegerType.php
@@ -49,6 +49,11 @@ final class NativeIntegerType implements IntegerType
             || $other instanceof MixedType;
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
+    }
+
     public function canCast(mixed $value): bool
     {
         if (is_string($value)) {

--- a/src/Type/Types/NativeStringType.php
+++ b/src/Type/Types/NativeStringType.php
@@ -47,6 +47,11 @@ final class NativeStringType implements StringType
             || $other instanceof MixedType;
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
+    }
+
     public function canCast(mixed $value): bool
     {
         return is_string($value)

--- a/src/Type/Types/NegativeIntegerType.php
+++ b/src/Type/Types/NegativeIntegerType.php
@@ -48,6 +48,11 @@ final class NegativeIntegerType implements IntegerType
             || $other instanceof MixedType;
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
+    }
+
     public function canCast(mixed $value): bool
     {
         return ! is_bool($value)

--- a/src/Type/Types/NonEmptyArrayType.php
+++ b/src/Type/Types/NonEmptyArrayType.php
@@ -92,6 +92,17 @@ final class NonEmptyArrayType implements CompositeTraversableType, DumpableType
             && $this->subType->matches($other->subType());
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        if (! $other instanceof CompositeTraversableType) {
+            return $generics;
+        }
+
+        $generics = $this->keyType->inferGenericsFrom($other->keyType(), $generics);
+
+        return $this->subType->inferGenericsFrom($other->subType(), $generics);
+    }
+
     public function keyType(): ArrayKeyType
     {
         return $this->keyType;

--- a/src/Type/Types/NonEmptyListType.php
+++ b/src/Type/Types/NonEmptyListType.php
@@ -97,6 +97,15 @@ final class NonEmptyListType implements CompositeTraversableType, DumpableType
         return false;
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        if (! $other instanceof CompositeTraversableType) {
+            return $generics;
+        }
+
+        return $this->subType->inferGenericsFrom($other->subType(), $generics);
+    }
+
     public function keyType(): ArrayKeyType
     {
         return ArrayKeyType::integer();

--- a/src/Type/Types/NonEmptyStringType.php
+++ b/src/Type/Types/NonEmptyStringType.php
@@ -48,6 +48,11 @@ final class NonEmptyStringType implements StringType
             || $other instanceof MixedType;
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
+    }
+
     public function canCast(mixed $value): bool
     {
         return (is_string($value) || is_numeric($value) || $value instanceof Stringable)

--- a/src/Type/Types/NonNegativeIntegerType.php
+++ b/src/Type/Types/NonNegativeIntegerType.php
@@ -46,6 +46,11 @@ final class NonNegativeIntegerType implements IntegerType
             || $other instanceof MixedType;
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
+    }
+
     public function canCast(mixed $value): bool
     {
         if (is_string($value)) {

--- a/src/Type/Types/NonPositiveIntegerType.php
+++ b/src/Type/Types/NonPositiveIntegerType.php
@@ -43,6 +43,11 @@ final class NonPositiveIntegerType implements IntegerType
             || $other instanceof MixedType;
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
+    }
+
     public function canCast(mixed $value): bool
     {
         return ! is_bool($value)

--- a/src/Type/Types/NullType.php
+++ b/src/Type/Types/NullType.php
@@ -34,6 +34,11 @@ final class NullType implements Type
             || $other instanceof MixedType;
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
+    }
+
     public function nativeType(): Type
     {
         return $this;

--- a/src/Type/Types/NumericStringType.php
+++ b/src/Type/Types/NumericStringType.php
@@ -49,6 +49,11 @@ final class NumericStringType implements StringType
             || $other instanceof MixedType;
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
+    }
+
     public function canCast(mixed $value): bool
     {
         if ($value instanceof Stringable) {

--- a/src/Type/Types/PositiveIntegerType.php
+++ b/src/Type/Types/PositiveIntegerType.php
@@ -50,6 +50,11 @@ final class PositiveIntegerType implements IntegerType
             || $other instanceof MixedType;
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
+    }
+
     public function canCast(mixed $value): bool
     {
         if (is_string($value)) {

--- a/src/Type/Types/ScalarConcreteType.php
+++ b/src/Type/Types/ScalarConcreteType.php
@@ -8,11 +8,7 @@ use CuyZ\Valinor\Compiler\Native\ComplianceNode;
 use CuyZ\Valinor\Compiler\Node;
 use CuyZ\Valinor\Mapper\Tree\Message\ErrorMessage;
 use CuyZ\Valinor\Mapper\Tree\Message\MessageBuilder;
-use CuyZ\Valinor\Type\BooleanType;
-use CuyZ\Valinor\Type\FloatType;
-use CuyZ\Valinor\Type\IntegerType;
 use CuyZ\Valinor\Type\ScalarType;
-use CuyZ\Valinor\Type\StringType;
 use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Utility\IsSingleton;
 use Stringable;
@@ -38,15 +34,16 @@ final class ScalarConcreteType implements ScalarType
     public function matches(Type $other): bool
     {
         if ($other instanceof UnionType) {
-            return $other->isMatchedBy($this);
+            return (new UnionType(NativeIntegerType::get(), NativeFloatType::get(), NativeStringType::get(), NativeBooleanType::get()))->matches($other);
         }
 
         return $other instanceof self
-            || $other instanceof IntegerType
-            || $other instanceof FloatType
-            || $other instanceof StringType
-            || $other instanceof BooleanType
             || $other instanceof MixedType;
+    }
+
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
     }
 
     public function canCast(mixed $value): bool

--- a/src/Type/Types/ShapedArrayType.php
+++ b/src/Type/Types/ShapedArrayType.php
@@ -196,6 +196,23 @@ final class ShapedArrayType implements CompositeType, DumpableType
         return false;
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        if (! $other instanceof self) {
+            return $generics;
+        }
+
+        foreach ($this->elements as $key => $element) {
+            if (! isset($other->elements[$key])) {
+                continue;
+            }
+
+            $generics = $element->type()->inferGenericsFrom($other->elements[$key]->type(), $generics);
+        }
+
+        return $generics;
+    }
+
     public function traverse(): array
     {
         $types = array_map(static fn (ShapedArrayElement $element) => $element->type(), array_values($this->elements));

--- a/src/Type/Types/StringValueType.php
+++ b/src/Type/Types/StringValueType.php
@@ -53,6 +53,11 @@ final class StringValueType implements StringType, FixedType
         return $other->accepts($this->value);
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
+    }
+
     public function canCast(mixed $value): bool
     {
         return (is_string($value) || is_numeric($value) || $value instanceof Stringable)

--- a/src/Type/Types/UndefinedObjectType.php
+++ b/src/Type/Types/UndefinedObjectType.php
@@ -36,6 +36,11 @@ final class UndefinedObjectType implements Type
             || $other instanceof MixedType;
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
+    }
+
     public function nativeType(): UndefinedObjectType
     {
         return $this;

--- a/src/Type/Types/UnresolvableType.php
+++ b/src/Type/Types/UnresolvableType.php
@@ -176,6 +176,11 @@ final class UnresolvableType implements VacantType
         throw new LogicException();
     }
 
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        throw new LogicException();
+    }
+
     public function compiledAccept(ComplianceNode $node): ComplianceNode
     {
         throw new LogicException();

--- a/tests/Fake/Type/FakeObjectType.php
+++ b/tests/Fake/Type/FakeObjectType.php
@@ -8,6 +8,7 @@ use CuyZ\Valinor\Compiler\Native\ComplianceNode;
 use CuyZ\Valinor\Compiler\Node;
 use CuyZ\Valinor\Type\ObjectType;
 use CuyZ\Valinor\Type\Type;
+use CuyZ\Valinor\Type\Types\Generics;
 use stdClass;
 
 final class FakeObjectType implements ObjectType
@@ -63,6 +64,11 @@ final class FakeObjectType implements ObjectType
     public function matches(Type $other): bool
     {
         return $other === ($this->matching ?? null);
+    }
+
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
     }
 
     public function nativeType(): ObjectType

--- a/tests/Fake/Type/FakeType.php
+++ b/tests/Fake/Type/FakeType.php
@@ -10,6 +10,7 @@ use CuyZ\Valinor\Tests\Fixture\Object\StringableObject;
 use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\ArrayKeyType;
 use CuyZ\Valinor\Type\Types\ArrayType;
+use CuyZ\Valinor\Type\Types\Generics;
 use CuyZ\Valinor\Type\Types\NativeClassType;
 use CuyZ\Valinor\Type\Types\NativeBooleanType;
 use CuyZ\Valinor\Type\Types\MixedType;
@@ -105,6 +106,11 @@ final class FakeType implements Type
         return $other === $this
             || $other instanceof MixedType
             || $other === ($this->matching ?? null);
+    }
+
+    public function inferGenericsFrom(Type $other, Generics $generics): Generics
+    {
+        return $generics;
     }
 
     public function nativeType(): Type

--- a/tests/Integration/Mapping/Converter/CommonExamples/ArrayKeysToCamelCaseFromAttributeMappingTest.php
+++ b/tests/Integration/Mapping/Converter/CommonExamples/ArrayKeysToCamelCaseFromAttributeMappingTest.php
@@ -43,8 +43,10 @@ final class ArrayKeysToCamelCaseFromAttributeMappingTest extends IntegrationTest
 final class CamelCaseKeys
 {
     /**
+     * @template T of object
      * @param array<mixed> $value
-     * @param callable(array<mixed>): object $next
+     * @param callable(array<mixed>): T $next
+     * @return T
      */
     public function map(array $value, callable $next): object
     {

--- a/tests/Integration/Mapping/Converter/CommonExamples/ArrayKeysToCamelCaseMappingTest.php
+++ b/tests/Integration/Mapping/Converter/CommonExamples/ArrayKeysToCamelCaseMappingTest.php
@@ -23,18 +23,26 @@ final class ArrayKeysToCamelCaseMappingTest extends IntegrationTestCase
 
         try {
             $result = $this->mapperBuilder()
-                ->registerConverter(function (array $value, callable $next): object {
-                    $transformed = [];
+                ->registerConverter(
+                    /**
+                     * @template T of object
+                     * @param array<mixed> $value
+                     * @param callable(array<mixed>): T $next
+                     * @return T
+                     */
+                    function (array $value, callable $next): object {
+                        $transformed = [];
 
-                    foreach ($value as $key => $item) {
-                        $camelCaseKey = lcfirst(str_replace('_', '', ucwords($key, '_')));
+                        foreach ($value as $key => $item) {
+                            $camelCaseKey = lcfirst(str_replace('_', '', ucwords($key, '_')));
 
-                        $transformed[$camelCaseKey] = $item;
+                            $transformed[$camelCaseKey] = $item;
+                        }
+
+                        /** @var callable(array<mixed>): object $next */
+                        return $next($transformed);
                     }
-
-                    /** @var callable(array<mixed>): object $next */
-                    return $next($transformed);
-                })
+                )
                 ->mapper()
                 ->map($class::class, [
                     'first_name' => 'John',

--- a/tests/Integration/Mapping/Converter/CommonExamples/ArrayToListFromAttributeMappingTest.php
+++ b/tests/Integration/Mapping/Converter/CommonExamples/ArrayToListFromAttributeMappingTest.php
@@ -15,8 +15,7 @@ final class ArrayToListFromAttributeMappingTest extends IntegrationTestCase
     {
         $class = new class () {
             /** @var non-empty-list<string> */
-            #[ArrayToList]
-            public array $value;
+            #[ArrayToList] public array $value;
         };
 
         try {
@@ -35,8 +34,9 @@ final class ArrayToListFromAttributeMappingTest extends IntegrationTestCase
 final class ArrayToList
 {
     /**
-     * @param array<mixed> $value
-     * @return list<mixed>
+     * @template T
+     * @param non-empty-array<T> $value
+     * @return non-empty-list<T>
      */
     public function map(array $value): array
     {

--- a/tests/Integration/Mapping/Converter/CommonExamples/ExplodeFromAttributeMappingTest.php
+++ b/tests/Integration/Mapping/Converter/CommonExamples/ExplodeFromAttributeMappingTest.php
@@ -42,7 +42,7 @@ final class Explode
     ) {}
 
     /**
-     * @return array<mixed>
+     * @return list<string>
      */
     public function map(string $value): array
     {

--- a/tests/Integration/Mapping/Converter/CommonExamples/JsonDecodeFromAttributeMappingTest.php
+++ b/tests/Integration/Mapping/Converter/CommonExamples/JsonDecodeFromAttributeMappingTest.php
@@ -17,8 +17,7 @@ final class JsonDecodeFromAttributeMappingTest extends IntegrationTestCase
     {
         $class = new class () {
             /** @var array<scalar> */
-            #[JsonDecode]
-            public array $value;
+            #[JsonDecode] public array $value;
         };
 
         try {
@@ -37,6 +36,11 @@ final class JsonDecodeFromAttributeMappingTest extends IntegrationTestCase
 #[Attribute, AsConverter]
 final class JsonDecode
 {
+    /**
+     * @template T
+     * @param callable(mixed): T $next
+     * @return T
+     */
     public function map(string $value, callable $next): mixed
     {
         $decoded = json_decode($value, associative: true, flags: JSON_THROW_ON_ERROR);

--- a/tests/Integration/Mapping/Converter/CommonExamples/RenameKeysFromAttributeMappingTest.php
+++ b/tests/Integration/Mapping/Converter/CommonExamples/RenameKeysFromAttributeMappingTest.php
@@ -43,8 +43,10 @@ final class RenameKeys
     ) {}
 
     /**
+     * @template T of object
      * @param array<mixed> $value
-     * @param callable(array<mixed>): object $next
+     * @param callable(array<mixed>): T $next
+     * @return T
      */
     public function map(array $value, callable $next): object
     {

--- a/tests/Integration/Mapping/Converter/CommonExamples/RenameKeysMappingTest.php
+++ b/tests/Integration/Mapping/Converter/CommonExamples/RenameKeysMappingTest.php
@@ -18,21 +18,29 @@ final class RenameKeysMappingTest extends IntegrationTestCase
 
         try {
             $result = $this->mapperBuilder()
-                ->registerConverter(function (array $value, callable $next): object {
-                    $mapping = [
-                        'town' => 'city',
-                        'postalCode' => 'zipCode',
-                    ];
+                ->registerConverter(
+                    /**
+                     * @template T of object
+                     * @param array<mixed> $value
+                     * @param callable(array<mixed>): T $next
+                     * @return T
+                     */
+                    function (array $value, callable $next): object {
+                        $mapping = [
+                            'town' => 'city',
+                            'postalCode' => 'zipCode',
+                        ];
 
-                    $renamed = [];
+                        $renamed = [];
 
-                    foreach ($value as $key => $item) {
-                        $renamed[$mapping[$key] ?? $key] = $item;
+                        foreach ($value as $key => $item) {
+                            $renamed[$mapping[$key] ?? $key] = $item;
+                        }
+
+                        /** @var callable(array<mixed>): object $next */
+                        return $next($renamed);
                     }
-
-                    /** @var callable(array<mixed>): object $next */
-                    return $next($renamed);
-                })
+                )
                 ->mapper()
                 ->map($class::class, [
                     'town' => 'Lyon',

--- a/tests/Integration/Mapping/Converter/ValueConverterMappingTest.php
+++ b/tests/Integration/Mapping/Converter/ValueConverterMappingTest.php
@@ -6,10 +6,16 @@ namespace CuyZ\Valinor\Tests\Integration\Mapping\Converter;
 
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Mapper\Tree\Exception\ConverterHasInvalidCallableParameter;
+use CuyZ\Valinor\Mapper\Tree\Exception\ConverterHasInvalidReturnType;
 use CuyZ\Valinor\Mapper\Tree\Exception\ConverterHasNoParameter;
 use CuyZ\Valinor\Mapper\Tree\Exception\ConverterHasTooManyParameters;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
+use DateTimeImmutable;
 use PHPUnit\Framework\Attributes\DataProvider;
+use stdClass;
+
+use function array_map;
+use function iterator_to_array;
 
 final class ValueConverterMappingTest extends IntegrationTestCase
 {
@@ -57,7 +63,7 @@ final class ValueConverterMappingTest extends IntegrationTestCase
             'expectedResult' => 'foo!',
             'convertersByPriority' => [
                 [
-                    fn (string $value, callable $next) => $next() . '!', // @phpstan-ignore binaryOp.invalid (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+                    fn (string $value, callable $next): string => $next() . '!', // @phpstan-ignore binaryOp.invalid (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
                 ],
             ],
         ];
@@ -113,14 +119,374 @@ final class ValueConverterMappingTest extends IntegrationTestCase
                 ],
             ],
         ];
+
+        yield 'generic array key' => [
+            'type' => 'array<int, string>',
+            'value' => [42 => 'foo', 1337 => 'bar'],
+            'expectedResult' => [42 => 'foo!', 1337 => 'bar!'],
+            'convertersByPriority' => [[
+                /**
+                 * @template T of array-key
+                 * @param array<T, string> $value
+                 * @return array<T, non-empty-string>
+                 */
+                fn (array $value) => array_map(fn ($v) => "$v!", $value), // @phpstan-ignore encapsedStringPart.nonString (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+            ]],
+        ];
+
+        yield 'generic array subtype' => [
+            'type' => 'array<int, string>',
+            'value' => [42 => 'foo', 1337 => 'bar'],
+            'expectedResult' => [42 => 'foo!', 1337 => 'bar!'],
+            'convertersByPriority' => [[
+                /**
+                 * @template T
+                 * @param array<int, T> $value
+                 * @return array<int, T>
+                 */
+                fn (array $value) => array_map(fn ($v) => "$v!", $value), // @phpstan-ignore encapsedStringPart.nonString (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+            ]],
+        ];
+
+        yield 'generic non-empty-array key' => [
+            'type' => 'non-empty-array<int, string>',
+            'value' => [42 => 'foo', 1337 => 'bar'],
+            'expectedResult' => [42 => 'foo!', 1337 => 'bar!'],
+            'convertersByPriority' => [[
+                /**
+                 * @template T of array-key
+                 * @param non-empty-array<T, string> $value
+                 * @return non-empty-array<T, non-empty-string>
+                 */
+                fn (array $value) => array_map(fn ($v) => "$v!", $value), // @phpstan-ignore encapsedStringPart.nonString (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+            ]],
+        ];
+
+        yield 'generic non-empty-array subtype' => [
+            'type' => 'non-empty-array<int, string>',
+            'value' => [42 => 'foo', 1337 => 'bar'],
+            'expectedResult' => [42 => 'foo!', 1337 => 'bar!'],
+            'convertersByPriority' => [[
+                /**
+                 * @template T
+                 * @param non-empty-array<int, T> $value
+                 * @return non-empty-array<int, T>
+                 */
+                fn (array $value) => array_map(fn ($v) => "$v!", $value), // @phpstan-ignore encapsedStringPart.nonString (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+            ]],
+        ];
+
+        yield 'generic list subtype' => [
+            'type' => 'list<string>',
+            'value' => ['foo', 'bar'],
+            'expectedResult' => ['foo!', 'bar!'],
+            'convertersByPriority' => [[
+                /**
+                 * @template T
+                 * @param list<T> $value
+                 * @return list<T>
+                 */
+                fn (array $value) => array_map(fn ($v) => "$v!", $value), // @phpstan-ignore encapsedStringPart.nonString (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+            ]],
+        ];
+
+        yield 'generic non-empty-list subtype' => [
+            'type' => 'non-empty-list<string>',
+            'value' => ['foo', 'bar'],
+            'expectedResult' => ['foo!', 'bar!'],
+            'convertersByPriority' => [[
+                /**
+                 * @template T
+                 * @param non-empty-list<T> $value
+                 * @return non-empty-list<T>
+                 */
+                fn (array $value) => array_map(fn ($v) => "$v!", $value), // @phpstan-ignore encapsedStringPart.nonString (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+            ]],
+        ];
+
+        yield 'generic iterable key' => [
+            'type' => 'iterable<int, string>',
+            'value' => [42 => 'foo', 1337 => 'bar'],
+            'expectedResult' => [42 => 'foo!', 1337 => 'bar!'],
+            'convertersByPriority' => [[
+                /**
+                 * @template T of array-key
+                 * @param iterable<T, string> $value
+                 * @return array<T, non-empty-string>
+                 *
+                 * PHP8.1 remove / @phpstan-ignore greaterOrEqual.alwaysTrue
+                 */
+                fn (iterable $value) => array_map(fn ($v) => "$v!", PHP_VERSION_ID >= 8_02_00 ? iterator_to_array($value) : $value), // @phpstan-ignore-line (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+            ]],
+        ];
+
+        yield 'generic iterable subtype' => [
+            'type' => 'iterable<int, string>',
+            'value' => [42 => 'foo', 1337 => 'bar'],
+            'expectedResult' => [42 => 'foo!', 1337 => 'bar!'],
+            'convertersByPriority' => [[
+                /**
+                 * @template T
+                 * @param iterable<int, T> $value
+                 * @return array<int, T>
+                 *
+                 * PHP8.1 remove / @phpstan-ignore greaterOrEqual.alwaysTrue
+                 */
+                fn (iterable $value) => array_map(fn ($v) => "$v!", PHP_VERSION_ID >= 8_02_00 ? iterator_to_array($value) : $value), // @phpstan-ignore-line (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+            ]],
+        ];
+
+        yield 'generic boolean' => [
+            'type' => 'bool',
+            'value' => false,
+            'expectedResult' => true,
+            'convertersByPriority' => [[
+                /**
+                 * @template T of true
+                 * @return T
+                 */
+                fn (bool $value) => true,
+            ]],
+        ];
+
+        yield 'generic boolean value' => [
+            'type' => 'true',
+            'value' => false,
+            'expectedResult' => true,
+            'convertersByPriority' => [[
+                /**
+                 * @template T of true
+                 * @return T
+                 */
+                fn (bool $value) => true,
+            ]],
+        ];
+
+        yield 'generic string' => [
+            'type' => 'string',
+            'value' => 'foo',
+            'expectedResult' => 'foo!',
+            'convertersByPriority' => [[
+                /**
+                 * @template T of string
+                 * @return T
+                 */
+                fn (string $value) => "$value!",
+            ]],
+        ];
+
+        yield 'generic string value' => [
+            'type' => '"foo"',
+            'value' => 'bar',
+            'expectedResult' => 'foo',
+            'convertersByPriority' => [[
+                /**
+                 * @template T of 'foo'
+                 * @return T
+                 */
+                fn (string $value) => 'foo',
+            ]],
+        ];
+
+        yield 'generic non-empty-string' => [
+            'type' => 'non-empty-string',
+            'value' => 'foo',
+            'expectedResult' => 'foo!',
+            'convertersByPriority' => [[
+                /**
+                 * @template T of string
+                 * @return T
+                 */
+                fn (string $value) => "$value!",
+            ]],
+        ];
+
+        yield 'generic numeric-string' => [
+            'type' => 'numeric-string',
+            'value' => '42',
+            'expectedResult' => '1337',
+            'convertersByPriority' => [[
+                /**
+                 * @template T of string
+                 * @return T
+                 */
+                fn (string $value) => '1337',
+            ]],
+        ];
+
+        yield 'generic class-string' => [
+            'type' => 'class-string',
+            'value' => stdClass::class,
+            'expectedResult' => DateTimeImmutable::class,
+            'convertersByPriority' => [[
+                /**
+                 * @template T of class-string
+                 * @return T
+                 */
+                fn (string $value) => DateTimeImmutable::class,
+            ]],
+        ];
+
+        yield 'generic class-string with subtype' => [
+            'type' => 'class-string<DateTimeInterface>',
+            'value' => stdClass::class,
+            'expectedResult' => DateTimeImmutable::class,
+            'convertersByPriority' => [[
+                /**
+                 * @template T class-string
+                 * @return T
+                 */
+                fn (string $value) => DateTimeImmutable::class,
+            ]],
+        ];
+
+        yield 'generic int' => [
+            'type' => 'int',
+            'value' => 42,
+            'expectedResult' => 1337,
+            'convertersByPriority' => [
+                [
+                    /**
+                     * @template T of int
+                     * @return T
+                     */
+                    fn (int $value) => 1337,
+                ]
+            ],
+        ];
+
+        yield 'generic int value' => [
+            'type' => '1337',
+            'value' => 42,
+            'expectedResult' => 1337,
+            'convertersByPriority' => [
+                [
+                    /**
+                     * @template T of 1337
+                     * @return T
+                     */
+                    fn (int $value) => 1337,
+                ]
+            ],
+        ];
+
+        yield 'generic float' => [
+            'type' => 'float',
+            'value' => 42.1,
+            'expectedResult' => 1337.1,
+            'convertersByPriority' => [
+                [
+                    /**
+                     * @template T of float
+                     * @return T
+                     */
+                    fn (float $value) => 1337.1,
+                ]
+            ],
+        ];
+
+        yield 'generic float value' => [
+            'type' => '1337.1',
+            'value' => 42.1,
+            'expectedResult' => 1337.1,
+            'convertersByPriority' => [
+                [
+                    /**
+                     * @template T of 1337.1
+                     * @return T
+                     */
+                    fn (float $value) => 1337.1,
+                ]
+            ],
+        ];
+
+        yield 'generic shaped array' => [
+            'type' => 'array{foo: string, bar: int}',
+            'value' => ['foo' => 'foo', 'bar' => 42],
+            'expectedResult' => ['foo' => 'foo!', 'bar' => 1337],
+            'convertersByPriority' => [
+                [
+                    /**
+                     * @template TFoo
+                     * @template TBar
+                     * @param array{foo: TFoo, bar: TBar} $value
+                     * @return array{foo: TFoo, bar: TBar}
+                     */
+                    fn (array $value) => [
+                        'foo' => 'foo!',
+                        'bar' => 1337,
+                    ],
+                ]
+            ],
+        ];
+
+        yield 'generic union' => [
+            'type' => 'array<string|int|float>',
+            'value' => ['foo', 42],
+            'expectedResult' => ['foo!', '42!'],
+            'convertersByPriority' => [
+                [
+                    /**
+                     * @template T of non-empty-string|positive-int
+                     * @param scalar $value
+                     * @return T|float
+                     */
+                    fn ($value) => "$value!", // @phpstan-ignore encapsedStringPart.nonString (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+                ]
+            ],
+        ];
+
+        yield 'generic inferring invalid parameter type cancels converter' => [
+            'type' => 'array<scalar>',
+            'value' => ['foo', 42],
+            'expectedResult' => ['foo', 42, 'another added value'],
+            'convertersByPriority' => [
+                [
+                    /**
+                     * @template T
+                     * @param array<T, scalar> $value The array key has a wrong type, so this converter will not be called.
+                     * @return T
+                     */
+                    fn (array $value) => [...$value, 'added value'],
+
+                    /**
+                     * @param array<scalar> $value
+                     * @return array<scalar>
+                     */
+                    fn (array $value) => [...$value, 'another added value'],
+                ],
+            ],
+        ];
+
+        yield 'generic inferring invalid return type cancels converter' => [
+            'type' => 'array<scalar>',
+            'value' => ['foo', 42],
+            'expectedResult' => ['foo', 42, 'another added value'],
+            'convertersByPriority' => [
+                [
+                    /**
+                     * @template T of array
+                     * @param array<scalar> $value
+                     * @return T|array<T, scalar> The generic inferring makes no sense, so this converter will not be called.
+                     */
+                    fn (array $value) => [...$value, 'added value'],
+
+                    /**
+                     * @param array<scalar> $value
+                     * @return array<scalar>
+                     */
+                    fn (array $value) => [...$value, 'another added value'],
+                ],
+            ],
+        ];
     }
 
     public function test_converter_with_no_priority_has_priority_0_by_default(): void
     {
         $result = $this->mapperBuilder()
-            ->registerConverter(fn (string $value, callable $next) => $next($value . '!'), -1)
-            ->registerConverter(fn (string $value, callable $next) => $next($value . '?'))
-            ->registerConverter(fn (string $value, callable $next) => $next($value . '#'), 1)
+            ->registerConverter(fn (string $value, callable $next): string => $next($value . '!'), -1) // @phpstan-ignore return.type (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+            ->registerConverter(fn (string $value, callable $next): string => $next($value . '?')) // @phpstan-ignore return.type (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+            ->registerConverter(fn (string $value, callable $next): string => $next($value . '#'), 1) // @phpstan-ignore return.type (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
             ->mapper()
             ->map('string', 'foo');
 
@@ -135,12 +501,9 @@ final class ValueConverterMappingTest extends IntegrationTestCase
 
         $result = $this->mapperBuilder()
             ->infer(SomeInterfaceForClassInferring::class, fn () => $class::class)
-            ->registerConverter(function (int $value, callable $next): SomeInterfaceForClassInferring {
-                $value++;
-
-                /** @var SomeInterfaceForClassInferring */
-                return $next($value);
-            })
+            ->registerConverter(
+                fn (int $value, callable $next): SomeInterfaceForClassInferring => $next($value + 1) // @phpstan-ignore return.type (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
+            )
             ->mapper()
             ->map(SomeInterfaceForClassInferring::class, 123);
 
@@ -151,7 +514,7 @@ final class ValueConverterMappingTest extends IntegrationTestCase
     {
         try {
             $this->mapperBuilder()
-                ->registerConverter(fn (string $value, callable $next) => $next(42))
+                ->registerConverter(fn (string $value, callable $next): string => $next(42)) // @phpstan-ignore return.type (we cannot set closure parameters / see https://github.com/phpstan/phpstan/issues/3770)
                 ->mapper()
                 ->map('string', 'foo');
         } catch (MappingError $exception) {
@@ -194,11 +557,28 @@ final class ValueConverterMappingTest extends IntegrationTestCase
             ->map('string', 'foo');
     }
 
+    public function test_converter_with_invalid_return_type_throws_exception(): void
+    {
+        $this->expectException(ConverterHasInvalidReturnType::class);
+        $this->expectExceptionMessageMatches('/The return type `invalid-type` of function `.*` could not be resolved: cannot parse unknown symbol `invalid-type`\./');
+
+        $this->mapperBuilder()
+            ->registerConverter(
+                /** @return invalid-type */
+                fn (string $foo) => 'bar'
+            )
+            ->mapper()
+            ->map('string', 'foo');
+    }
+
     public function test_converter_returning_invalid_value_makes_mapping_fail(): void
     {
         try {
             $this->mapperBuilder()
-                ->registerConverter(fn (string $value) => '')
+                ->registerConverter(
+                    /** @return non-empty-string */
+                    fn (string $value) => ''
+                )
                 ->mapper()
                 ->map('non-empty-string', 'foo');
         } catch (MappingError $exception) {

--- a/tests/Integration/Type/GenericInferringTest.php
+++ b/tests/Integration/Type/GenericInferringTest.php
@@ -1,0 +1,351 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Type;
+
+use CuyZ\Valinor\Tests\Fixture\Enum\BackedStringEnum;
+use CuyZ\Valinor\Tests\Functional\FunctionalTestCase;
+use CuyZ\Valinor\Type\Parser\Factory\Specifications\ObjectSpecification;
+use CuyZ\Valinor\Type\Parser\Lexer\NativeLexer;
+use CuyZ\Valinor\Type\Parser\Lexer\SpecificationsLexer;
+use CuyZ\Valinor\Type\Parser\LexingParser;
+use CuyZ\Valinor\Type\Parser\VacantTypeAssignerParser;
+use CuyZ\Valinor\Type\Type;
+use CuyZ\Valinor\Type\Types\Generics;
+use CuyZ\Valinor\Type\Types\GenericType;
+use CuyZ\Valinor\Type\Types\MixedType;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+use function array_map;
+
+final class GenericInferringTest extends FunctionalTestCase
+{
+    /**
+     * @param array<non-empty-string, non-empty-string> $generics
+     * @param array<non-empty-string, non-empty-string> $expectedGenerics
+     */
+    #[DataProvider('generics_can_be_inferred_from_type_data_provider')]
+    public function test_generics_can_be_inferred_from_type(array $generics, string $rawTypeA, string $rawTypeB, array $expectedGenerics): void
+    {
+        $lexer = new SpecificationsLexer([new ObjectSpecification(mustCheckTemplates: true)]);
+        $lexer = new NativeLexer($lexer);
+        $parser = new LexingParser($lexer);
+
+        $baseGenerics = [];
+
+        foreach ($generics as $name => $type) {
+            $baseGenerics[$name] = new GenericType($name, $parser->parse($type));
+        }
+
+        $parser = new VacantTypeAssignerParser($parser, $baseGenerics);
+
+        $typeA = $parser->parse($rawTypeA);
+        $typeB = $parser->parse($rawTypeB);
+
+        $inferredGenerics = $typeA->inferGenericsFrom($typeB, new Generics());
+        $inferredGenerics = array_map(static fn (Type $type) => $type->toString(), $inferredGenerics->items);
+
+        self::assertSame($expectedGenerics, $inferredGenerics);
+
+        // We also check that the typeB cannot infer a generic from a mixed type
+        // as it would be a contravariance violation.
+        $inferredGenerics = $typeB->inferGenericsFrom(new MixedType(), new Generics());
+
+        self::assertSame([], $inferredGenerics->items);
+    }
+
+    public static function generics_can_be_inferred_from_type_data_provider(): iterable
+    {
+        $scalars = [
+            'scalar',
+            'array-key',
+            'bool',
+            'true',
+            'float',
+            '1337.42',
+            'string',
+            'non-empty-string',
+            'numeric-string',
+            'class-string',
+            '"string value"',
+            'int',
+            'int<42, 1337>',
+            'positive-int',
+            'negative-int',
+            'non-positive-int',
+            'non-negative-int',
+            '42',
+        ];
+
+        foreach ($scalars as $scalar) {
+            yield "from $scalar" => [
+                'generics' => ['T' => 'scalar'],
+                'typeA' => 'T',
+                'typeB' => $scalar,
+                'expectedGenerics' => [
+                    'T' => $scalar,
+                ],
+            ];
+        }
+
+        yield 'from array key' => [
+            'generics' => ['T' => 'scalar'],
+            'typeA' => 'array<T, string>',
+            'typeB' => 'array<int, string>',
+            'expectedGenerics' => [
+                'T' => 'int',
+            ],
+        ];
+
+        yield 'from array key with union' => [
+            'generics' => ['T' => 'scalar'],
+            'typeA' => 'array<T|string, string>',
+            'typeB' => 'array<int|non-empty-string, string>',
+            'expectedGenerics' => [
+                'T' => 'int',
+            ],
+        ];
+
+        yield 'from array subtype' => [
+            'generics' => ['T' => 'scalar'],
+            'typeA' => 'array<int, T>',
+            'typeB' => 'array<int, string>',
+            'expectedGenerics' => [
+                'T' => 'string',
+            ],
+        ];
+
+        yield 'from array subtype with union' => [
+            'generics' => ['T' => 'scalar'],
+            'typeA' => 'array<int, T|int>',
+            'typeB' => 'array<int, string|positive-int>',
+            'expectedGenerics' => [
+                'T' => 'string',
+            ],
+        ];
+
+        yield 'from non-empty-array key' => [
+            'generics' => ['T' => 'scalar'],
+            'typeA' => 'non-empty-array<T, string>',
+            'typeB' => 'non-empty-array<int, string>',
+            'expectedGenerics' => [
+                'T' => 'int',
+            ],
+        ];
+
+        yield 'from non-empty-array key with union' => [
+            'generics' => ['T' => 'scalar'],
+            'typeA' => 'non-empty-array<T|string, string>',
+            'typeB' => 'non-empty-array<int|non-empty-string, string>',
+            'expectedGenerics' => [
+                'T' => 'int',
+            ],
+        ];
+
+        yield 'from non-empty-array subtype' => [
+            'generics' => ['T' => 'scalar'],
+            'typeA' => 'non-empty-array<int, T>',
+            'typeB' => 'non-empty-array<int, string>',
+            'expectedGenerics' => [
+                'T' => 'string',
+            ],
+        ];
+
+        yield 'from non-empty-array subtype with union' => [
+            'generics' => ['T' => 'scalar'],
+            'typeA' => 'non-empty-array<int, T|int>',
+            'typeB' => 'non-empty-array<int, string|positive-int>',
+            'expectedGenerics' => [
+                'T' => 'string',
+            ],
+        ];
+
+        yield 'from iterable key' => [
+            'generics' => ['T' => 'scalar'],
+            'typeA' => 'iterable<T, string>',
+            'typeB' => 'iterable<int, string>',
+            'expectedGenerics' => [
+                'T' => 'int',
+            ],
+        ];
+
+        yield 'from iterable key with union' => [
+            'generics' => ['T' => 'scalar'],
+            'typeA' => 'iterable<T|string, string>',
+            'typeB' => 'iterable<int|non-empty-string, string>',
+            'expectedGenerics' => [
+                'T' => 'int',
+            ],
+        ];
+
+        yield 'from iterable subtype' => [
+            'generics' => ['T' => 'scalar'],
+            'typeA' => 'iterable<int, T>',
+            'typeB' => 'iterable<int, string>',
+            'expectedGenerics' => [
+                'T' => 'string',
+            ],
+        ];
+
+        yield 'from iterable subtype with union' => [
+            'generics' => ['T' => 'scalar'],
+            'typeA' => 'iterable<int, T|int>',
+            'typeB' => 'iterable<int, string|positive-int>',
+            'expectedGenerics' => [
+                'T' => 'string',
+            ],
+        ];
+
+        yield 'from list subtype' => [
+            'generics' => ['T' => 'scalar'],
+            'typeA' => 'list<T>',
+            'typeB' => 'list<string>',
+            'expectedGenerics' => [
+                'T' => 'string',
+            ],
+        ];
+
+        yield 'from list subtype with union' => [
+            'generics' => ['T' => 'scalar'],
+            'typeA' => 'list<T|int>',
+            'typeB' => 'list<string|positive-int>',
+            'expectedGenerics' => [
+                'T' => 'string',
+            ],
+        ];
+
+        yield 'from non-empty-list subtype' => [
+            'generics' => ['T' => 'scalar'],
+            'typeA' => 'non-empty-list<T>',
+            'typeB' => 'non-empty-list<string>',
+            'expectedGenerics' => [
+                'T' => 'string',
+            ],
+        ];
+
+        yield 'from non-empty-list subtype with union' => [
+            'generics' => ['T' => 'scalar'],
+            'typeA' => 'non-empty-list<T|int>',
+            'typeB' => 'non-empty-list<string|positive-int>',
+            'expectedGenerics' => [
+                'T' => 'string',
+            ],
+        ];
+
+        yield 'from array shape element' => [
+            'generics' => ['T' => 'scalar'],
+            'typeA' => 'array{foo: T, bar: int}',
+            'typeB' => 'array{foo: string, bar: 42|43}',
+            'expectedGenerics' => [
+                'T' => 'string',
+            ],
+        ];
+
+        yield 'from array shape elements' => [
+            'generics' => ['T' => 'scalar'],
+            'typeA' => 'array{foo: T, bar: int, baz: T}',
+            'typeB' => 'array{foo: string, baz: int}',
+            'expectedGenerics' => [
+                'T' => 'string|int',
+            ],
+        ];
+
+        yield 'from class' => [
+            'generics' => [
+                'T1' => 'scalar',
+                'T2' => 'scalar',
+            ],
+            'typeA' => ObjectWithGenerics::class . '<T1, T2>',
+            'typeB' => ObjectWithGenerics::class . '<string, int>',
+            'expectedGenerics' => [
+                'T1' => 'string',
+                'T2' => 'int',
+            ],
+        ];
+
+        yield 'from interface' => [
+            'generics' => [
+                'T1' => 'scalar',
+                'T2' => 'scalar',
+            ],
+            'typeA' => InterfaceWithGenerics::class . '<T1, T2>',
+            'typeB' => InterfaceWithGenerics::class . '<string, int>',
+            'expectedGenerics' => [
+                'T1' => 'string',
+                'T2' => 'int',
+            ],
+        ];
+
+        yield 'from enum' => [
+            'generics' => ['T' => 'mixed'],
+            'typeA' => 'string|T',
+            'typeB' => BackedStringEnum::class . '::BA*|string',
+            'expectedGenerics' => [
+                'T' => BackedStringEnum::class . '::BA*',
+            ],
+        ];
+
+        yield 'from class string' => [
+            'generics' => ['T' => 'object'],
+            'typeA' => 'class-string<T>',
+            'typeB' => 'class-string<stdClass|DateTimeInterface>',
+            'expectedGenerics' => [
+                'T' => 'stdClass|DateTimeInterface',
+            ],
+        ];
+
+        yield 'from union' => [
+            'generics' => [
+                'T1' => 'scalar',
+                'T2' => 'scalar',
+            ],
+            'typeA' => 'T1|T2|string',
+            'typeB' => 'bool|non-empty-string|float',
+            'expectedGenerics' => [
+                'T1' => 'bool|float',
+                'T2' => 'bool|float',
+            ],
+        ];
+
+        yield 'from union inferred with a single type' => [
+            'generics' => [
+                'T1' => 'scalar',
+                'T2' => 'scalar',
+            ],
+            'typeA' => 'T1|T2|string',
+            'typeB' => 'bool',
+            'expectedGenerics' => [
+                'T1' => 'bool',
+                'T2' => 'bool',
+            ],
+        ];
+
+        yield 'from union containing types with subtypes' => [
+            'generics' => [
+                'T1' => 'object',
+                'T2' => 'object',
+            ],
+            'typeA' => 'class-string<T1>|class-string<T2>|float',
+            'typeB' => 'class-string<stdClass>|float|class-string<DateTimeInterface>',
+            'expectedGenerics' => [
+                'T1' => 'stdClass|DateTimeInterface',
+                'T2' => 'stdClass|DateTimeInterface',
+            ],
+        ];
+    }
+}
+
+/**
+ * @template T1
+ * @template T2
+ */
+class ObjectWithGenerics {}
+
+class SimpleObject {}
+
+/**
+ * @template T1
+ * @template T2
+ */
+interface InterfaceWithGenerics {}

--- a/tests/Unit/Definition/ParametersTest.php
+++ b/tests/Unit/Definition/ParametersTest.php
@@ -4,9 +4,15 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Unit\Definition;
 
+use CuyZ\Valinor\Definition\Attributes;
+use CuyZ\Valinor\Definition\ParameterDefinition;
 use CuyZ\Valinor\Definition\Parameters;
 use CuyZ\Valinor\Tests\Fake\Definition\FakeParameterDefinition;
 use CuyZ\Valinor\Tests\Traits\IteratorTester;
+use CuyZ\Valinor\Type\Types\Generics;
+use CuyZ\Valinor\Type\Types\GenericType;
+use CuyZ\Valinor\Type\Types\MixedType;
+use CuyZ\Valinor\Type\Types\NativeStringType;
 use PHPUnit\Framework\TestCase;
 
 use function array_values;
@@ -43,6 +49,26 @@ final class ParametersTest extends TestCase
         $parameters = new Parameters($parameterA, $parameterB);
 
         self::assertSame(['SomeParameterA' => $parameterA, 'SomeParameterB' => $parameterB], $parameters->toArray());
+    }
+
+    public function test_parameters_can_have_generics_assigned(): void
+    {
+        $parameters = new Parameters(
+            new ParameterDefinition(
+                name: 'SomeParameterA',
+                signature: 'someSignature',
+                type: new GenericType('T', new MixedType()),
+                nativeType: new MixedType(),
+                isOptional: true,
+                isVariadic: false,
+                defaultValue: null,
+                attributes: Attributes::empty(),
+            ),
+        );
+
+        $parameters = $parameters->assignGenerics(new Generics(['T' => new NativeStringType()]));
+
+        self::assertInstanceOf(NativeStringType::class, $parameters->at(0)->type);
     }
 
     public function test_parameters_are_countable(): void

--- a/tests/Unit/Type/Types/ScalarConcreteTypeTest.php
+++ b/tests/Unit/Type/Types/ScalarConcreteTypeTest.php
@@ -129,24 +129,24 @@ final class ScalarConcreteTypeTest extends TestCase
         self::assertTrue($this->scalarType->matches(new MixedType()));
     }
 
-    public function test_matches_native_float_type(): void
+    public function test_does_not_match_native_float_type(): void
     {
-        self::assertTrue($this->scalarType->matches(new NativeFloatType()));
+        self::assertFalse($this->scalarType->matches(new NativeFloatType()));
     }
 
-    public function test_matches_native_integer_type(): void
+    public function test_does_not_match_native_integer_type(): void
     {
-        self::assertTrue($this->scalarType->matches(new NativeIntegerType()));
+        self::assertFalse($this->scalarType->matches(new NativeIntegerType()));
     }
 
-    public function test_matches_native_string_type(): void
+    public function test_does_not_match_native_string_type(): void
     {
-        self::assertTrue($this->scalarType->matches(new NativeStringType()));
+        self::assertFalse($this->scalarType->matches(new NativeStringType()));
     }
 
-    public function test_matches_native_boolean_type(): void
+    public function test_does_not_match_native_boolean_type(): void
     {
-        self::assertTrue($this->scalarType->matches(new NativeBooleanType()));
+        self::assertFalse($this->scalarType->matches(new NativeBooleanType()));
     }
 
     public function test_matches_union_type_containing_scalar_type(): void

--- a/tests/Unit/Type/Types/UnionTypeTest.php
+++ b/tests/Unit/Type/Types/UnionTypeTest.php
@@ -45,6 +45,7 @@ final class UnionTypeTest extends TestCase
         $unionA = UnionType::from($typeA, $typeB);
         $unionB = UnionType::from($unionA, $typeC);
 
+        self::assertInstanceOf(UnionType::class, $unionB);
         self::assertSame(
             [$typeA, $typeB, $typeC],
             $unionB->types()

--- a/tests/Unit/Type/Types/UnresolvableTypeTest.php
+++ b/tests/Unit/Type/Types/UnresolvableTypeTest.php
@@ -6,6 +6,8 @@ namespace CuyZ\Valinor\Tests\Unit\Type\Types;
 
 use CuyZ\Valinor\Compiler\Node;
 use CuyZ\Valinor\Tests\Fake\Type\FakeType;
+use CuyZ\Valinor\Type\Types\Generics;
+use CuyZ\Valinor\Type\Types\NativeStringType;
 use CuyZ\Valinor\Type\Types\UnresolvableType;
 use LogicException;
 use PHPUnit\Framework\TestCase;
@@ -46,6 +48,15 @@ final class UnresolvableTypeTest extends TestCase
         $this->expectException(LogicException::class);
 
         $type->nativeType();
+    }
+
+    public function test_call_unresolvable_type_infer_generic_throws_exception(): void
+    {
+        $type = new UnresolvableType('some-type', 'some message');
+
+        $this->expectException(LogicException::class);
+
+        $type->inferGenericsFrom(new NativeStringType(), new Generics());
     }
 
     public function test_cast_string_unresolvable_type_returns_type(): void


### PR DESCRIPTION
Fixes #684
Fixes #691

This commit is the result of a long journey whose goal was to fix a very upsetting bug that would make mapper converters being called when they shouldn't be. This could result in unexpected behaviors and could even lead to invalid data being mapped.

---

Take the following example below:

We register a converter that will return null if the string length is lower than 5. For this converter to be called, the target type should match the `string|null` type, because that is what the converter can return.

In this example, we want to map a value to `string`, which is not matched by the converter return type because it does not contain `null`. This means that the converter should never be called, because it could return an invalid value (`null` will never be a valid `string`).

```php
 (new \CuyZ\Valinor\MapperBuilder())
    ->registerConverter(
        // If the string length is lower than 5, we return `null`
        fn (string $val): ?string => strlen($val) < 5 ? null : $val
    )
    ->mapper()
    ->map('string', 'foo');
```

Before this commit, the converter would be called and return `null`, which would raise an unexpected error:

> An error occurred at path *root*: value null is not a valid string.

This error was caused by the following line:

```php
if (! $shell->type->matches($converter->returnType)) {
    continue;
}
```

It should have been:

```php
if (! $converter->returnType->matches($shell->type)) {
    continue;
}
```

Easy fix, isn't it?

Well… actually no. Because changing this completely modifies the behavior of the converters, and the library is now missing a lot of information to properly infer the return type of the converter.

In some cases this change was enough, but in some more complex cases we now would need more information.

For instance, let's take the `CamelCaseKeys` example as it was written in the documentation before this commit:

```php
final class CamelCaseKeys
{
    /**
     * @param array<mixed> $value
     * @param callable(array<mixed>): object $next
     */
    public function map(array $value, callable $next): object { … }
}
```

There is a big issue in the types signature of this converter: the `object` return type means that the converter can return *anything*, as long as this is an object. This breaks the type matching contract and the converter should never be called. But it was.

This is the new way of writing this converter:

```php
final class CamelCaseKeys
{
    /**
     * @template T of object
     * @param array<mixed> $value
     * @param callable(array<mixed>): T $next
     * @return T
     */
    public function map(array $value, callable $next): object { … }
```

Now, the type matching contract is respected because of the `@template` annotation, and the converter is called when mapping to any object.

To be able to properly infer the return type of the converter, we needed to:

1. Be able to understand `@template` annotations inside functions
2. Be able to statically infer the generics using these annotations
3. Assign the inferred generics to the whole converter
4. Let the system call the converter pipeline properly

This was a *huge* amount of work, which required several small changes during the last month, as well as b7f3e5f and this very commit. A lot of work for an error in a single line of code, right? T_T

The good news is: the library is now more powerful than ever, as it is now able to statically infer generic types, which could bring new possibilities in the future.

Now the bad news is: this commit can break backwards compatibility promise in some cases. But as this is still a (huge) bug fix, we will not release a new major version, although it can break some existing code. Instead, converters should be adapted to use proper type signatures.

To help with that, here are the list of the diff that should be applied to converter examples that were written in the documentation:

**CamelCaseKeys**

```diff
#[\CuyZ\Valinor\Mapper\AsConverter]
#[\Attribute(\Attribute::TARGET_CLASS)]
final class CamelCaseKeys
{
    /**
+    * @template T of object
     * @param array<mixed> $value
-    * @param callable(array<mixed>): object $next
+    * @param callable(array<mixed>): T $next
+    * @return T
     */
    public function map(array $value, callable $next): object
    {
        …
    }
}
```

**RenameKeys**

```diff
#[\CuyZ\Valinor\Mapper\AsConverter]
#[\Attribute(\Attribute::TARGET_CLASS)]
final class RenameKeys
{
    public function __construct(
        /** @var non-empty-array<non-empty-string, non-empty-string> */
        private array $mapping,
    ) {}

    /**
+    * @template T of object
     * @param array<mixed> $value
-    * @param callable(array<mixed>): object $next
+    * @param callable(array<mixed>): T $next
+    * @return T
     */
    public function map(array $value, callable $next): object
    {
        …
    }
}
```

**Explode**

```diff
#[\CuyZ\Valinor\Mapper\AsConverter]
#[\Attribute(\Attribute::TARGET_PROPERTY)]
final class Explode
{
    public function __construct(
        /** @var non-empty-string */
        private string $separator,
    ) {}

    /**
-    * @return array<mixed>
+    * @return list<string>
     */
    public function map(string $value): array
    {
        return explode($this->separator, $value);
    }
}
```

**ArrayToList**

```diff
#[\CuyZ\Valinor\Mapper\AsConverter]
#[\Attribute(\Attribute::TARGET_PROPERTY)]
final class ArrayToList
{
    /**
     * @template T
-    * @param array<mixed> $value
+    * @param non-empty-array<T> $value
-    * @return list<mixed>
+    * @return non-empty-list<T>
     */
    public function map(array $value): array
    {
        return array_values($value);
    }
}
```

**JsonDecode**

```diff
#[\CuyZ\Valinor\Mapper\AsConverter]
#[\Attribute(\Attribute::TARGET_PROPERTY)]
final class JsonDecode
{
     /**
+    * @template T
-    * @param callable(mixed): mixed $next
+    * @param callable(mixed): T $next
+    * @return T
     */
    public function map(string $value, callable $next): mixed
    {
        $decoded = json_decode($value, associative: true);

        return $next($decoded);
    }
}
```