### PR TITLE
feat: add normalizer configurator `NormalizeKeysToCamelCase`

### DIFF
--- a/docs/pages/serialization/common-transformers-examples.md
+++ b/docs/pages/serialization/common-transformers-examples.md
@@ -31,7 +31,7 @@ See [date time configurator chapter].
 
 See [snake_case configurator chapter].
 
-[snake_case configurator chapter]: use-provided-normalizer-configurators.md#converting-keys-to-snake_case
+[snake_case configurator chapter]: use-provided-normalizer-configurators.md#converting-key-case
 
 ## Ignoring properties
 

--- a/docs/pages/serialization/use-provided-normalizer-configurators.md
+++ b/docs/pages/serialization/use-provided-normalizer-configurators.md
@@ -6,7 +6,7 @@ can be used to apply common normalization behaviors:
 [normalizer configurators]: ./use-normalizer-configurators.md
 
 - [Specifying date time normalization format](#specifying-date-time-normalization-format)
-- [Converting keys to “snake_case”](#converting-keys-to-snake_case)
+- [Converting key case](#converting-key-case)
 
 ## Specifying date time normalization format
 
@@ -62,21 +62,22 @@ $userAsArray = (new NormalizerBuilder())
 // ]
 ```
 
-## Converting keys to “snake_case”
+## Converting key case
 
-The `NormalizeKeysToSnakeCase` configurator converts the keys of normalized
-objects to `snake_case`. This allows producing output with a different naming
-convention than the one used in the PHP codebase.
+Several configurators convert the keys of normalized objects to a different
+naming convention than the one used in the PHP codebase.
 
-| Conversion                 |
-|----------------------------|
-| `firstName` → `first_name` |
-| `FirstName` → `first_name` |
+| Configurator               | Result        |
+|----------------------------|---------------|
+| `NormalizeKeysToCamelCase` | `firstName`   |
+| `NormalizeKeysToSnakeCase` | `first_name`  |
 
-This class can be used either as a configurator for global usage or as an
-attribute to target a specific class.
+Each of these classes can be used either as a configurator for global usage or
+as an attribute to target a specific class.
 
 ### Global usage as a configurator
+
+The keys of every normalized object are converted to the target case:
 
 ```php
 use CuyZ\Valinor\Normalizer\Configurator\NormalizeKeysToSnakeCase;

--- a/src/Normalizer/Configurator/NormalizeKeysToCamelCase.php
+++ b/src/Normalizer/Configurator/NormalizeKeysToCamelCase.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Normalizer\Configurator;
+
+use Attribute;
+use CuyZ\Valinor\Normalizer\AsTransformer;
+use CuyZ\Valinor\NormalizerBuilder;
+
+use function is_array;
+use function lcfirst;
+use function str_replace;
+use function ucwords;
+
+/**
+ * Normalizes the keys of an object to `camelCase`.
+ *
+ * This class can be used either as a configurator for global usage or as an
+ * attribute to target a specific class.
+ *
+ * Global usage as a configurator
+ * ------------------------------
+ *
+ *  ```
+ *  use CuyZ\Valinor\NormalizerBuilder;
+ *  use CuyZ\Valinor\Normalizer\Configurator\NormalizeKeysToCamelCase;
+ *  use CuyZ\Valinor\Normalizer\Format;
+ *
+ *  // The keys of every normalized object will be converted to `camelCase`
+ *  $userAsArray = (new NormalizerBuilder())
+ *      ->configureWith(new NormalizeKeysToCamelCase())
+ *      ->normalizer(Format::array())
+ *      ->normalize($user);
+ *
+ *  // ['firstName' => 'John']
+ *  ```
+ *
+ * Local usage as an attribute
+ * ---------------------------
+ *
+ *  ```
+ *  use CuyZ\Valinor\Normalizer\Configurator\NormalizeKeysToCamelCase;
+ *  use CuyZ\Valinor\Normalizer\Format;
+ *  use CuyZ\Valinor\NormalizerBuilder;
+ *
+ *  // Only the keys of this class will be converted to `camelCase`
+ *  #[NormalizeKeysToCamelCase]
+ *  final readonly class User
+ *  {
+ *      public function __construct(
+ *          public string $first_name,
+ *      ) {}
+ *  }
+ *
+ *  $userAsArray = (new NormalizerBuilder())
+ *      ->normalizer(Format::array())
+ *      ->normalize(new User('John'));
+ *
+ *  // ['firstName' => 'John']
+ *  ```
+ *
+ * @api
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+#[AsTransformer]
+final readonly class NormalizeKeysToCamelCase implements NormalizerBuilderConfigurator
+{
+    public function configureNormalizerBuilder(NormalizerBuilder $builder): NormalizerBuilder
+    {
+        return $builder->registerTransformer($this->normalize(...));
+    }
+
+    public function normalize(object $object, callable $next): mixed
+    {
+        $result = $next();
+
+        if (! is_array($result)) {
+            return $result;
+        }
+
+        $camelCased = [];
+
+        foreach ($result as $key => $value) {
+            $newKey = lcfirst(str_replace(['_', '-'], '', ucwords($key, '_-')));
+
+            $camelCased[$newKey] = $value;
+        }
+
+        return $camelCased;
+    }
+}

--- a/tests/Integration/Normalizer/Configurator/NormalizeKeysToCamelCaseTest.php
+++ b/tests/Integration/Normalizer/Configurator/NormalizeKeysToCamelCaseTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Normalizer\Configurator;
+
+use CuyZ\Valinor\Normalizer\Configurator\NormalizeKeysToCamelCase;
+use CuyZ\Valinor\Normalizer\Format;
+use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class NormalizeKeysToCamelCaseTest extends IntegrationTestCase
+{
+    /**
+     * @param array<string, non-empty-string> $expectedValue
+     */
+    #[DataProvider('to_camel_case_data_provider')]
+    public function test_to_camel_case_converts_keys(array $expectedValue, object $object): void
+    {
+        $result = $this->normalizerBuilder()
+            ->configureWith(new NormalizeKeysToCamelCase())
+            ->normalizer(Format::array())
+            ->normalize($object);
+
+        self::assertSame($expectedValue, $result);
+    }
+
+    public function test_to_camel_case_attribute_converts_keys_of_annotated_class(): void
+    {
+        $object = new #[NormalizeKeysToCamelCase] class () {
+            public string $some_value = 'foo';
+        };
+
+        $result = $this->normalizerBuilder()
+            ->normalizer(Format::array())
+            ->normalize($object);
+
+        self::assertSame(['someValue' => 'foo'], $result);
+    }
+
+    public function test_to_camel_case_attribute_targets_only_annotated_class(): void
+    {
+        $annotated = new #[NormalizeKeysToCamelCase] class () {
+            public string $postal_code = 'NW1 6XE';
+        };
+
+        $object = new class ($annotated) {
+            public function __construct(
+                public object $address,
+                public string $user_name = 'John Doe',
+            ) {}
+        };
+
+        $result = $this->normalizerBuilder()
+            ->normalizer(Format::array())
+            ->normalize($object);
+
+        // Only the annotated nested class is converted; the enclosing object
+        // keeps its original `snake_case` keys.
+        self::assertSame([
+            'address' => ['postalCode' => 'NW1 6XE'],
+            'user_name' => 'John Doe',
+        ], $result);
+    }
+
+    public function test_to_camel_case_leaves_non_array_normalized_value_untouched(): void
+    {
+        // Some objects (e.g. a `DateTimeInterface`) normalize to a scalar; the
+        // configurator must return that value as-is instead of mangling it.
+        $date = new DateTimeImmutable('2000-01-01T00:00:00+00:00');
+
+        $result = $this->normalizerBuilder()
+            ->configureWith(new NormalizeKeysToCamelCase())
+            ->normalizer(Format::array())
+            ->normalize($date);
+
+        self::assertSame('2000-01-01T00:00:00.000000+00:00', $result);
+    }
+
+    /**
+     * @return iterable<string, array{array, object}>
+     */
+    public static function to_camel_case_data_provider(): iterable
+    {
+        yield 'from snake_case' => [['someValue' => 'foo'], new class () {
+            public string $some_value = 'foo';
+        }];
+
+        yield 'from PascalCase' => [['someValue' => 'foo'], new class () {
+            public string $SomeValue = 'foo';
+        }];
+
+        yield 'already camelCase' => [['someValue' => 'foo'], new class () {
+            public string $someValue = 'foo';
+        }];
+
+        yield 'from snake_case with leading underscore' => [['someValue' => 'foo'], new class () {
+            public string $_some_value = 'foo';
+        }];
+    }
+}


