### PR TITLE
chore: change compiled transformer method hashing algo

### DIFF
--- a/src/Normalizer/Transformer/Compiler/TypeFormatter/ClassFormatter.php
+++ b/src/Normalizer/Transformer/Compiler/TypeFormatter/ClassFormatter.php
@@ -207,6 +207,6 @@ final class ClassFormatter implements TypeFormatter
     {
         $slug = preg_replace('/[^a-z0-9]+/', '_', strtolower($this->class->type->toString()));
 
-        return "transform_object_{$slug}_" . hash('xxh128', $this->class->type->toString());
+        return "transform_object_{$slug}_" . hash('crc32', $this->class->type->toString());
     }
 }

--- a/src/Normalizer/Transformer/Compiler/TypeFormatter/ShapedArrayFormatter.php
+++ b/src/Normalizer/Transformer/Compiler/TypeFormatter/ShapedArrayFormatter.php
@@ -97,6 +97,6 @@ final class ShapedArrayFormatter implements TypeFormatter
      */
     private function methodName(): string
     {
-        return 'transform_shaped_array_' . hash('xxh128', $this->type->toString());
+        return 'transform_shaped_array_' . hash('crc32', $this->type->toString());
     }
 }

--- a/src/Normalizer/Transformer/Compiler/TypeFormatter/TraversableFormatter.php
+++ b/src/Normalizer/Transformer/Compiler/TypeFormatter/TraversableFormatter.php
@@ -109,6 +109,6 @@ final class TraversableFormatter implements TypeFormatter
     {
         $slug = preg_replace('/[^a-z0-9]+/', '_', strtolower($this->subType->toString()));
 
-        return "transform_iterable_{$slug}_" . hash('xxh128', $this->subType->toString());
+        return "transform_iterable_{$slug}_" . hash('crc32', $this->subType->toString());
     }
 }

--- a/src/Normalizer/Transformer/Compiler/TypeFormatter/UnionFormatter.php
+++ b/src/Normalizer/Transformer/Compiler/TypeFormatter/UnionFormatter.php
@@ -78,6 +78,6 @@ final class UnionFormatter implements TypeFormatter
      */
     private function methodName(): string
     {
-        return 'transform_union_' . hash('xxh128', $this->type->toString());
+        return 'transform_union_' . hash('crc32', $this->type->toString());
     }
 }

--- a/src/Normalizer/Transformer/Compiler/TypeFormatter/UnsureTypeFormatter.php
+++ b/src/Normalizer/Transformer/Compiler/TypeFormatter/UnsureTypeFormatter.php
@@ -73,6 +73,6 @@ final class UnsureTypeFormatter implements TypeFormatter
     {
         $slug = preg_replace('/[^a-z0-9]+/', '_', strtolower($this->unsureType->toString()));
 
-        return "transform_unsure_{$slug}_" . hash('xxh128', $this->unsureType->toString());
+        return "transform_unsure_{$slug}_" . hash('crc32', $this->unsureType->toString());
     }
 }

--- a/tests/Integration/Normalizer/ExpectedCache/class-implementing-iterator-aggregate.php
+++ b/tests/Integration/Normalizer/ExpectedCache/class-implementing-iterator-aggregate.php
@@ -13,7 +13,7 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
     public function transform(mixed $value): mixed
     {
         $references = new WeakMap();
-        return $this->transform_iterable_string_3be84d23fb1096447c64fce6e12d003c($value, $references);
+        return $this->transform_iterable_string_6a11bcce($value, $references);
     }
 
     private function transform_mixed(mixed $value, WeakMap $references): mixed
@@ -43,12 +43,12 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
             return $value->getName();
         }
         if (\is_iterable($value) && ! $value instanceof Generator) {
-            return $this->transform_iterable_mixed_070660c7e72aa3e14a93c1039279afb6($value, $references);
+            return $this->transform_iterable_mixed_bf66259c($value, $references);
         }
         return $this->delegate->transform($value);
     }
 
-    private function transform_iterable_mixed_070660c7e72aa3e14a93c1039279afb6(iterable $value, WeakMap $references): iterable
+    private function transform_iterable_mixed_bf66259c(iterable $value, WeakMap $references): iterable
     {
         if (\is_array($value)) {
             return \array_map(fn (mixed $item) => $this->transform_mixed($item, $references), $value);
@@ -60,7 +60,7 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
         })();
     }
 
