### PR TITLE
chore: use memoization for arguments' conversion to shaped array

### DIFF
--- a/src/Mapper/Object/Arguments.php
+++ b/src/Mapper/Object/Arguments.php
@@ -30,6 +30,8 @@ final class Arguments implements IteratorAggregate, Countable
     /** @var array<string, Argument> */
     private readonly array $arguments;
 
+    private ShapedArrayType $shapedArray;
+
     public function __construct(Argument ...$arguments)
     {
         $args = [];
@@ -78,17 +80,16 @@ final class Arguments implements IteratorAggregate, Countable
 
     public function toShapedArray(): ShapedArrayType
     {
-        $shapedArrayElements = [];
-        foreach ($this->arguments as $i => $argument) {
-            $shapedArrayElements[$i] = new ShapedArrayElement(
-                key: new StringValueType($argument->name()),
-                type: $argument->type(),
-                optional: ! $argument->isRequired(),
-                attributes: $argument->attributes(),
-            );
-        }
-        return new ShapedArrayType(
-            elements: $shapedArrayElements,
+        return $this->shapedArray ??= new ShapedArrayType(
+            elements: array_map(
+                static fn (Argument $argument) => new ShapedArrayElement(
+                    key: new StringValueType($argument->name()),
+                    type: $argument->type(),
+                    optional: ! $argument->isRequired(),
+                    attributes: $argument->attributes(),
+                ),
+                $this->arguments,
+            ),
             isUnsealed: false,
             unsealedType: null,
         );


### PR DESCRIPTION
See #733, #735

I actually think using memoization is probably a best idea, the memory footprint is not that high. Also we can re-add the `array_map` which would not be used that often now.

@staabm WDYT? Could you benchmark this?