### PR TITLE
fix: Allow passing pure-closures to NormalizerBuilder::registerTransformer

### DIFF
--- a/src/NormalizerBuilder.php
+++ b/src/NormalizerBuilder.php
@@ -173,7 +173,7 @@ final class NormalizerBuilder
      * {@see https://en.wikipedia.org/wiki/Pure_function}
      *
      * @pure
-     * @param pure-callable|class-string $transformer
+     * @param pure-callable|pure-Closure|class-string $transformer
      */
     public function registerTransformer(callable|string $transformer, int $priority = 0): self
     {


### PR DESCRIPTION
This will solve PHPStan errors when passing Closure to registerTransformer

Ref: https://phpstan.org/writing-php-code/phpdoc-types#callables