### PR TITLE
misc: rename configurators

### DIFF
--- a/docs/pages/how-to/map-http-request.md
+++ b/docs/pages/how-to/map-http-request.md
@@ -315,21 +315,21 @@ properties. Two families of configurators help with this:
 
 - [RestrictKeysTo*Case] configurators reject keys that do not match the
   expected format (e.g. `snake_case`, `camelCase`), raising a mapping error.
-- [ConvertKeysTo*Case] configurators convert input keys to the target format
-  before mapping (e.g. `first_name` → `firstName`).
+- [MapKeysTo*Case] configurators convert input keys to the target format before
+  mapping (e.g. `first_name` → `firstName`).
 
 They can be combined so that the restriction validates the original keys and the
 conversion remaps them. Both work with HTTP request mapping.
 
 ```php
-use CuyZ\Valinor\Mapper\Configurator\ConvertKeysToCamelCase;
+use CuyZ\Valinor\Mapper\Configurator\MapKeysToCamelCase;
 use CuyZ\Valinor\Mapper\Configurator\RestrictKeysToSnakeCase;
 use CuyZ\Valinor\MapperBuilder;
 
 $controllerArguments = (new MapperBuilder())
     ->configureWith(
         new RestrictKeysToSnakeCase(),
-        new ConvertKeysToCamelCase(),
+        new MapKeysToCamelCase(),
     )
     ->argumentsMapper()
     ->mapArguments($controller, $httpRequest);
@@ -339,7 +339,7 @@ Read the [common mapper configurators chapter] for the full list of available
 configurators and detailed usage.
 
 [RestrictKeysTo*Case]: use-provided-mapper-configurators.md#restricting-key-case
-[ConvertKeysTo*Case]: use-provided-mapper-configurators.md#converting-key-case
+[MapKeysTo*Case]: use-provided-mapper-configurators.md#converting-key-case
 [common mapper configurators chapter]: use-provided-mapper-configurators.md
 
 ## Error handling

--- a/docs/pages/how-to/use-provided-mapper-configurators.md
+++ b/docs/pages/how-to/use-provided-mapper-configurators.md
@@ -45,7 +45,7 @@ Two configurators are available to convert the keys of input data before mapping
 them to object properties or shaped array keys. This allows accepting data with
 a different naming convention than the one used in the PHP codebase.
 
-### `ConvertKeysToCamelCase`
+### `MapKeysToCamelCase`
 
 | Conversion                   |
 |------------------------------|
@@ -56,7 +56,7 @@ a different naming convention than the one used in the PHP codebase.
 ```php
 $user = (new \CuyZ\Valinor\MapperBuilder())
     ->configureWith(
-        new \CuyZ\Valinor\Mapper\Configurator\ConvertKeysToCamelCase()
+        new \CuyZ\Valinor\Mapper\Configurator\MapKeysToCamelCase()
     )
     ->mapper()
     ->map(\My\App\User::class, [
@@ -65,7 +65,7 @@ $user = (new \CuyZ\Valinor\MapperBuilder())
     ]);
 ```
 
-### `ConvertKeysToSnakeCase`
+### `MapKeysToSnakeCase`
 
 | Conversion                    |
 |-------------------------------|
@@ -76,7 +76,7 @@ $user = (new \CuyZ\Valinor\MapperBuilder())
 ```php
 $user = (new \CuyZ\Valinor\MapperBuilder())
     ->configureWith(
-        new \CuyZ\Valinor\Mapper\Configurator\ConvertKeysToSnakeCase()
+        new \CuyZ\Valinor\Mapper\Configurator\MapKeysToSnakeCase()
     )
     ->mapper()
     ->map(\My\App\User::class, [
@@ -94,7 +94,7 @@ input keys:
 $user = (new \CuyZ\Valinor\MapperBuilder())
     ->configureWith(
         new \CuyZ\Valinor\Mapper\Configurator\RestrictKeysToSnakeCase(),
-        new \CuyZ\Valinor\Mapper\Configurator\ConvertKeysToCamelCase(),
+        new \CuyZ\Valinor\Mapper\Configurator\MapKeysToCamelCase(),
     )
     ->mapper()
     ->map(\My\App\User::class, [

--- a/docs/pages/serialization/use-provided-normalizer-configurators.md
+++ b/docs/pages/serialization/use-provided-normalizer-configurators.md
@@ -10,7 +10,8 @@ can be used to apply common normalization behaviors:
 ## Specifying date time normalization format
 
 By default, dates will be formatted using the RFC 3339 format. The
-`ConvertDateTime` configurator can be used to specify which format to use.
+`NormalizeDateTimeFormat` configurator can be used to specify which format to
+use.
 
 This class can be used either as a configurator for global usage or as an
 attribute to target a specific property.
@@ -18,12 +19,12 @@ attribute to target a specific property.
 ### Global usage as a configurator
 
 ```php
-use CuyZ\Valinor\Normalizer\Configurator\ConvertDateTime;
+use CuyZ\Valinor\Normalizer\Configurator\NormalizeDateTimeFormat;
 use CuyZ\Valinor\Normalizer\Format;
 use CuyZ\Valinor\NormalizerBuilder;
 
 $userAsArray = (new NormalizerBuilder())
-    ->configureWith(new ConvertDateTime(\DateTimeInterface::ATOM))
+    ->configureWith(new NormalizeDateTimeFormat(\DateTimeInterface::ATOM))
     ->normalizer(Format::array())
     ->normalize($user);
 
@@ -36,7 +37,7 @@ $userAsArray = (new NormalizerBuilder())
 ### Targeted usage as an attribute
 
 ```php
-use CuyZ\Valinor\Normalizer\Configurator\ConvertDateTime;
+use CuyZ\Valinor\Normalizer\Configurator\NormalizeDateTimeFormat;
 use CuyZ\Valinor\Normalizer\Format;
 use CuyZ\Valinor\NormalizerBuilder;
 
@@ -45,7 +46,7 @@ final readonly class User
     public function __construct(
         public string $name,
 
-        #[ConvertDateTime(\DateTimeInterface::ATOM)]
+        #[NormalizeDateTimeFormat(\DateTimeInterface::ATOM)]
         public DateTimeInterface $createdAt,
     ) {}
 }

--- a/src/Mapper/Configurator/ConvertKeysToCamelCase.php
+++ b/src/Mapper/Configurator/ConvertKeysToCamelCase.php
@@ -11,51 +11,7 @@ use function str_replace;
 use function ucwords;
 
 /**
- * Converts the keys of input data to `camelCase` before mapping them to object
- * properties or shaped array keys. This allows accepting data with a different
- * naming convention than the one used in the PHP codebase.
- *
- * A typical use case is mapping a JSON API payload that uses `snake_case` keys
- * to PHP objects that follow the `camelCase` convention:
- *
- * ```
- * use CuyZ\Valinor\MapperBuilder;
- * use CuyZ\Valinor\Mapper\Configurator\ConvertKeysToCamelCase;
- *
- * $user = (new MapperBuilder())
- *     ->configureWith(new ConvertKeysToCamelCase())
- *     ->mapper()
- *     ->map(User::class, [
- *         'first_name' => 'John', // mapped to `$firstName`
- *         'last_name' => 'Doe',   // mapped to `$lastName`
- *     ]);
- * ```
- *
- * This configurator can be combined with a key restriction configurator to both
- * validate and convert keys in a single step. The restriction configurator must
- * be registered *before* the conversion so that the validation runs on the
- * original input keys.
- *
- * - {@see RestrictKeysToSnakeCase}
- * - {@see RestrictKeysToKebabCase}
- * - {@see RestrictKeysToPascalCase}
- *
- * ```
- * use CuyZ\Valinor\MapperBuilder;
- * use CuyZ\Valinor\Mapper\Configurator\ConvertKeysToCamelCase;
- * use CuyZ\Valinor\Mapper\Configurator\RestrictKeysToSnakeCase;
- *
- * $user = (new MapperBuilder())
- *     ->configureWith(
- *         new RestrictKeysToSnakeCase(),
- *         new ConvertKeysToCamelCase(),
- *     )
- *     ->mapper()
- *     ->map(User::class, [
- *         'first_name' => 'John',
- *         'last_name' => 'Doe',
- *     ]);
- * ```
+ * @deprecated use {@see MapKeysToCamelCase} instead.
  *
  * @api
  */

--- a/src/Mapper/Configurator/ConvertKeysToSnakeCase.php
+++ b/src/Mapper/Configurator/ConvertKeysToSnakeCase.php
@@ -12,48 +12,7 @@ use function str_replace;
 use function strtolower;
 
 /**
- * Converts the keys of input data to `snake_case` before mapping them to
- * object properties or shaped array keys. This allows accepting data with a
- * different naming convention than the one used in the PHP codebase.
- *
- * ```
- * use CuyZ\Valinor\MapperBuilder;
- * use CuyZ\Valinor\Mapper\Configurator\ConvertKeysToSnakeCase;
- *
- * $user = (new MapperBuilder())
- *     ->configureWith(new ConvertKeysToSnakeCase())
- *     ->mapper()
- *     ->map(User::class, [
- *         'firstName' => 'John', // mapped to `$first_name`
- *         'lastName' => 'Doe',   // mapped to `$last_name`
- *     ]);
- * ```
- *
- * This configurator can be combined with a key restriction configurator to both
- * validate and convert keys in a single step. The restriction configurator must
- * be registered *before* the conversion so that the validation runs on the
- * original input keys.
- *
- * - {@see RestrictKeysToCamelCase}
- * - {@see RestrictKeysToKebabCase}
- * - {@see RestrictKeysToPascalCase}
- *
- * ```
- * use CuyZ\Valinor\MapperBuilder;
- * use CuyZ\Valinor\Mapper\Configurator\ConvertKeysToSnakeCase;
- * use CuyZ\Valinor\Mapper\Configurator\RestrictKeysToCamelCase;
- *
- * $user = (new MapperBuilder())
- *     ->configureWith(
- *         new RestrictKeysToCamelCase(),
- *         new ConvertKeysToSnakeCase(),
- *     )
- *     ->mapper()
- *     ->map(User::class, [
- *         'firstName' => 'John',
- *         'lastName' => 'Doe',
- *     ]);
- * ```
+ * @deprecated use {@see MapKeysToSnakeCase} instead.
  *
  * @api
  */

--- a/src/Mapper/Configurator/MapKeysToCamelCase.php
+++ b/src/Mapper/Configurator/MapKeysToCamelCase.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Configurator;
+
+use CuyZ\Valinor\MapperBuilder;
+
+use function lcfirst;
+use function str_replace;
+use function ucwords;
+
+/**
+ * Converts the keys of input data to `camelCase` before mapping them to object
+ * properties or shaped array keys. This allows accepting data with a different
+ * naming convention than the one used in the PHP codebase.
+ *
+ * A typical use case is mapping a JSON API payload that uses `snake_case` keys
+ * to PHP objects that follow the `camelCase` convention:
+ *
+ * ```
+ * use CuyZ\Valinor\MapperBuilder;
+ * use CuyZ\Valinor\Mapper\Configurator\MapKeysToCamelCase;
+ *
+ * $user = (new MapperBuilder())
+ *     ->configureWith(new MapKeysToCamelCase())
+ *     ->mapper()
+ *     ->map(User::class, [
+ *         'first_name' => 'John', // mapped to `$firstName`
+ *         'last_name' => 'Doe',   // mapped to `$lastName`
+ *     ]);
+ * ```
+ *
+ * This configurator can be combined with a key restriction configurator to both
+ * validate and convert keys in a single step. The restriction configurator must
+ * be registered *before* the conversion so that the validation runs on the
+ * original input keys.
+ *
+ * - {@see RestrictKeysToSnakeCase}
+ * - {@see RestrictKeysToKebabCase}
+ * - {@see RestrictKeysToPascalCase}
+ *
+ * ```
+ * use CuyZ\Valinor\MapperBuilder;
+ * use CuyZ\Valinor\Mapper\Configurator\MapKeysToCamelCase;
+ * use CuyZ\Valinor\Mapper\Configurator\RestrictKeysToSnakeCase;
+ *
+ * $user = (new MapperBuilder())
+ *     ->configureWith(
+ *         new RestrictKeysToSnakeCase(),
+ *         new MapKeysToCamelCase(),
+ *     )
+ *     ->mapper()
+ *     ->map(User::class, [
+ *         'first_name' => 'John',
+ *         'last_name' => 'Doe',
+ *     ]);
+ * ```
+ *
+ * @api
+ */
+final class MapKeysToCamelCase implements MapperBuilderConfigurator
+{
+    public function configureMapperBuilder(MapperBuilder $builder): MapperBuilder
+    {
+        return $builder->registerKeyConverter(
+            static fn (string $key): string => lcfirst(str_replace(['_', '-'], '', ucwords($key, '_-'))), // @phpstan-ignore argument.type
+        );
+    }
+}

--- a/src/Mapper/Configurator/MapKeysToSnakeCase.php
+++ b/src/Mapper/Configurator/MapKeysToSnakeCase.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Mapper\Configurator;
+
+use CuyZ\Valinor\MapperBuilder;
+
+use function ltrim;
+use function preg_replace;
+use function str_replace;
+use function strtolower;
+
+/**
+ * Converts the keys of input data to `snake_case` before mapping them to
+ * object properties or shaped array keys. This allows accepting data with a
+ * different naming convention than the one used in the PHP codebase.
+ *
+ * ```
+ * use CuyZ\Valinor\MapperBuilder;
+ * use CuyZ\Valinor\Mapper\Configurator\MapKeysToSnakeCase;
+ *
+ * $user = (new MapperBuilder())
+ *     ->configureWith(new MapKeysToSnakeCase())
+ *     ->mapper()
+ *     ->map(User::class, [
+ *         'firstName' => 'John', // mapped to `$first_name`
+ *         'lastName' => 'Doe',   // mapped to `$last_name`
+ *     ]);
+ * ```
+ *
+ * This configurator can be combined with a key restriction configurator to both
+ * validate and convert keys in a single step. The restriction configurator must
+ * be registered *before* the conversion so that the validation runs on the
+ * original input keys.
+ *
+ * - {@see RestrictKeysToCamelCase}
+ * - {@see RestrictKeysToKebabCase}
+ * - {@see RestrictKeysToPascalCase}
+ *
+ * ```
+ * use CuyZ\Valinor\MapperBuilder;
+ * use CuyZ\Valinor\Mapper\Configurator\MapKeysToSnakeCase;
+ * use CuyZ\Valinor\Mapper\Configurator\RestrictKeysToCamelCase;
+ *
+ * $user = (new MapperBuilder())
+ *     ->configureWith(
+ *         new RestrictKeysToCamelCase(),
+ *         new MapKeysToSnakeCase(),
+ *     )
+ *     ->mapper()
+ *     ->map(User::class, [
+ *         'firstName' => 'John',
+ *         'lastName' => 'Doe',
+ *     ]);
+ * ```
+ *
+ * @api
+ */
+final class MapKeysToSnakeCase implements MapperBuilderConfigurator
+{
+    public function configureMapperBuilder(MapperBuilder $builder): MapperBuilder
+    {
+        return $builder->registerKeyConverter(
+            static fn (string $key): string => ltrim(strtolower((string)preg_replace('/[A-Z]/', '_$0', str_replace('-', '_', $key))), '_') // @phpstan-ignore argument.type
+        );
+    }
+}

--- a/src/Mapper/Source/Modifier/CamelCaseKeys.php
+++ b/src/Mapper/Source/Modifier/CamelCaseKeys.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Mapper\Source\Modifier;
 
-use CuyZ\Valinor\Mapper\Configurator\ConvertKeysToCamelCase;
+use CuyZ\Valinor\Mapper\Configurator\MapKeysToCamelCase;
 use IteratorAggregate;
 use Traversable;
 
@@ -18,7 +18,7 @@ use function ucwords;
 
 /**
  * @deprecated This modifier will be removed in version 3.0.
- *             Use the configurator {@see ConvertKeysToCamelCase} instead.
+ *             Use the configurator {@see MapKeysToCamelCase} instead.
  *
  * @api
  * @implements IteratorAggregate<mixed>

--- a/src/Mapper/Source/Source.php
+++ b/src/Mapper/Source/Source.php
@@ -67,7 +67,7 @@ final class Source implements IteratorAggregate
 
     /**
      * @deprecated This modifier will be removed in version 3.0.
-     *              Use the configurator {@see ConvertKeysToCamelCase} instead.
+     *              Use the configurator {@see MapKeysToCamelCase} instead.
      *
      * @pure
      */

--- a/src/Normalizer/Configurator/NormalizeDateTimeFormat.php
+++ b/src/Normalizer/Configurator/NormalizeDateTimeFormat.php
@@ -10,7 +10,7 @@ use CuyZ\Valinor\NormalizerBuilder;
 use DateTimeInterface;
 
 /**
- * Converts a `DateTimeInterface` to a string using the given format.
+ * Normalizes a `DateTimeInterface` to a string using the given format.
  *
  * This class can be used either as a configurator for global usage or as an
  * attribute to target a specific property.
@@ -19,13 +19,13 @@ use DateTimeInterface;
  * ------------------------------
  *
  *  ```
- *  use CuyZ\Valinor\Normalizer\Configurator\ConvertDateTime;
+ *  use CuyZ\Valinor\Normalizer\Configurator\NormalizeDateTimeFormat;
  *  use CuyZ\Valinor\Normalizer\Format;
  *  use CuyZ\Valinor\NormalizerBuilder;
  *
  *  $userAsArray = (new NormalizerBuilder())
- *      // All `DateTimeInterface` will be converted to this format
- *      ->configureWith(new ConvertDateTime(DATE_ATOM))
+ *      // All `DateTimeInterface` will be normalized to this format
+ *      ->configureWith(new NormalizeDateTimeFormat(DATE_ATOM))
  *      ->normalizer(Format::array())
  *      ->normalize($user);
  *
@@ -39,7 +39,7 @@ use DateTimeInterface;
  * ---------------------------
  *
  * ```
- * use CuyZ\Valinor\Normalizer\Configurator\ConvertDateTime;
+ * use CuyZ\Valinor\Normalizer\Configurator\NormalizeDateTimeFormat;
  * use CuyZ\Valinor\Normalizer\Format;
  * use CuyZ\Valinor\NormalizerBuilder;
  *
@@ -48,7 +48,7 @@ use DateTimeInterface;
  *     public function __construct(
  *         public string $name,
  *
- *         #[ConvertDateTime(DATE_ATOM)]
+ *         #[NormalizeDateTimeFormat(DATE_ATOM)]
  *         public DateTimeInterface $createdAt,
  *     ) {}
  * }
@@ -67,7 +67,7 @@ use DateTimeInterface;
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
 #[AsTransformer]
-final readonly class ConvertDateTime implements NormalizerBuilderConfigurator
+final readonly class NormalizeDateTimeFormat implements NormalizerBuilderConfigurator
 {
     public function __construct(
         /** @var non-empty-string */

--- a/tests/Integration/Mapping/Configurator/MapKeysToCamelCaseTest.php
+++ b/tests/Integration/Mapping/Configurator/MapKeysToCamelCaseTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Mapping\Configurator;
+
+use CuyZ\Valinor\Mapper\Configurator\MapKeysToCamelCase;
+use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class MapKeysToCamelCaseTest extends IntegrationTestCase
+{
+    #[DataProvider('to_camel_case_data_provider')]
+    public function test_to_camel_case_converts_keys(string $inputKey, string $expectedValue): void
+    {
+        $class = new class () {
+            public string $someValue;
+        };
+
+        try {
+            $result = $this->mapperBuilder()
+                ->configureWith(new MapKeysToCamelCase())
+                ->mapper()
+                ->map($class::class, [$inputKey => $expectedValue]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame($expectedValue, $result->someValue);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function to_camel_case_data_provider(): iterable
+    {
+        yield 'already camelCase' => ['someValue', 'foo'];
+        yield 'from PascalCase' => ['SomeValue', 'bar'];
+        yield 'from snake_case' => ['some_value', 'baz'];
+        yield 'from kebab-case' => ['some-value', 'fiz'];
+    }
+
+    public function test_to_camel_case_converts_multiple_keys(): void
+    {
+        $class = new class () {
+            public string $someValue;
+
+            public string $otherValue;
+        };
+
+        try {
+            $result = $this->mapperBuilder()
+                ->configureWith(new MapKeysToCamelCase())
+                ->mapper()
+                ->map($class::class, ['some_value' => 'foo', 'other_value' => 'bar']);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame('foo', $result->someValue);
+        self::assertSame('bar', $result->otherValue);
+    }
+}

--- a/tests/Integration/Mapping/Configurator/MapKeysToSnakeCaseTest.php
+++ b/tests/Integration/Mapping/Configurator/MapKeysToSnakeCaseTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Mapping\Configurator;
+
+use CuyZ\Valinor\Mapper\Configurator\MapKeysToSnakeCase;
+use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class MapKeysToSnakeCaseTest extends IntegrationTestCase
+{
+    #[DataProvider('to_snake_case_data_provider')]
+    public function test_to_snake_case_converts_keys(string $inputKey, string $expectedValue): void
+    {
+        $class = new class () {
+            public string $some_value;
+        };
+
+        try {
+            $result = $this->mapperBuilder()
+                ->configureWith(new MapKeysToSnakeCase())
+                ->mapper()
+                ->map($class::class, [$inputKey => $expectedValue]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame($expectedValue, $result->some_value);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function to_snake_case_data_provider(): iterable
+    {
+        yield 'from camelCase' => ['someValue', 'foo'];
+        yield 'from PascalCase' => ['SomeValue', 'bar'];
+        yield 'already snake_case' => ['some_value', 'baz'];
+        yield 'from kebab-case' => ['some-value', 'fiz'];
+    }
+
+    public function test_to_snake_case_converts_multiple_keys(): void
+    {
+        $class = new class () {
+            public string $some_value;
+
+            public string $other_value;
+        };
+
+        try {
+            $result = $this->mapperBuilder()
+                ->configureWith(new MapKeysToSnakeCase())
+                ->mapper()
+                ->map($class::class, ['someValue' => 'foo', 'otherValue' => 'bar']);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame('foo', $result->some_value);
+        self::assertSame('bar', $result->other_value);
+    }
+}

--- a/tests/Integration/Mapping/Configurator/RestrictKeysToKebabCaseTest.php
+++ b/tests/Integration/Mapping/Configurator/RestrictKeysToKebabCaseTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Configurator;
 
-use CuyZ\Valinor\Mapper\Configurator\ConvertKeysToCamelCase;
+use CuyZ\Valinor\Mapper\Configurator\MapKeysToCamelCase;
 use CuyZ\Valinor\Mapper\Configurator\RestrictKeysToKebabCase;
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
@@ -22,7 +22,7 @@ final class RestrictKeysToKebabCaseTest extends IntegrationTestCase
             $result = $this->mapperBuilder()
                 ->configureWith(
                     new RestrictKeysToKebabCase(),
-                    new ConvertKeysToCamelCase(),
+                    new MapKeysToCamelCase(),
                 )
                 ->mapper()
                 ->map($class::class, ['some-value' => 'foo']);

--- a/tests/Integration/Mapping/Configurator/RestrictKeysToPascalCaseTest.php
+++ b/tests/Integration/Mapping/Configurator/RestrictKeysToPascalCaseTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Configurator;
 
-use CuyZ\Valinor\Mapper\Configurator\ConvertKeysToCamelCase;
+use CuyZ\Valinor\Mapper\Configurator\MapKeysToCamelCase;
 use CuyZ\Valinor\Mapper\Configurator\RestrictKeysToPascalCase;
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
@@ -22,7 +22,7 @@ final class RestrictKeysToPascalCaseTest extends IntegrationTestCase
             $result = $this->mapperBuilder()
                 ->configureWith(
                     new RestrictKeysToPascalCase(),
-                    new ConvertKeysToCamelCase(),
+                    new MapKeysToCamelCase(),
                 )
                 ->mapper()
                 ->map($class::class, ['SomeValue' => 'foo']);

--- a/tests/Integration/Mapping/Http/HttpRequestConflictMappingTest.php
+++ b/tests/Integration/Mapping/Http/HttpRequestConflictMappingTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Http;
 
-use CuyZ\Valinor\Mapper\Configurator\ConvertKeysToCamelCase;
+use CuyZ\Valinor\Mapper\Configurator\MapKeysToCamelCase;
 use CuyZ\Valinor\Mapper\Http\HttpRequest;
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
@@ -116,7 +116,7 @@ final class HttpRequestConflictMappingTest extends IntegrationTestCase
 
         try {
             $this->mapperBuilder()
-                ->configureWith(new ConvertKeysToCamelCase())
+                ->configureWith(new MapKeysToCamelCase())
                 ->argumentsMapper()
                 ->mapArguments($controller, $request);
 

--- a/tests/Integration/Mapping/Http/HttpRequestMappingTest.php
+++ b/tests/Integration/Mapping/Http/HttpRequestMappingTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Http;
 
-use CuyZ\Valinor\Mapper\Configurator\ConvertKeysToCamelCase;
+use CuyZ\Valinor\Mapper\Configurator\MapKeysToCamelCase;
 use CuyZ\Valinor\Mapper\Configurator\RestrictKeysToSnakeCase;
 use CuyZ\Valinor\Mapper\Exception\TypeErrorDuringArgumentsMapping;
 use CuyZ\Valinor\Mapper\Exception\TypeErrorDuringMapping;
@@ -687,7 +687,7 @@ final class HttpRequestMappingTest extends IntegrationTestCase
         ) => [];
 
         $result = $this->mapperBuilder()
-            ->configureWith(new ConvertKeysToCamelCase())
+            ->configureWith(new MapKeysToCamelCase())
             ->argumentsMapper()
             ->mapArguments($controller, $request);
 

--- a/tests/Integration/Normalizer/Configurator/NormalizeDateTimeFormatTest.php
+++ b/tests/Integration/Normalizer/Configurator/NormalizeDateTimeFormatTest.php
@@ -2,7 +2,7 @@
 
 namespace CuyZ\Valinor\Tests\Integration\Normalizer\Configurator;
 
-use CuyZ\Valinor\Normalizer\Configurator\ConvertDateTime;
+use CuyZ\Valinor\Normalizer\Configurator\NormalizeDateTimeFormat;
 use CuyZ\Valinor\Normalizer\Format;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use DateTimeInterface;
@@ -10,7 +10,7 @@ use DateTimeZone;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Safe\DateTimeImmutable;
 
-final class ConvertDateTimeTest extends IntegrationTestCase
+final class NormalizeDateTimeFormatTest extends IntegrationTestCase
 {
     /**
      * @param non-empty-string $format
@@ -19,7 +19,7 @@ final class ConvertDateTimeTest extends IntegrationTestCase
     public function test_date_time_converts_values(mixed $expectedValue, string $format, object $value): void
     {
         $result = $this->normalizerBuilder()
-            ->configureWith(new ConvertDateTime($format))
+            ->configureWith(new NormalizeDateTimeFormat($format))
             ->normalizer(Format::array())
             ->normalize($value);
 
@@ -53,7 +53,7 @@ final class ConvertDateTimeTest extends IntegrationTestCase
             'format' => DATE_ATOM, // Will be overridden by the attribute below
             'value' => new class () {
                 public function __construct(
-                    #[ConvertDateTime('d.m.Y H:i:s')]
+                    #[NormalizeDateTimeFormat('d.m.Y H:i:s')]
                     public DateTimeInterface $date = new DateTimeImmutable('1955-11-05T21:10:14', new DateTimeZone('UTC')),
                 ) {}
             },


### PR DESCRIPTION
The `ConvertKeysToCamelCase` and `ConvertKeysToSnakeCase` configurators
are renamed to `MapKeysToCamelCase` and `MapKeysToSnakeCase`.

The `Convert` prefix was easily confused with normalizer configurators,
whereas `Map` makes it clear these operate on the mapping side. The
former classes are kept as deprecated aliases and will be removed in a
future major version.

---

The `ConvertDateTime` normalizer configurator is renamed to
`NormalizeDateTimeFormat`.

The `Convert` prefix was easily confused with mapper configurators,
whereas `Normalize` makes it clear this operates on the normalization
side. The name also spells out that it sets the date time *format*.