### PR TITLE
qa: Do not use named parameters for Mapper\Tree\Builder\Node::$value

### DIFF
--- a/src/Mapper/Tree/Builder/Node.php
+++ b/src/Mapper/Tree/Builder/Node.php
@@ -27,7 +27,7 @@ final class Node
      */
     public static function new(mixed $value, int $childrenCount): self
     {
-        return new self(value: $value, childrenCount: $childrenCount);
+        return new self($value, childrenCount: $childrenCount);
     }
 
     public static function error(Shell $shell, Message $error): self
@@ -42,7 +42,7 @@ final class Node
             $shell->dumpValue(),
         );
 
-        return new self(value: null, messages: [$nodeMessage]);
+        return new self(null, messages: [$nodeMessage]);
     }
 
     /**
@@ -56,7 +56,7 @@ final class Node
             $messages = array_merge($messages, $node->messages);
         }
 
-        return new self(value: null, messages: $messages);
+        return new self(null, messages: $messages);
     }
 
     /**
@@ -85,7 +85,7 @@ final class Node
     public function appendMessage(NodeMessage $message): self
     {
         return new self(
-            value: null,
+            null,
             messages: [...$this->messages, $message],
         );
     }


### PR DESCRIPTION
Named parameters are measurably slower than positional parameters. `$value` appears to be the “main property” of the Node class and is always passed, thus passing it positionally is reasonable without forcing a “mental lookup” of parameter names.

For:

    <?php

    use CuyZ\Valinor\MapperBuilder;

    require('vendor/autoload.php');

    final class Target
    {
        /**
         * @param   array{
         *              foo?: string,
         *              bar?: int,
         *              baz?: array<string, int>,
         *          } $foo
         * @param   array<string,string> $bar
         */
        public function __construct(
            public readonly array $foo,
            public readonly array $bar,
        )
        {
        }
    }

    $mapper = (new MapperBuilder())
        ->mapper();

    for ($i = 0; $i < 70_000; $i++) {
            $mapper->map(
                Target::class,
                [
                    "bar" => [],
                    "foo" => [
                        "foo" => "foo",
                    ]
                ]
            );
    }

This change results in:

    Benchmark 1: php -d opcache.enable_cli=1 valinor/test.php
      Time (mean ± σ):     786.9 ms ±   9.2 ms    [User: 768.5 ms, System: 16.0 ms]
      Range (min … max):   776.9 ms … 807.2 ms    10 runs

    Benchmark 2: php -d opcache.enable_cli=1 valinor.before/test.php
      Time (mean ± σ):     799.3 ms ±   7.9 ms    [User: 778.7 ms, System: 18.3 ms]
      Range (min … max):   790.1 ms … 813.2 ms    10 runs

    Summary
      php -d opcache.enable_cli=1 valinor/test.php ran
        1.02 ± 0.02 times faster than php -d opcache.enable_cli=1 valinor.before/test.php

see php/php-src#20259