### PR TITLE
Multiple fixes

### DIFF
--- a/src/Definition/Repository/Reflection/ReflectionClassDefinitionRepository.php
+++ b/src/Definition/Repository/Reflection/ReflectionClassDefinitionRepository.php
@@ -136,6 +136,7 @@ final class ReflectionClassDefinitionRepository implements ClassDefinitionReposi
         $reflection = Reflection::class($type->className());
 
         $properties = [];
+        $parentClasses = [];
 
         foreach ($reflection->getProperties() as $property) {
             $declaringClass = $property->getDeclaringClass();
@@ -144,8 +145,10 @@ final class ReflectionClassDefinitionRepository implements ClassDefinitionReposi
                 $properties[$property->name] = $this->propertyBuilder->for($property, $typeResolver);
             } else {
                 $parentClass = $this->parentTypeResolver->resolveParentTypeFor($type);
+                // @infection-ignore-all Just some memoization
+                $parentClasses[$parentClass->toString()] ??= $this->for($parentClass);
 
-                $properties[$property->name] = $this->for($parentClass)->properties->get($property->name);
+                $properties[$property->name] = $parentClasses[$parentClass->toString()]->properties->get($property->name);
             }
         }
 
@@ -177,6 +180,9 @@ final class ReflectionClassDefinitionRepository implements ClassDefinitionReposi
         $reflection = Reflection::class($type->className());
         $methods = array_filter($reflection->getMethods(), $this->shouldMethodBeIncluded(...));
 
+        $parentClasses = [];
+        $definitions = [];
+
         // Because `ReflectionMethod::getMethods()` wont list the constructor if
         // it comes from a parent class AND is not public, we need to manually
         // fetch it and add it to the list.
@@ -184,17 +190,22 @@ final class ReflectionClassDefinitionRepository implements ClassDefinitionReposi
             $methods[] = $reflection->getMethod('__construct');
         }
 
-        return array_map(function (ReflectionMethod $method) use ($type, $typeResolver) {
+        foreach ($methods as $method) {
             $declaringClass = $method->getDeclaringClass();
 
             if ($declaringClass->name === $type->className()) {
-                return $this->methodBuilder->for($method, $typeResolver);
+                $definitions[] = $this->methodBuilder->for($method, $typeResolver);
+                continue;
             }
 
             $parentClass = $this->parentTypeResolver->resolveParentTypeFor($type);
 
-            return $this->for($parentClass)->methods->get($method->name);
-        }, $methods);
+            // @infection-ignore-all Just some memoization
+            $parentClasses[$parentClass->toString()] ??= $this->for($parentClass);
+
+            $definitions[] = $parentClasses[$parentClass->toString()]->methods->get($method->name);
+        }
+        return $definitions;
     }
 
     private function shouldMethodBeIncluded(ReflectionMethod $method): bool

--- a/src/Definition/Repository/Reflection/TypeResolver/ClassLocalTypeAliasResolver.php
+++ b/src/Definition/Repository/Reflection/TypeResolver/ClassLocalTypeAliasResolver.php
@@ -45,12 +45,12 @@ final class ClassLocalTypeAliasResolver
         }
 
         $typeParser = $this->typeParserFactory->buildAdvancedTypeParserForClass($type->className());
