### PR TITLE
feat: add normalizer configurator `NormalizeKeysToPascalCase`

### DIFF
--- a/docs/pages/serialization/use-provided-normalizer-configurators.md
+++ b/docs/pages/serialization/use-provided-normalizer-configurators.md
@@ -67,10 +67,11 @@ $userAsArray = (new NormalizerBuilder())
 Several configurators convert the keys of normalized objects to a different
 naming convention than the one used in the PHP codebase.
 
-| Configurator               | Result        |
-|----------------------------|---------------|
-| `NormalizeKeysToCamelCase` | `firstName`   |
-| `NormalizeKeysToSnakeCase` | `first_name`  |
+| Configurator                | Result        |
+|-----------------------------|---------------|
+| `NormalizeKeysToSnakeCase`  | `first_name`  |
+| `NormalizeKeysToCamelCase`  | `firstName`   |
+| `NormalizeKeysToPascalCase` | `FirstName`   |
 
 Each of these classes can be used either as a configurator for global usage or
 as an attribute to target a specific class.

--- a/src/Normalizer/Configurator/NormalizeKeysToPascalCase.php
+++ b/src/Normalizer/Configurator/NormalizeKeysToPascalCase.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Normalizer\Configurator;
+
+use Attribute;
+use CuyZ\Valinor\Normalizer\AsTransformer;
+use CuyZ\Valinor\NormalizerBuilder;
+
+use function is_array;
+use function str_replace;
+use function ucwords;
+
+/**
+ * Normalizes the keys of an object to `PascalCase`.
+ *
+ * This class can be used either as a configurator for global usage or as an
+ * attribute to target a specific class.
+ *
+ * Global usage as a configurator
+ * ------------------------------
+ *
+ *  ```
+ *  use CuyZ\Valinor\NormalizerBuilder;
+ *  use CuyZ\Valinor\Normalizer\Configurator\NormalizeKeysToPascalCase;
+ *  use CuyZ\Valinor\Normalizer\Format;
+ *
+ *  // The keys of every normalized object will be converted to `PascalCase`
+ *  $userAsArray = (new NormalizerBuilder())
+ *      ->configureWith(new NormalizeKeysToPascalCase())
+ *      ->normalizer(Format::array())
+ *      ->normalize($user);
+ *
+ *  // ['FirstName' => 'John']
+ *  ```
+ *
+ * Local usage as an attribute
+ * ---------------------------
+ *
+ *  ```
+ *  use CuyZ\Valinor\Normalizer\Configurator\NormalizeKeysToPascalCase;
+ *  use CuyZ\Valinor\Normalizer\Format;
+ *  use CuyZ\Valinor\NormalizerBuilder;
+ *
+ *  // Only the keys of this class will be converted to `PascalCase`
+ *  #[NormalizeKeysToPascalCase]
+ *  final readonly class User
+ *  {
+ *      public function __construct(
+ *          public string $first_name,
+ *      ) {}
+ *  }
+ *
+ *  $userAsArray = (new NormalizerBuilder())
+ *      ->normalizer(Format::array())
+ *      ->normalize(new User('John'));
+ *
+ *  // ['FirstName' => 'John']
+ *  ```
+ *
+ * @api
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+#[AsTransformer]
+final readonly class NormalizeKeysToPascalCase implements NormalizerBuilderConfigurator
+{
+    public function configureNormalizerBuilder(NormalizerBuilder $builder): NormalizerBuilder
+    {
+        return $builder->registerTransformer($this->normalize(...));
+    }
+
+    public function normalize(object $object, callable $next): mixed
+    {
+        $result = $next();
+
+        if (! is_array($result)) {
+            return $result;
+        }
+
+        $pascalCased = [];
+
+        foreach ($result as $key => $value) {
+            $newKey = str_replace(['_', '-'], '', ucwords($key, '_-'));
+
+            $pascalCased[$newKey] = $value;
+        }
+
+        return $pascalCased;
+    }
+}

--- a/tests/Integration/Normalizer/Configurator/NormalizeKeysToPascalCaseTest.php
+++ b/tests/Integration/Normalizer/Configurator/NormalizeKeysToPascalCaseTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Normalizer\Configurator;
+
+use CuyZ\Valinor\Normalizer\Configurator\NormalizeKeysToPascalCase;
+use CuyZ\Valinor\Normalizer\Format;
+use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class NormalizeKeysToPascalCaseTest extends IntegrationTestCase
+{
+    /**
+     * @param array<string, non-empty-string> $expectedValue
+     */
+    #[DataProvider('to_pascal_case_data_provider')]
+    public function test_to_pascal_case_converts_keys(array $expectedValue, object $object): void
+    {
+        $result = $this->normalizerBuilder()
+            ->configureWith(new NormalizeKeysToPascalCase())
+            ->normalizer(Format::array())
+            ->normalize($object);
+
+        self::assertSame($expectedValue, $result);
+    }
+
+    public function test_to_pascal_case_attribute_converts_keys_of_annotated_class(): void
+    {
+        $object = new #[NormalizeKeysToPascalCase] class () {
+            public string $some_value = 'foo';
+        };
+
+        $result = $this->normalizerBuilder()
+            ->normalizer(Format::array())
+            ->normalize($object);
+
+        self::assertSame(['SomeValue' => 'foo'], $result);
+    }
+
+    public function test_to_pascal_case_attribute_targets_only_annotated_class(): void
+    {
+        $annotated = new #[NormalizeKeysToPascalCase] class () {
+            public string $postal_code = 'NW1 6XE';
+        };
+
+        $object = new class ($annotated) {
+            public function __construct(
+                public object $address,
+                public string $user_name = 'John Doe',
+            ) {}
+        };
+
+        $result = $this->normalizerBuilder()
+            ->normalizer(Format::array())
+            ->normalize($object);
+
+        // Only the annotated nested class is converted; the enclosing object
+        // keeps its original `snake_case` keys.
+        self::assertSame([
+            'address' => ['PostalCode' => 'NW1 6XE'],
+            'user_name' => 'John Doe',
+        ], $result);
+    }
+
+    public function test_to_pascal_case_leaves_non_array_normalized_value_untouched(): void
+    {
+        // Some objects (e.g. a `DateTimeInterface`) normalize to a scalar; the
+        // configurator must return that value as-is instead of mangling it.
+        $date = new DateTimeImmutable('2000-01-01T00:00:00+00:00');
+
+        $result = $this->normalizerBuilder()
+            ->configureWith(new NormalizeKeysToPascalCase())
+            ->normalizer(Format::array())
+            ->normalize($date);
+
+        self::assertSame('2000-01-01T00:00:00.000000+00:00', $result);
+    }
+
+    /**
+     * @return iterable<string, array{array, object}>
+     */
+    public static function to_pascal_case_data_provider(): iterable
+    {
+        yield 'from snake_case' => [['SomeValue' => 'foo'], new class () {
+            public string $some_value = 'foo';
+        }];
+
+        yield 'from camelCase' => [['SomeValue' => 'foo'], new class () {
+            public string $someValue = 'foo';
+        }];
+
+        yield 'already PascalCase' => [['SomeValue' => 'foo'], new class () {
+            public string $SomeValue = 'foo';
+        }];
+
+        yield 'from snake_case with leading underscore' => [['SomeValue' => 'foo'], new class () {
+            public string $_some_value = 'foo';
+        }];
+    }
+}