-    private function transform_unsure_string_3be84d23fb1096447c64fce6e12d003c(mixed $value, WeakMap $references): mixed
+    private function transform_unsure_string_6a11bcce(mixed $value, WeakMap $references): mixed
     {
         if (! (\is_string($value))) {
             return $this->transform_mixed($value, $references);
@@ -68,14 +68,14 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
         return $value;
     }
 
-    private function transform_iterable_string_3be84d23fb1096447c64fce6e12d003c(iterable $value, WeakMap $references): iterable
+    private function transform_iterable_string_6a11bcce(iterable $value, WeakMap $references): iterable
     {
         if (\is_array($value)) {
-            return \array_map(fn (mixed $item) => $this->transform_unsure_string_3be84d23fb1096447c64fce6e12d003c($item, $references), $value);
+            return \array_map(fn (mixed $item) => $this->transform_unsure_string_6a11bcce($item, $references), $value);
         }
         return (function () use ($value, $references) {
             foreach ($value as $key => $item) {
-                yield $key => $this->transform_unsure_string_3be84d23fb1096447c64fce6e12d003c($item, $references);
+                yield $key => $this->transform_unsure_string_6a11bcce($item, $references);
             }
         })();
     }

--- a/tests/Integration/Normalizer/ExpectedCache/class-with-datetime-interface.php
+++ b/tests/Integration/Normalizer/ExpectedCache/class-with-datetime-interface.php
@@ -13,10 +13,10 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
     public function transform(mixed $value): mixed
     {
         $references = new WeakMap();
-        return $this->transform_object_cuyz_valinor_tests_integration_normalizer_classwithdatetimeinterface_697272ac658921dbf7da725eb7ffc5c3($value, $references);
+        return $this->transform_object_cuyz_valinor_tests_integration_normalizer_classwithdatetimeinterface_538b7341($value, $references);
     }
 
-    private function transform_object_cuyz_valinor_tests_integration_normalizer_classwithdatetimeinterface_697272ac658921dbf7da725eb7ffc5c3(CuyZ\Valinor\Tests\Integration\Normalizer\ClassWithDateTimeInterface $value, WeakMap $references): array
+    private function transform_object_cuyz_valinor_tests_integration_normalizer_classwithdatetimeinterface_538b7341(CuyZ\Valinor\Tests\Integration\Normalizer\ClassWithDateTimeInterface $value, WeakMap $references): array
     {
         if (isset($references[$value])) {
             throw new CuyZ\Valinor\Normalizer\Exception\CircularReferenceFoundDuringNormalization($value);

--- a/tests/Integration/Normalizer/ExpectedCache/class-with-enum.php
+++ b/tests/Integration/Normalizer/ExpectedCache/class-with-enum.php
@@ -13,10 +13,10 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
     public function transform(mixed $value): mixed
     {
         $references = new WeakMap();
-        return $this->transform_object_cuyz_valinor_tests_integration_normalizer_classwithenum_5ba80f2863248b0097de99712151de8c($value, $references);
+        return $this->transform_object_cuyz_valinor_tests_integration_normalizer_classwithenum_00fa11fc($value, $references);
     }
 
-    private function transform_object_cuyz_valinor_tests_integration_normalizer_classwithenum_5ba80f2863248b0097de99712151de8c(CuyZ\Valinor\Tests\Integration\Normalizer\ClassWithEnum $value, WeakMap $references): array
+    private function transform_object_cuyz_valinor_tests_integration_normalizer_classwithenum_00fa11fc(CuyZ\Valinor\Tests\Integration\Normalizer\ClassWithEnum $value, WeakMap $references): array
     {
         if (isset($references[$value])) {
             throw new CuyZ\Valinor\Normalizer\Exception\CircularReferenceFoundDuringNormalization($value);

--- a/tests/Integration/Normalizer/ExpectedCache/class-with-generic.php
+++ b/tests/Integration/Normalizer/ExpectedCache/class-with-generic.php
@@ -13,10 +13,10 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
     public function transform(mixed $value): mixed
     {
         $references = new WeakMap();
-        return $this->transform_object_cuyz_valinor_tests_integration_normalizer_classwithgeneric_02e4435eef61644851bf0e1f138c4c61($value, $references);
+        return $this->transform_object_cuyz_valinor_tests_integration_normalizer_classwithgeneric_1292a3d8($value, $references);
     }
 
-    private function transform_object_cuyz_valinor_tests_integration_normalizer_classwithgeneric_02e4435eef61644851bf0e1f138c4c61(CuyZ\Valinor\Tests\Integration\Normalizer\ClassWithGeneric $value, WeakMap $references): array
+    private function transform_object_cuyz_valinor_tests_integration_normalizer_classwithgeneric_1292a3d8(CuyZ\Valinor\Tests\Integration\Normalizer\ClassWithGeneric $value, WeakMap $references): array
     {
         if (isset($references[$value])) {
             throw new CuyZ\Valinor\Normalizer\Exception\CircularReferenceFoundDuringNormalization($value);
@@ -27,7 +27,7 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
             'value' => $value->value,
         ];
         $transformed = [];
-        $transformed['value'] = $this->transform_unsure_t_of_string_01a0c1224a31bfe672d329efa0903033($values['value'], $references);
+        $transformed['value'] = $this->transform_unsure_t_of_string_674cb654($values['value'], $references);
         return $transformed;
     }
 
@@ -58,12 +58,12 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
             return $value->getName();
         }
         if (\is_iterable($value) && ! $value instanceof Generator) {
-            return $this->transform_iterable_mixed_070660c7e72aa3e14a93c1039279afb6($value, $references);
+            return $this->transform_iterable_mixed_bf66259c($value, $references);
         }
         return $this->delegate->transform($value);
     }
 
-    private function transform_iterable_mixed_070660c7e72aa3e14a93c1039279afb6(iterable $value, WeakMap $references): iterable
+    private function transform_iterable_mixed_bf66259c(iterable $value, WeakMap $references): iterable
     {
         if (\is_array($value)) {
             return \array_map(fn (mixed $item) => $this->transform_mixed($item, $references), $value);
@@ -75,7 +75,7 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
         })();
     }
 
-    private function transform_unsure_t_of_string_01a0c1224a31bfe672d329efa0903033(mixed $value, WeakMap $references): mixed
+    private function transform_unsure_t_of_string_674cb654(mixed $value, WeakMap $references): mixed
     {
         if (! (\is_string($value))) {
             return $this->transform_mixed($value, $references);

--- a/tests/Integration/Normalizer/ExpectedCache/class-with-transformers-on-first-property.php
+++ b/tests/Integration/Normalizer/ExpectedCache/class-with-transformers-on-first-property.php
@@ -13,10 +13,10 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
     public function transform(mixed $value): mixed
     {
         $references = new WeakMap();
-        return $this->transform_object_cuyz_valinor_tests_integration_normalizer_classwithtwoproperties_c92577fbc267308639f49ed4ff6c9630($value, $references);
+        return $this->transform_object_cuyz_valinor_tests_integration_normalizer_classwithtwoproperties_770bd0d9($value, $references);
     }
 
-    private function transform_object_cuyz_valinor_tests_integration_normalizer_classwithtwoproperties_c92577fbc267308639f49ed4ff6c9630(CuyZ\Valinor\Tests\Integration\Normalizer\ClassWithTwoProperties $value, WeakMap $references): array
+    private function transform_object_cuyz_valinor_tests_integration_normalizer_classwithtwoproperties_770bd0d9(CuyZ\Valinor\Tests\Integration\Normalizer\ClassWithTwoProperties $value, WeakMap $references): array
     {
         if (isset($references[$value])) {
             throw new CuyZ\Valinor\Normalizer\Exception\CircularReferenceFoundDuringNormalization($value);

--- a/tests/Integration/Normalizer/ExpectedCache/class-with-two-properties.php
+++ b/tests/Integration/Normalizer/ExpectedCache/class-with-two-properties.php
@@ -13,10 +13,10 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
     public function transform(mixed $value): mixed
     {
         $references = new WeakMap();
-        return $this->transform_object_cuyz_valinor_tests_integration_normalizer_classwithtwoproperties_c92577fbc267308639f49ed4ff6c9630($value, $references);
+        return $this->transform_object_cuyz_valinor_tests_integration_normalizer_classwithtwoproperties_770bd0d9($value, $references);
     }
 
-    private function transform_object_cuyz_valinor_tests_integration_normalizer_classwithtwoproperties_c92577fbc267308639f49ed4ff6c9630(CuyZ\Valinor\Tests\Integration\Normalizer\ClassWithTwoProperties $value, WeakMap $references): array
+    private function transform_object_cuyz_valinor_tests_integration_normalizer_classwithtwoproperties_770bd0d9(CuyZ\Valinor\Tests\Integration\Normalizer\ClassWithTwoProperties $value, WeakMap $references): array
     {
         if (isset($references[$value])) {
             throw new CuyZ\Valinor\Normalizer\Exception\CircularReferenceFoundDuringNormalization($value);

--- a/tests/Integration/Normalizer/ExpectedCache/class-with-union.php
+++ b/tests/Integration/Normalizer/ExpectedCache/class-with-union.php
@@ -13,10 +13,10 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
     public function transform(mixed $value): mixed
     {
         $references = new WeakMap();
-        return $this->transform_object_cuyz_valinor_tests_integration_normalizer_classwithunion_c052217c4ff1d9fdc10dc978828c924d($value, $references);
+        return $this->transform_object_cuyz_valinor_tests_integration_normalizer_classwithunion_ecce9fbb($value, $references);
     }
 
-    private function transform_object_cuyz_valinor_tests_integration_normalizer_classwithunion_c052217c4ff1d9fdc10dc978828c924d(CuyZ\Valinor\Tests\Integration\Normalizer\ClassWithUnion $value, WeakMap $references): array
+    private function transform_object_cuyz_valinor_tests_integration_normalizer_classwithunion_ecce9fbb(CuyZ\Valinor\Tests\Integration\Normalizer\ClassWithUnion $value, WeakMap $references): array
     {
         if (isset($references[$value])) {
             throw new CuyZ\Valinor\Normalizer\Exception\CircularReferenceFoundDuringNormalization($value);
@@ -27,7 +27,7 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
             'value' => $value->value,
         ];
         $transformed = [];
-        $transformed['value'] = $this->transform_union_1f8b539a9ee7a716469ab010cef5ca01($values['value'], $references);
+        $transformed['value'] = $this->transform_union_aaa10f70($values['value'], $references);
         return $transformed;
     }
 
@@ -58,12 +58,12 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
             return $value->getName();
         }
         if (\is_iterable($value) && ! $value instanceof Generator) {
-            return $this->transform_iterable_mixed_070660c7e72aa3e14a93c1039279afb6($value, $references);
+            return $this->transform_iterable_mixed_bf66259c($value, $references);
         }
         return $this->delegate->transform($value);
     }
 
-    private function transform_iterable_mixed_070660c7e72aa3e14a93c1039279afb6(iterable $value, WeakMap $references): iterable
+    private function transform_iterable_mixed_bf66259c(iterable $value, WeakMap $references): iterable
     {
         if (\is_array($value)) {
             return \array_map(fn (mixed $item) => $this->transform_mixed($item, $references), $value);
@@ -75,7 +75,7 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
         })();
     }
 
-    private function transform_union_1f8b539a9ee7a716469ab010cef5ca01(mixed $value, WeakMap $references): mixed
+    private function transform_union_aaa10f70(mixed $value, WeakMap $references): mixed
     {
         if ($value instanceof DateTimeInterface) {
             return $value->format('Y-m-d\\TH:i:s.uP');

--- a/tests/Integration/Normalizer/ExpectedCache/class-with-unresolvable-type-and-mixed-native-type.php
+++ b/tests/Integration/Normalizer/ExpectedCache/class-with-unresolvable-type-and-mixed-native-type.php
@@ -13,10 +13,10 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
     public function transform(mixed $value): mixed
     {
         $references = new WeakMap();
-        return $this->transform_object_cuyz_valinor_tests_integration_normalizer_classwithunresolvabletypeandmixednativetype_b20b7aa697cba45f8001418603f28c69($value, $references);
+        return $this->transform_object_cuyz_valinor_tests_integration_normalizer_classwithunresolvabletypeandmixednativetype_21415243($value, $references);
     }
 
-    private function transform_object_cuyz_valinor_tests_integration_normalizer_classwithunresolvabletypeandmixednativetype_b20b7aa697cba45f8001418603f28c69(CuyZ\Valinor\Tests\Integration\Normalizer\ClassWithUnresolvableTypeAndMixedNativeType $value, WeakMap $references): array
+    private function transform_object_cuyz_valinor_tests_integration_normalizer_classwithunresolvabletypeandmixednativetype_21415243(CuyZ\Valinor\Tests\Integration\Normalizer\ClassWithUnresolvableTypeAndMixedNativeType $value, WeakMap $references): array
     {
         if (isset($references[$value])) {
             throw new CuyZ\Valinor\Normalizer\Exception\CircularReferenceFoundDuringNormalization($value);
@@ -58,12 +58,12 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
             return $value->getName();
         }
         if (\is_iterable($value) && ! $value instanceof Generator) {
-            return $this->transform_iterable_mixed_070660c7e72aa3e14a93c1039279afb6($value, $references);
+            return $this->transform_iterable_mixed_bf66259c($value, $references);
         }
         return $this->delegate->transform($value);
     }
 
-    private function transform_iterable_mixed_070660c7e72aa3e14a93c1039279afb6(iterable $value, WeakMap $references): iterable
+    private function transform_iterable_mixed_bf66259c(iterable $value, WeakMap $references): iterable
     {
         if (\is_array($value)) {
             return \array_map(fn (mixed $item) => $this->transform_mixed($item, $references), $value);

--- a/tests/Integration/Normalizer/ExpectedCache/class-with-unresolvable-type-and-string-native-type.php
+++ b/tests/Integration/Normalizer/ExpectedCache/class-with-unresolvable-type-and-string-native-type.php
@@ -13,10 +13,10 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
     public function transform(mixed $value): mixed
     {
         $references = new WeakMap();
-        return $this->transform_object_cuyz_valinor_tests_integration_normalizer_classwithunresolvabletypeandstringnativetype_a54f43042f7e8b387fca94af92af8e09($value, $references);
+        return $this->transform_object_cuyz_valinor_tests_integration_normalizer_classwithunresolvabletypeandstringnativetype_19d6251e($value, $references);
     }
 
-    private function transform_object_cuyz_valinor_tests_integration_normalizer_classwithunresolvabletypeandstringnativetype_a54f43042f7e8b387fca94af92af8e09(CuyZ\Valinor\Tests\Integration\Normalizer\ClassWithUnresolvableTypeAndStringNativeType $value, WeakMap $references): array
+    private function transform_object_cuyz_valinor_tests_integration_normalizer_classwithunresolvabletypeandstringnativetype_19d6251e(CuyZ\Valinor\Tests\Integration\Normalizer\ClassWithUnresolvableTypeAndStringNativeType $value, WeakMap $references): array
     {
         if (isset($references[$value])) {
             throw new CuyZ\Valinor\Normalizer\Exception\CircularReferenceFoundDuringNormalization($value);
@@ -58,12 +58,12 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
             return $value->getName();
         }
         if (\is_iterable($value) && ! $value instanceof Generator) {
-            return $this->transform_iterable_mixed_070660c7e72aa3e14a93c1039279afb6($value, $references);
+            return $this->transform_iterable_mixed_bf66259c($value, $references);
         }
         return $this->delegate->transform($value);
     }
 
-    private function transform_iterable_mixed_070660c7e72aa3e14a93c1039279afb6(iterable $value, WeakMap $references): iterable
+    private function transform_iterable_mixed_bf66259c(iterable $value, WeakMap $references): iterable
     {
         if (\is_array($value)) {
             return \array_map(fn (mixed $item) => $this->transform_mixed($item, $references), $value);

--- a/tests/Integration/Normalizer/ExpectedCache/class-with-unsealed-shaped-array.php
+++ b/tests/Integration/Normalizer/ExpectedCache/class-with-unsealed-shaped-array.php
@@ -13,10 +13,10 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
     public function transform(mixed $value): mixed
     {
         $references = new WeakMap();
-        return $this->transform_object_cuyz_valinor_tests_integration_normalizer_classwithunsealedshapedarray_8ddd6ae4828a3f796a5a41d74f786c00($value, $references);
+        return $this->transform_object_cuyz_valinor_tests_integration_normalizer_classwithunsealedshapedarray_58858794($value, $references);
     }
 
-    private function transform_object_cuyz_valinor_tests_integration_normalizer_classwithunsealedshapedarray_8ddd6ae4828a3f796a5a41d74f786c00(CuyZ\Valinor\Tests\Integration\Normalizer\ClassWithUnsealedShapedArray $value, WeakMap $references): array
+    private function transform_object_cuyz_valinor_tests_integration_normalizer_classwithunsealedshapedarray_58858794(CuyZ\Valinor\Tests\Integration\Normalizer\ClassWithUnsealedShapedArray $value, WeakMap $references): array
     {
         if (isset($references[$value])) {
             throw new CuyZ\Valinor\Normalizer\Exception\CircularReferenceFoundDuringNormalization($value);
@@ -27,7 +27,7 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
             'shapedArray' => $value->shapedArray,
         ];
         $transformed = [];
-        $transformed['shapedArray'] = $this->transform_shaped_array_6e221ad90986e9902ef7a23f87c2f63a($values['shapedArray'], $references);
+        $transformed['shapedArray'] = $this->transform_shaped_array_5d47d611($values['shapedArray'], $references);
         return $transformed;
     }
 
@@ -58,12 +58,12 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
             return $value->getName();
         }
         if (\is_iterable($value) && ! $value instanceof Generator) {
-            return $this->transform_iterable_mixed_070660c7e72aa3e14a93c1039279afb6($value, $references);
+            return $this->transform_iterable_mixed_bf66259c($value, $references);
         }
         return $this->delegate->transform($value);
     }
 
-    private function transform_iterable_mixed_070660c7e72aa3e14a93c1039279afb6(iterable $value, WeakMap $references): iterable
+    private function transform_iterable_mixed_bf66259c(iterable $value, WeakMap $references): iterable
     {
         if (\is_array($value)) {
             return \array_map(fn (mixed $item) => $this->transform_mixed($item, $references), $value);
@@ -75,7 +75,7 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
         })();
     }
 
-    private function transform_unsure_string_3be84d23fb1096447c64fce6e12d003c(mixed $value, WeakMap $references): mixed
+    private function transform_unsure_string_6a11bcce(mixed $value, WeakMap $references): mixed
     {
         if (! (\is_string($value))) {
             return $this->transform_mixed($value, $references);
@@ -83,7 +83,7 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
         return $value;
     }
 
-    private function transform_unsure_int_7617cc4b435dae7c97211c6082923b47(mixed $value, WeakMap $references): mixed
+    private function transform_unsure_int_c53673f7(mixed $value, WeakMap $references): mixed
     {
         if (! (\is_int($value))) {
             return $this->transform_mixed($value, $references);
@@ -91,14 +91,14 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
         return $value;
     }
 
-    private function transform_shaped_array_6e221ad90986e9902ef7a23f87c2f63a(array $value, WeakMap $references): array
+    private function transform_shaped_array_5d47d611(array $value, WeakMap $references): array
     {
         $result = [];
         foreach ($value as $key => $item) {
             $result[$key] = match ($key) {
-                'someString' => $this->transform_unsure_string_3be84d23fb1096447c64fce6e12d003c($item, $references),
-                'someInt' => $this->transform_unsure_int_7617cc4b435dae7c97211c6082923b47($item, $references),
-                default => $this->transform_unsure_string_3be84d23fb1096447c64fce6e12d003c($item, $references),
+                'someString' => $this->transform_unsure_string_6a11bcce($item, $references),
+                'someInt' => $this->transform_unsure_int_c53673f7($item, $references),
+                default => $this->transform_unsure_string_6a11bcce($item, $references),
             };
         }
         return $result;

--- a/tests/Integration/Normalizer/ExpectedCache/generator-with-scalars.php
+++ b/tests/Integration/Normalizer/ExpectedCache/generator-with-scalars.php
@@ -13,7 +13,7 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
     public function transform(mixed $value): mixed
     {
         $references = new WeakMap();
-        return $this->transform_iterable_string_3be84d23fb1096447c64fce6e12d003c($value, $references);
+        return $this->transform_iterable_string_6a11bcce($value, $references);
     }
 
     private function transform_mixed(mixed $value, WeakMap $references): mixed
@@ -43,12 +43,12 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
             return $value->getName();
         }
         if (\is_iterable($value) && ! $value instanceof Generator) {
-            return $this->transform_iterable_mixed_070660c7e72aa3e14a93c1039279afb6($value, $references);
+            return $this->transform_iterable_mixed_bf66259c($value, $references);
         }
         return $this->delegate->transform($value);
     }
 
-    private function transform_iterable_mixed_070660c7e72aa3e14a93c1039279afb6(iterable $value, WeakMap $references): iterable
+    private function transform_iterable_mixed_bf66259c(iterable $value, WeakMap $references): iterable
     {
         if (\is_array($value)) {
             return \array_map(fn (mixed $item) => $this->transform_mixed($item, $references), $value);
@@ -60,7 +60,7 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
         })();
     }
 
-    private function transform_unsure_string_3be84d23fb1096447c64fce6e12d003c(mixed $value, WeakMap $references): mixed
+    private function transform_unsure_string_6a11bcce(mixed $value, WeakMap $references): mixed
     {
         if (! (\is_string($value))) {
             return $this->transform_mixed($value, $references);
@@ -68,14 +68,14 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
         return $value;
     }
 
-    private function transform_iterable_string_3be84d23fb1096447c64fce6e12d003c(iterable $value, WeakMap $references): iterable
+    private function transform_iterable_string_6a11bcce(iterable $value, WeakMap $references): iterable
     {
         if (\is_array($value)) {
-            return \array_map(fn (mixed $item) => $this->transform_unsure_string_3be84d23fb1096447c64fce6e12d003c($item, $references), $value);
+            return \array_map(fn (mixed $item) => $this->transform_unsure_string_6a11bcce($item, $references), $value);
         }
         return (function () use ($value, $references) {
             foreach ($value as $key => $item) {
-                yield $key => $this->transform_unsure_string_3be84d23fb1096447c64fce6e12d003c($item, $references);
+                yield $key => $this->transform_unsure_string_6a11bcce($item, $references);
             }
         })();
     }

--- a/tests/Integration/Normalizer/ExpectedCache/iterable-of-objects.php
+++ b/tests/Integration/Normalizer/ExpectedCache/iterable-of-objects.php
@@ -13,7 +13,7 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
     public function transform(mixed $value): mixed
     {
         $references = new WeakMap();
-        return $this->transform_iterable_stdclass_8fe5e53a83cbf2f3b41ad249eab32395($value, $references);
+        return $this->transform_iterable_stdclass_738f02a0($value, $references);
     }
 
     private function transform_mixed(mixed $value, WeakMap $references): mixed
@@ -43,12 +43,12 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
             return $value->getName();
         }
         if (\is_iterable($value) && ! $value instanceof Generator) {
-            return $this->transform_iterable_mixed_070660c7e72aa3e14a93c1039279afb6($value, $references);
+            return $this->transform_iterable_mixed_bf66259c($value, $references);
         }
         return $this->delegate->transform($value);
     }
 
-    private function transform_iterable_mixed_070660c7e72aa3e14a93c1039279afb6(iterable $value, WeakMap $references): iterable
+    private function transform_iterable_mixed_bf66259c(iterable $value, WeakMap $references): iterable
     {
         if (\is_array($value)) {
             return \array_map(fn (mixed $item) => $this->transform_mixed($item, $references), $value);
@@ -69,7 +69,7 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
         return \array_map(fn (mixed $value) => $this->transform_mixed($value, $references), (array)$value);
     }
 
-    private function transform_unsure_stdclass_8fe5e53a83cbf2f3b41ad249eab32395(mixed $value, WeakMap $references): mixed
+    private function transform_unsure_stdclass_738f02a0(mixed $value, WeakMap $references): mixed
     {
         if (! ($value instanceof stdClass)) {
             return $this->transform_mixed($value, $references);
@@ -77,14 +77,14 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
         return $this->transform_stdclass($value, $references);
     }
 
-    private function transform_iterable_stdclass_8fe5e53a83cbf2f3b41ad249eab32395(iterable $value, WeakMap $references): iterable
+    private function transform_iterable_stdclass_738f02a0(iterable $value, WeakMap $references): iterable
     {
         if (\is_array($value)) {
-            return \array_map(fn (mixed $item) => $this->transform_unsure_stdclass_8fe5e53a83cbf2f3b41ad249eab32395($item, $references), $value);
+            return \array_map(fn (mixed $item) => $this->transform_unsure_stdclass_738f02a0($item, $references), $value);
         }
         return (function () use ($value, $references) {
             foreach ($value as $key => $item) {
-                yield $key => $this->transform_unsure_stdclass_8fe5e53a83cbf2f3b41ad249eab32395($item, $references);
+                yield $key => $this->transform_unsure_stdclass_738f02a0($item, $references);
             }
         })();
     }

--- a/tests/Integration/Normalizer/ExpectedCache/iterable-of-scalars-with-transformers.php
+++ b/tests/Integration/Normalizer/ExpectedCache/iterable-of-scalars-with-transformers.php
@@ -13,7 +13,7 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
     public function transform(mixed $value): mixed
     {
         $references = new WeakMap();
-        return $this->transform_iterable_string_3be84d23fb1096447c64fce6e12d003c($value, $references);
+        return $this->transform_iterable_string_6a11bcce($value, $references);
     }
 
     private function transform_string_a745897c0704318aa48e8aa8d29ba050aa7eda39(mixed $value, WeakMap $references): mixed
@@ -52,7 +52,7 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
             return $value->getName();
         }
         if (\is_iterable($value) && ! $value instanceof Generator) {
-            return $this->transform_iterable_mixed_070660c7e72aa3e14a93c1039279afb6($value, $references);
+            return $this->transform_iterable_mixed_bf66259c($value, $references);
         }
         return $this->delegate->transform($value);
     }
@@ -84,7 +84,7 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
         return $next();
     }
 
-    private function transform_iterable_mixed_070660c7e72aa3e14a93c1039279afb6(iterable $value, WeakMap $references): iterable
+    private function transform_iterable_mixed_bf66259c(iterable $value, WeakMap $references): iterable
     {
         if (\is_array($value)) {
             return \array_map(fn (mixed $item) => $this->transform_mixed($item, $references), $value);
@@ -96,7 +96,7 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
         })();
     }
 
-    private function transform_unsure_string_3be84d23fb1096447c64fce6e12d003c(mixed $value, WeakMap $references): mixed
+    private function transform_unsure_string_6a11bcce(mixed $value, WeakMap $references): mixed
     {
         if (! (\is_string($value))) {
             return $this->transform_mixed($value, $references);
@@ -104,14 +104,14 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
         return $this->transform_string_a745897c0704318aa48e8aa8d29ba050aa7eda39($value, $references);
     }
 
-    private function transform_iterable_string_3be84d23fb1096447c64fce6e12d003c(iterable $value, WeakMap $references): iterable
+    private function transform_iterable_string_6a11bcce(iterable $value, WeakMap $references): iterable
     {
         if (\is_array($value)) {
-            return \array_map(fn (mixed $item) => $this->transform_unsure_string_3be84d23fb1096447c64fce6e12d003c($item, $references), $value);
+            return \array_map(fn (mixed $item) => $this->transform_unsure_string_6a11bcce($item, $references), $value);
         }
         return (function () use ($value, $references) {
             foreach ($value as $key => $item) {
-                yield $key => $this->transform_unsure_string_3be84d23fb1096447c64fce6e12d003c($item, $references);
+                yield $key => $this->transform_unsure_string_6a11bcce($item, $references);
             }
         })();
     }

--- a/tests/Integration/Normalizer/ExpectedCache/iterable-of-scalars-without-transformers.php
+++ b/tests/Integration/Normalizer/ExpectedCache/iterable-of-scalars-without-transformers.php
@@ -13,7 +13,7 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
     public function transform(mixed $value): mixed
     {
         $references = new WeakMap();
-        return $this->transform_iterable_string_3be84d23fb1096447c64fce6e12d003c($value, $references);
+        return $this->transform_iterable_string_6a11bcce($value, $references);
     }
 
     private function transform_mixed(mixed $value, WeakMap $references): mixed
@@ -43,12 +43,12 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
             return $value->getName();
         }
         if (\is_iterable($value) && ! $value instanceof Generator) {
-            return $this->transform_iterable_mixed_070660c7e72aa3e14a93c1039279afb6($value, $references);
+            return $this->transform_iterable_mixed_bf66259c($value, $references);
         }
         return $this->delegate->transform($value);
     }
 
-    private function transform_iterable_mixed_070660c7e72aa3e14a93c1039279afb6(iterable $value, WeakMap $references): iterable
+    private function transform_iterable_mixed_bf66259c(iterable $value, WeakMap $references): iterable
     {
         if (\is_array($value)) {
             return \array_map(fn (mixed $item) => $this->transform_mixed($item, $references), $value);
@@ -60,7 +60,7 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
         })();
     }
 
-    private function transform_unsure_string_3be84d23fb1096447c64fce6e12d003c(mixed $value, WeakMap $references): mixed
+    private function transform_unsure_string_6a11bcce(mixed $value, WeakMap $references): mixed
     {
         if (! (\is_string($value))) {
             return $this->transform_mixed($value, $references);
@@ -68,14 +68,14 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
         return $value;
     }
 
-    private function transform_iterable_string_3be84d23fb1096447c64fce6e12d003c(iterable $value, WeakMap $references): iterable
+    private function transform_iterable_string_6a11bcce(iterable $value, WeakMap $references): iterable
     {
         if (\is_array($value)) {
-            return \array_map(fn (mixed $item) => $this->transform_unsure_string_3be84d23fb1096447c64fce6e12d003c($item, $references), $value);
+            return \array_map(fn (mixed $item) => $this->transform_unsure_string_6a11bcce($item, $references), $value);
         }
         return (function () use ($value, $references) {
             foreach ($value as $key => $item) {
-                yield $key => $this->transform_unsure_string_3be84d23fb1096447c64fce6e12d003c($item, $references);
+                yield $key => $this->transform_unsure_string_6a11bcce($item, $references);
             }
         })();
     }


### PR DESCRIPTION
We change from `xxh128` to `crc32` for smaller methods names.