### PR TITLE
chore: standardize documentation comments

### DIFF
--- a/src/Cache/FileWatchingCache.php
+++ b/src/Cache/FileWatchingCache.php
@@ -20,7 +20,7 @@ use function var_export;
  * environment, where source files are often modified by developers.
  *
  * It should decorate the original cache implementation and should be given to
- * the mapper builder: @see \CuyZ\Valinor\MapperBuilder::withCache
+ * the mapper builder: {@see \CuyZ\Valinor\MapperBuilder::withCache()}
  *
  * @api
  *

--- a/src/Cache/TypeFilesWatcher.php
+++ b/src/Cache/TypeFilesWatcher.php
@@ -41,7 +41,7 @@ final class TypeFilesWatcher
      *
      * Example of returned value:
      *
-     * ```php
+     * ```
      * [
      *     // An entity representing a user
      *     '/root/path/src/Domain/User/User.php',

--- a/src/Mapper/AsConverter.php
+++ b/src/Mapper/AsConverter.php
@@ -10,18 +10,16 @@ use Attribute;
  * This attribute can be used to automatically register a converter attribute.
  *
  * When there is no control over the transformer attribute class, the following
- * method can be used: @see \CuyZ\Valinor\MapperBuilder::registerConverter()
+ * method can be used: {@see \CuyZ\Valinor\MapperBuilder::registerConverter()}
  *
- * ```php
+ * ```
  * namespace My\App;
  *
  * #[\CuyZ\Valinor\Mapper\AsConverter]
  * #[\Attribute(\Attribute::TARGET_PROPERTY)]
  * final class CastToBool
  * {
- *     /**
- *      * @param callable(mixed): bool $next
- *      * /
+ *     // @param callable(mixed): bool $next
  *     public function map(string $value, callable $next): bool
  *     {
  *         $value = match ($value) {
@@ -56,7 +54,7 @@ use Attribute;
  * Attribute converters can also be used on function parameters when mapping
  * arguments:
  *
- * ```php
+ * ```
  * function someFunction(string $name, #[\My\App\CastToBool] bool $isActive) {
  *     // …
  * };

--- a/src/Mapper/Object/ArgumentsValues.php
+++ b/src/Mapper/Object/ArgumentsValues.php
@@ -46,7 +46,7 @@ final class ArgumentsValues
      *
      * Example:
      *
-     * ```php
+     * ```
      * final readonly class User
      * {
      *     public function __construct(

--- a/src/Mapper/Object/Constructor.php
+++ b/src/Mapper/Object/Constructor.php
@@ -13,9 +13,10 @@ use Attribute;
  * of.
  *
  * This attribute is a convenient replacement to the usage of the constructor
- * registration method: @see \CuyZ\Valinor\MapperBuilder::registerConstructor()
+ * registration method:
+ * {@see \CuyZ\Valinor\MapperBuilder::registerConstructor()}
  *
- * ```php
+ * ```
  * final readonly class Email
  * {
  *     // When another constructor is registered for the class, the native

--- a/src/Mapper/Object/DynamicConstructor.php
+++ b/src/Mapper/Object/DynamicConstructor.php
@@ -18,7 +18,7 @@ use CuyZ\Valinor\MapperBuilder;
  * Note that the first parameter of the constructor has to be a string otherwise
  * an exception will be thrown on mapping.
  *
- * ```php
+ * ```
  * interface SomeInterfaceWithStaticConstructor
  * {
  *     public static function from(string $value): self;

--- a/src/Mapper/Tree/Message/Formatter/CallbackMessageFormatter.php
+++ b/src/Mapper/Tree/Message/Formatter/CallbackMessageFormatter.php
@@ -11,7 +11,7 @@ use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
  *
  * Example:
  *
- * ```php
+ * ```
  * // Customize the body of messages that have a certain code.
  * $formatter = new CallbackMessageFormatter(
  *     fn (NodeMessage $message) => match ($message->code()) {

--- a/src/Mapper/Tree/Message/Formatter/MessageMapFormatter.php
+++ b/src/Mapper/Tree/Message/Formatter/MessageMapFormatter.php
@@ -27,7 +27,7 @@ use function is_string;
  *
  * See usage examples below:
  *
- * ```php
+ * ```
  * $formatter = (new MessageMapFormatter([
  *     // Will match if the given message has this exact code
  *     'some_code' => 'New content / code: {message_code}',

--- a/src/Mapper/Tree/Message/Formatter/TranslationMessageFormatter.php
+++ b/src/Mapper/Tree/Message/Formatter/TranslationMessageFormatter.php
@@ -30,7 +30,7 @@ final class TranslationMessageFormatter implements MessageFormatter
     /**
      * Creates or overrides a single translation.
      *
-     * ```php
+     * ```
      * (TranslationMessageFormatter::default())->withTranslation(
      *     'fr',
      *     'Invalid value {source_value}.',
@@ -54,7 +54,7 @@ final class TranslationMessageFormatter implements MessageFormatter
      * The given array consists of messages to be translated and for each one a
      * list of locales with their associated translations.
      *
-     * ```php
+     * ```
      * $formatter = (TranslationMessageFormatter::default())->withTranslations([
      *     'Invalid value {source_value}.' => [
      *         'fr' => 'Valeur invalide {source_value}.',

--- a/src/Mapper/Tree/Message/HasParameters.php
+++ b/src/Mapper/Tree/Message/HasParameters.php
@@ -8,7 +8,7 @@ namespace CuyZ\Valinor\Mapper\Tree\Message;
  * This interface can be implemented by a message to provide parameters that can
  * be used as placeholders in the message's body.
  *
- * ```php
+ * ```
  * use CuyZ\Valinor\Mapper\Tree\Message\Message;
  * use CuyZ\Valinor\Mapper\Tree\Message\HasParameters;
  *

--- a/src/Mapper/Tree/Message/MessageBuilder.php
+++ b/src/Mapper/Tree/Message/MessageBuilder.php
@@ -10,7 +10,7 @@ use Throwable;
 /**
  * Can be used to easily create an instance of (error) message.
  *
- * ```php
+ * ```
  * $message = MessageBuilder::newError('Some message with {some_parameter}.')
  *     ->withCode('some_code')
  *     ->withParameter('some_parameter', 'some_value')

--- a/src/Mapper/Tree/Message/Messages.php
+++ b/src/Mapper/Tree/Message/Messages.php
@@ -18,11 +18,11 @@ use function iterator_to_array;
  *
  * Message formatters can be added and will be applied on all messages.
  *
- * ```php
+ * ```
  * try {
  *     return (new \CuyZ\Valinor\MapperBuilder())
  *         ->mapper()
- *         ->map(SomeClass::class, [/* … * /]);
+ *         ->map(SomeClass::class, [ … ]);
  * } catch (\CuyZ\Valinor\Mapper\MappingError $error) {
  *     // Get a flattened list of all messages detected during mapping
  *     $messages = $error->messages();

--- a/src/Mapper/Tree/Message/NodeMessage.php
+++ b/src/Mapper/Tree/Message/NodeMessage.php
@@ -62,7 +62,7 @@ final class NodeMessage implements Message, HasCode, Stringable
      *
      * Example:
      *
-     * ```php
+     * ```
      * $message = $message->withBody('new message for value: {source_value}');
      * ```
      *

--- a/src/MapperBuilder.php
+++ b/src/MapperBuilder.php
@@ -35,12 +35,12 @@ final class MapperBuilder
      * using the given source. These arguments can then be used to decide which
      * implementation should be used.
      *
-     * The callback *must* be pure, its output must be deterministic.
-     * @see https://en.wikipedia.org/wiki/Pure_function
+     * The callback *must* be pure, its output must be deterministic:
+     * {@see https://en.wikipedia.org/wiki/Pure_function}
      *
      * Example:
      *
-     * ```php
+     * ```
      * (new \CuyZ\Valinor\MapperBuilder())
      *     ->infer(UuidInterface::class, fn () => MyUuid::class)
      *     ->infer(SomeInterface::class, fn (string $type) => match($type) {
@@ -73,7 +73,7 @@ final class MapperBuilder
      *
      * Note that depending on your needs, a more straightforward way to register
      * a constructor is to use the following attribute on a static method:
-     * @see \CuyZ\Valinor\Mapper\Object\Constructor
+     * {@see \CuyZ\Valinor\Mapper\Object\Constructor}
      *
      * A constructor is a callable that can be either:
      *
@@ -92,7 +92,7 @@ final class MapperBuilder
      * needs to be handled as well, the name of the class must be given to this
      * method.
      *
-     * ```php
+     * ```
      * final class SomeClass
      * {
      *     private string $foo;
@@ -140,13 +140,9 @@ final class MapperBuilder
      *     ->registerConstructor(
      *         // Named constructor
      *         SomeClass::namedConstructor(...),
-     *         // …or for PHP < 8.1:
-     *         [SomeClass::class, 'namedConstructor'],
      *
      *         // Method of an object
      *         (new SomeRepository())->findById(...),
-     *         // …or for PHP < 8.1:
-     *         [new SomeRepository(), 'findById'],
      *
      *         // Callable object
      *         new SomeCallableObject(),
@@ -170,7 +166,7 @@ final class MapperBuilder
      *
      * Enum constructors can be registered the same way:
      *
-     * * ```php
+     * ```
      * enum SomeEnum: string
      * {
      *     case CASE_A = 'FOO_VALUE_1';
@@ -178,10 +174,8 @@ final class MapperBuilder
      *     case CASE_C = 'BAR_VALUE_1';
      *     case CASE_D = 'BAR_VALUE_2';
      *
-     *     /**
-     *      * \@param 'FOO'|'BAR' $type
-     *      * \@param int<1, 2> $number
-     *      * /
+     *     // @param 'FOO'|'BAR' $type
+     *     // @param int<1, 2> $number
      *     public static function fromMatrix(string $type, int $number): self
      *     {
      *         return self::from("{$type}_VALUE_{$number}");
@@ -203,8 +197,8 @@ final class MapperBuilder
      *     ]);
      * ```
      *
-     * The constructor *must* be pure, its output must be deterministic.
-     * @see https://en.wikipedia.org/wiki/Pure_function
+     * The constructor *must* be pure, its output must be deterministic:
+     * {@see https://en.wikipedia.org/wiki/Pure_function}
      *
      * @pure
      * @param pure-callable|class-string ...$constructors
@@ -230,7 +224,7 @@ final class MapperBuilder
      * By default, the dates will accept any valid timestamp or RFC 3339-formatted
      * value.
      *
-     * ```php
+     * ```
      * (new \CuyZ\Valinor\MapperBuilder())
      *     // Both `Cookie` and `ATOM` formats will be accepted
      *     ->supportDateFormats(DATE_COOKIE, DATE_ATOM)
@@ -278,7 +272,7 @@ final class MapperBuilder
      * a PHP file is modified by a developer — preventing the library not
      * behaving as expected when the signature of a property or a method changes.
      *
-     * ```php
+     * ```
      * $cache = new \CuyZ\Valinor\Cache\FileSystemCache('path/to/cache-dir');
      *
      * if ($isApplicationInDevelopmentEnvironment) {
@@ -319,7 +313,7 @@ final class MapperBuilder
      *     - "true" (string), "1" (string) and 1 (int) will be cast to `true`
      *     - "false" (string), "0" (string) and 0 (int) will be cast to `false`
      *
-     * ```php
+     * ```
      * (new \CuyZ\Valinor\MapperBuilder())
      *     ->allowScalarValueCasting()
      *     ->mapper()
@@ -346,7 +340,7 @@ final class MapperBuilder
      * This setting allows the mapper to convert associative arrays to a list
      * with sequential keys.
      *
-     * ```php
+     * ```
      * (new \CuyZ\Valinor\MapperBuilder())
      *     ->allowNonSequentialList()
      *     ->mapper()
@@ -373,7 +367,7 @@ final class MapperBuilder
      * converting them to `null` (if the current type is nullable) or an empty
      * array (if the current type is an object or an iterable).
      *
-     * ```php
+     * ```
      * (new \CuyZ\Valinor\MapperBuilder())
      *     ->allowUndefinedValues()
      *     ->mapper()
@@ -401,7 +395,7 @@ final class MapperBuilder
      *
      * This setting allows the mapper to ignore these superfluous keys.
      *
-     * ```php
+     * ```
      * (new \CuyZ\Valinor\MapperBuilder())
      *     ->allowSuperfluousKeys()
      *     ->mapper()
@@ -425,7 +419,7 @@ final class MapperBuilder
     /**
      * Allows permissive types `mixed` and `object` to be used during mapping.
      *
-     * ```php
+     * ```
      * (new \CuyZ\Valinor\MapperBuilder())
      *     ->allowPermissiveTypes()
      *     ->mapper()
@@ -460,7 +454,7 @@ final class MapperBuilder
      * Below is a basic example of a converter that converts string inputs to
      * uppercase:
      *
-     * ```php
+     * ```
      * (new \CuyZ\Valinor\MapperBuilder())
      *     ->registerConverter(fn (string $value): string => strtoupper($value))
      *     ->mapper()
@@ -478,9 +472,9 @@ final class MapperBuilder
      * An attribute on a property or a class can act as a converter if:
      *  1. It defines a `map` method.
      *  2. It is registered using either the `registerConverter()` method or
-     *     the following attribute: @see \CuyZ\Valinor\Mapper\AsConverter
+     *     the following attribute: {@see \CuyZ\Valinor\Mapper\AsConverter}
      *
-     * ```php
+     * ```
      * (new \CuyZ\Valinor\MapperBuilder())
      *
      *     // The type of the first parameter of the converter will determine
@@ -514,7 +508,7 @@ final class MapperBuilder
      * It is also possible to register attributes that share a common interface
      * by giving the interface name to the registration method.
      *
-     * ```php
+     * ```
      * namespace My\App;
      *
      * interface MyAttributeInterface {}
@@ -532,8 +526,8 @@ final class MapperBuilder
      *     ->map(…);
      * ```
      *
-     * The converter *must* be pure, its output must be deterministic.
-     * @see https://en.wikipedia.org/wiki/Pure_function
+     * The converter *must* be pure, its output must be deterministic:
+     * {@see https://en.wikipedia.org/wiki/Pure_function}
      *
      * @pure
      * @param pure-callable|class-string $converter
@@ -559,7 +553,7 @@ final class MapperBuilder
      * part of a query should never be allowed. Therefore, only an exhaustive
      * list of carefully chosen exceptions should be filtered.
      *
-     * ```php
+     * ```
      * final class SomeClass
      * {
      *     public function __construct(string $value)
@@ -600,7 +594,7 @@ final class MapperBuilder
      * signatures. This will improve the performance when the first call to the
      * mapper is done for each of these types.
      *
-     * ```php
+     * ```
      * $mapperBuilder = (new \CuyZ\Valinor\MapperBuilder())
      *    ->withCache(new \CuyZ\Valinor\Cache\FileSystemCache('path/to/dir'));
      *

--- a/src/Normalizer/AsTransformer.php
+++ b/src/Normalizer/AsTransformer.php
@@ -10,9 +10,10 @@ use Attribute;
  * This attribute can be used to automatically register a transformer attribute.
  *
  * When there is no control over the transformer attribute class, the following
- * method can be used: @see \CuyZ\Valinor\NormalizerBuilder::registerTransformer
+ * method can be used:
+ * {@see \CuyZ\Valinor\NormalizerBuilder::registerTransformer()}
  *
- * ```php
+ * ```
  * namespace My\App;
  *
  * #[\CuyZ\Valinor\Normalizer\AsTransformer]

--- a/src/Normalizer/Format.php
+++ b/src/Normalizer/Format.php
@@ -15,7 +15,7 @@ final class Format
      * Allows a normalizer to format an input to a PHP array, containing only
      * scalar values.
      *
-     * ```php
+     * ```
      * namespace My\App;
      *
      * $normalizer = (new \CuyZ\Valinor\NormalizerBuilder())
@@ -32,8 +32,8 @@ final class Format
      *     )
      * );
      *
-     * // `$userAsArray` is now an array and can be manipulated much more easily, for
-     * // instance to be serialized to the wanted data format.
+     * // `$userAsArray` is now an array and can be manipulated much more
+     * // easily, for instance to be serialized to the wanted data format.
      * //
      * // [
      * //     'name' => 'John Doe',
@@ -56,7 +56,7 @@ final class Format
     /**
      * Allows a normalizer to format an input to JSON syntax.
      *
-     * ```php
+     * ```
      * namespace My\App;
      *
      * $normalizer = (new \CuyZ\Valinor\NormalizerBuilder())

--- a/src/Normalizer/JsonNormalizer.php
+++ b/src/Normalizer/JsonNormalizer.php
@@ -86,7 +86,7 @@ final class JsonNormalizer implements Normalizer
      *
      * This can be achieved by passing these flags to this method:
      *
-     * ```php
+     * ```
      * $normalizer = (new \CuyZ\Valinor\NormalizerBuilder())
      *     ->normalizer(\CuyZ\Valinor\Normalizer\Format::json())
      *     ->withOptions(\JSON_PRESERVE_ZERO_FRACTION);
@@ -138,7 +138,7 @@ final class JsonNormalizer implements Normalizer
      * memory-efficient when using generators — for instance when querying a
      * database:
      *
-     * ```php
+     * ```
      * // In this example, we assume that the result of the query below is a
      * // generator, every entry will be yielded one by one, instead of
      * // everything being loaded in memory at once.

--- a/src/Normalizer/Transformer/Compiler/TransformerDefinition.php
+++ b/src/Normalizer/Transformer/Compiler/TransformerDefinition.php
@@ -24,7 +24,7 @@ final class TransformerDefinition
      *
      * For instance, in the following case we know that the value is a string:
      *
-     * ```php
+     * ```
      * final class SomeClass
      * {
      *     public string $value;
@@ -34,10 +34,10 @@ final class TransformerDefinition
      * However, in the following case, we cannot guarantee the type of the
      * value, as it may contain any value.
      *
-     * ```php
+     * ```
      *  final class SomeClass
      *  {
-     *      /** @var string *\
+     *      // @var string
      *      public $value;
      *  }
      *  ```

--- a/src/Normalizer/Transformer/Compiler/TypeFormatter/TraversableFormatter.php
+++ b/src/Normalizer/Transformer/Compiler/TypeFormatter/TraversableFormatter.php
@@ -40,7 +40,7 @@ final class TraversableFormatter implements TypeFormatter
      *
      * Generated code should look like:
      *
-     * ```php
+     * ```
      * if (is_array($value)) {
      *     return array_map(
      *         fn ($item) => $this->some_function($item),

--- a/src/NormalizerBuilder.php
+++ b/src/NormalizerBuilder.php
@@ -38,7 +38,7 @@ final class NormalizerBuilder
      * a PHP file is modified by a developer — preventing the library not
      * behaving as expected when the signature of a property or a method changes.
      *
-     * ```php
+     * ```
      * $cache = new \CuyZ\Valinor\Cache\FileSystemCache('path/to/cache-dir');
      *
      * if ($isApplicationInDevelopmentEnvironment) {
@@ -83,11 +83,11 @@ final class NormalizerBuilder
      * An attribute on a property or a class can act as a transformer if:
      *  1. It defines a `normalize` or `normalizeKey` method.
      *  2. It is registered using either the `registerTransformer()` method or
-     *     the following attribute: @see \CuyZ\Valinor\Normalizer\AsTransformer
+     *     the attribute: {@see \CuyZ\Valinor\Normalizer\AsTransformer}
      *
      * Example:
      *
-     * ```php
+     * ```
      * (new \CuyZ\Valinor\NormalizerBuilder())
      *
      *     // The type of the first parameter of the transformer will determine
@@ -118,8 +118,8 @@ final class NormalizerBuilder
      *     ->normalize('Hello world'); // HELLO WORLD?!
      * ```
      *
-     * The transformer *must* be pure, its output must be deterministic.
-     * @see https://en.wikipedia.org/wiki/Pure_function
+     * The transformer *must* be pure, its output must be deterministic:
+     * {@see https://en.wikipedia.org/wiki/Pure_function}
      *
      * @pure
      * @param pure-callable|class-string $transformer


### PR DESCRIPTION
Those two changes aim to be more respectful of PHPDoc, resulting in a better integration of, for instance, PhpStorm's documentation comments rendering which gives a nice integration of code blocks, links, etc. for users.

Changing "```php" to "```", because the first one breaks the code block rendering.

Changing "@see some-link" to "{@see some-link}".