### PR DESCRIPTION
Normalizes the keys of an object to `PascalCase`.

This class can be used either as a configurator for global usage or as an attribute to target a specific class.

Global usage as a configurator
------------------------------

 ```php
 use CuyZ\Valinor\NormalizerBuilder;
 use CuyZ\Valinor\Normalizer\Configurator\NormalizeKeysToPascalCase;
 use CuyZ\Valinor\Normalizer\Format;

 // The keys of every normalized object will be converted to PascalCase
 $userAsArray = (new NormalizerBuilder())
     ->configureWith(new NormalizeKeysToPascalCase())
     ->normalizer(Format::array())
     ->normalize($user);

 // ['FirstName' => 'John']
 ```

Local usage as an attribute
---------------------------

 ```php
 use CuyZ\Valinor\Normalizer\Configurator\NormalizeKeysToPascalCase;
 use CuyZ\Valinor\Normalizer\Format;
 use CuyZ\Valinor\NormalizerBuilder;

 // Only the keys of this class will be converted to `PascalCase`
 #[NormalizeKeysToPascalCase]
 final readonly class User
 {
     public function __construct(
         public string $first_name,
     ) {}
 }

 $userAsArray = (new NormalizerBuilder())
     ->normalizer(Format::array())
     ->normalize(new User('John'));

 // ['FirstName' => 'John']
 ```