### PR TITLE
chore: use memoization for ShapedArrayType->toString()

### DIFF
--- a/src/Type/Types/ShapedArrayType.php
+++ b/src/Type/Types/ShapedArrayType.php
@@ -269,10 +269,11 @@ final class ShapedArrayType implements CompositeType, DumpableType
 
     public function toString(): string
     {
-        if ($this->signature !== null) {
-            return $this->signature;
-        }
+        return $this->signature ??= $this->buildSignature();
+    }
 
+    private function buildSignature(): string
+    {
         $signature = 'array{';
         $signature .= implode(', ', array_map(static fn (ShapedArrayElement $element) => $element->toString(), $this->elements));
 
@@ -286,6 +287,6 @@ final class ShapedArrayType implements CompositeType, DumpableType
 
         $signature .= '}';
 
-        return $this->signature = $signature;
+        return $signature;
     }
 }


### PR DESCRIPTION
fixes 

<img width="325" height="670" alt="grafik" src="https://github.com/user-attachments/assets/a4c3d028-a7bc-4586-ae14-797a554dc1df" />

leads to

<img width="163" height="72" alt="grafik" src="https://github.com/user-attachments/assets/882b2c24-d7cd-443a-8fff-3617f4ca049e" />

refs https://github.com/CuyZ/Valinor/issues/733