### PR DESCRIPTION
Normalizes the keys of an object to `camelCase`.

This class can be used either as a configurator for global usage or as an attribute to target a specific class.

Global usage as a configurator
------------------------------

 ```php
 use CuyZ\Valinor\NormalizerBuilder;
 use CuyZ\Valinor\Normalizer\Configurator\NormalizeKeysToCamelCase;
 use CuyZ\Valinor\Normalizer\Format;

 // The keys of every normalized object will be converted to camelCase
 $userAsArray = (new NormalizerBuilder())
     ->configureWith(new NormalizeKeysToCamelCase())
     ->normalizer(Format::array())
     ->normalize($user);

 // ['firstName' => 'John']
 ```

Local usage as an attribute
---------------------------

 ```php
 use CuyZ\Valinor\Normalizer\Configurator\NormalizeKeysToCamelCase;
 use CuyZ\Valinor\Normalizer\Format;
 use CuyZ\Valinor\NormalizerBuilder;

 // Only the keys of this class will be converted to `camelCase`
 #[NormalizeKeysToCamelCase]
 final readonly class User
 {
     public function __construct(
         public string $first_name,
     ) {}
 }

 $userAsArray = (new NormalizerBuilder())
     ->normalizer(Format::array())
     ->normalize(new User('John'));

 // ['firstName' => 'John']
 ```

The normalizer documentation chapters covering key case conversion are merged into a single `Converting key case` section.