### PR TITLE
fix: handle default value retrieval for properties

### DIFF
--- a/src/Definition/Repository/Reflection/ReflectionPropertyDefinitionBuilder.php
+++ b/src/Definition/Repository/Reflection/ReflectionPropertyDefinitionBuilder.php
@@ -29,7 +29,7 @@ final class ReflectionPropertyDefinitionBuilder
         $type = $propertyTypeResolver->resolveTypeFor($reflection);
         $nativeType = $propertyTypeResolver->resolveNativeTypeFor($reflection);
         $hasDefaultValue = $this->hasDefaultValue($reflection, $type);
-        $defaultValue = $reflection->getDefaultValue();
+        $defaultValue = $hasDefaultValue ? $reflection->getDefaultValue() : null;
         $isPublic = $reflection->isPublic();
 
         if ($type instanceof UnresolvableType) {


### PR DESCRIPTION
Calling `ReflectionProperty::getDefaultValue()` on a property without a default value is deprecated since PHP v8.5[^1]. With this change, the method is now only called if the property actually contains a default value.

[^1]: https://github.com/php/php-src/pull/19457