-        $typeParser = new VacantTypeAssignerParser($typeParser, $vacantTypes);
 
         $types = [];
 
         foreach ($localAliases as $name => $raw) {
-            $types[$name] = $typeParser->parse($raw);
+            $parser = new VacantTypeAssignerParser($typeParser, [...$vacantTypes, ...$types]);
+            $types[$name] = $parser->parse($raw);
 
             if ($types[$name] instanceof UnresolvableType) {
                 $types[$name] = $types[$name]->forLocalAlias($raw, $name, $type);

--- a/src/Type/Parser/Exception/ExpectedClosingParenthesisAfterType.php
+++ b/src/Type/Parser/Exception/ExpectedClosingParenthesisAfterType.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Type\Parser\Exception;
+
+use RuntimeException;
+
+/** @internal */
+final class ExpectedClosingParenthesisAfterType extends RuntimeException implements InvalidType
+{
+    public function __construct(string $value)
+    {
+        parent::__construct("Expected closing parenthesis after `$value`.");
+    }
+}

--- a/src/Type/Parser/Lexer/Token/OpeningParenthesisToken.php
+++ b/src/Type/Parser/Lexer/Token/OpeningParenthesisToken.php
@@ -4,12 +4,36 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Type\Parser\Lexer\Token;
 
+use CuyZ\Valinor\Type\Parser\Exception\ExpectedClosingParenthesisAfterType;
+use CuyZ\Valinor\Type\Parser\Exception\UnexpectedToken;
+use CuyZ\Valinor\Type\Parser\Lexer\TokenStream;
+use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Utility\IsSingleton;
 
 /** @internal */
-final class OpeningParenthesisToken implements Token
+final class OpeningParenthesisToken implements TraversingToken
 {
     use IsSingleton;
+
+    public function traverse(TokenStream $stream): Type
+    {
+        if ($stream->done()) {
+            throw new UnexpectedToken('(');
+        }
+
+        $type = $stream->read();
+
+        if ($stream->done()) {
+            throw new ExpectedClosingParenthesisAfterType($type->toString());
+        }
+
+        $next = $stream->forward();
+        if (! $next instanceof ClosingParenthesisToken) {
+            throw new UnexpectedToken($next->symbol());
+        }
+
+        return $type;
+    }
 
     public function symbol(): string
     {

--- a/src/Type/Types/Factory/ValueTypeFactory.php
+++ b/src/Type/Types/Factory/ValueTypeFactory.php
@@ -11,6 +11,7 @@ use CuyZ\Valinor\Type\Types\EnumType;
 use CuyZ\Valinor\Type\Types\FloatValueType;
 use CuyZ\Valinor\Type\Types\IntegerValueType;
 use CuyZ\Valinor\Type\Types\NativeClassType;
+use CuyZ\Valinor\Type\Types\NullType;
 use CuyZ\Valinor\Type\Types\ShapedArrayElement;
 use CuyZ\Valinor\Type\Types\ShapedArrayType;
 use CuyZ\Valinor\Type\Types\StringValueType;
@@ -28,6 +29,10 @@ final class ValueTypeFactory
 {
     public static function from(mixed $value): Type
     {
+        if ($value === null) {
+            return NullType::get();
+        }
+
         if (is_bool($value)) {
             return $value ? BooleanValueType::true() : BooleanValueType::false();
         }

--- a/tests/Fixture/Object/ObjectWithConstants.php
+++ b/tests/Fixture/Object/ObjectWithConstants.php
@@ -20,6 +20,8 @@ class ObjectWithConstants
 
     final public const CONST_WITH_INTEGER_VALUE_B = 1653398289;
 
+    final public const CONST_WITH_NULL_VALUE = null;
+
     final public const CONST_WITH_FLOAT_VALUE_A = 1337.42;
 
     final public const CONST_WITH_FLOAT_VALUE_B = 404.512;

--- a/tests/Unit/Definition/Repository/Reflection/TypeResolver/ClassLocalTypeAliasResolverTest.php
+++ b/tests/Unit/Definition/Repository/Reflection/TypeResolver/ClassLocalTypeAliasResolverTest.php
@@ -99,6 +99,20 @@ final class ClassLocalTypeAliasResolverTest extends UnitTestCase
                 'SomeType' => 'int<42, 1337>',
             ]
         ];
+
+        yield 'local alias can reference previous local alias' => [
+            'className' => (
+                /**
+                 * @phpstan-type AddressType = 'foo'|'bar'
+                 * @phpstan-type Address = array{types: list<AddressType>}
+                 */
+                new class () {}
+            )::class,
+            'expectedAliases' => [
+                'AddressType' => "'foo'|'bar'",
+                'Address' => "array{types: list<'foo'|'bar'>}",
+            ],
+        ];
     }
 
     public function test_can_resolve_local_types_for_enum(): void

--- a/tests/Unit/Type/Parser/LexingParserTest.php
+++ b/tests/Unit/Type/Parser/LexingParserTest.php
@@ -1043,6 +1043,12 @@ final class LexingParserTest extends UnitTestCase
             'type' => IntegerValueType::class,
         ];
 
+        yield 'Class constant with null value' => [
+            'raw' => ObjectWithConstants::class . '::CONST_WITH_NULL_VALUE',
+            'transformed' => 'null',
+            'type' => NullType::class,
+        ];
+
         yield 'Class constant with float value' => [
             'raw' => ObjectWithConstants::class . '::CONST_WITH_FLOAT_VALUE_A',
             'transformed' => '1337.42',

--- a/tests/Unit/Type/Parser/LexingParserTest.php
+++ b/tests/Unit/Type/Parser/LexingParserTest.php
@@ -1019,6 +1019,12 @@ final class LexingParserTest extends UnitTestCase
             'type' => UnionType::class,
         ];
 
+        yield 'Parenthesized union type' => [
+            'raw' => "('foo'|'bar')",
+            'transformed' => "'foo'|'bar'",
+            'type' => UnionType::class,
+        ];
+
         yield 'Intersection type' => [
             'raw' => 'stdClass&DateTimeInterface',
             'transformed' => 'stdClass&DateTimeInterface',
@@ -1885,6 +1891,30 @@ final class LexingParserTest extends UnitTestCase
 
         self::assertInstanceOf(UnresolvableType::class, $type);
         self::assertSame('Invalid types in intersection `int&DateTimeInterface`, each element must be a class name or an interface name but found `int`.', $type->message());
+    }
+
+    public function test_missing_closing_parens(): void
+    {
+        $type = $this->parse("('foo'|'bar'");
+
+        self::assertInstanceOf(UnresolvableType::class, $type);
+        self::assertSame("Expected closing parenthesis after `'foo'|'bar'`.", $type->message());
+    }
+
+    public function test_not_closing_parens(): void
+    {
+        $type = $this->parse("('foo'|'bar'(");
+
+        self::assertInstanceOf(UnresolvableType::class, $type);
+        self::assertSame('Unexpected token `(`, expected a valid type.', $type->message());
+    }
+
+    public function test_just_opening_parens(): void
+    {
+        $type = $this->parse("(");
+
+        self::assertInstanceOf(UnresolvableType::class, $type);
+        self::assertSame('Unexpected token `(`, expected a valid type.', $type->message());
     }
 
     public function test_invalid_right_intersection_member_throws_exception(): void


### PR DESCRIPTION
- Use explicitly prefixed namespaces
- Cache parent classes more often
- Add support for null constants
- Add support for local alias types within other local aliases
- Add support for parenthesized union types