### PR TITLE
feat: add normalizer configurator `NormalizeKeysToKebabCase`

### DIFF
--- a/docs/pages/serialization/use-provided-normalizer-configurators.md
+++ b/docs/pages/serialization/use-provided-normalizer-configurators.md
@@ -72,6 +72,7 @@ naming convention than the one used in the PHP codebase.
 | `NormalizeKeysToSnakeCase`  | `first_name`  |
 | `NormalizeKeysToCamelCase`  | `firstName`   |
 | `NormalizeKeysToPascalCase` | `FirstName`   |
+| `NormalizeKeysToKebabCase`  | `first-name`  |
 
 Each of these classes can be used either as a configurator for global usage or
 as an attribute to target a specific class.

--- a/src/Normalizer/Configurator/NormalizeKeysToKebabCase.php
+++ b/src/Normalizer/Configurator/NormalizeKeysToKebabCase.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Normalizer\Configurator;
+
+use Attribute;
+use CuyZ\Valinor\Normalizer\AsTransformer;
+use CuyZ\Valinor\NormalizerBuilder;
+
+use function is_array;
+use function lcfirst;
+use function preg_replace;
+use function str_replace;
+use function strtolower;
+
+/**
+ * Normalizes the keys of an object to `kebab-case`.
+ *
+ * This class can be used either as a configurator for global usage or as an
+ * attribute to target a specific class.
+ *
+ * Global usage as a configurator
+ * ------------------------------
+ *
+ *  ```
+ *  use CuyZ\Valinor\NormalizerBuilder;
+ *  use CuyZ\Valinor\Normalizer\Configurator\NormalizeKeysToKebabCase;
+ *  use CuyZ\Valinor\Normalizer\Format;
+ *
+ *  // The keys of every normalized object will be converted to `kebab-case`
+ *  $userAsArray = (new NormalizerBuilder())
+ *      ->configureWith(new NormalizeKeysToKebabCase())
+ *      ->normalizer(Format::array())
+ *      ->normalize($user);
+ *
+ *  // ['first-name' => 'John']
+ *  ```
+ *
+ * Local usage as an attribute
+ * ---------------------------
+ *
+ *  ```
+ *  use CuyZ\Valinor\Normalizer\Configurator\NormalizeKeysToKebabCase;
+ *  use CuyZ\Valinor\Normalizer\Format;
+ *  use CuyZ\Valinor\NormalizerBuilder;
+ *
+ *  // Only the keys of this class will be converted to `kebab-case`
+ *  #[NormalizeKeysToKebabCase]
+ *  final readonly class User
+ *  {
+ *      public function __construct(
+ *          public string $firstName,
+ *      ) {}
+ *  }
+ *
+ *  $userAsArray = (new NormalizerBuilder())
+ *      ->normalizer(Format::array())
+ *      ->normalize(new User('John'));
+ *
+ *  // ['first-name' => 'John']
+ *  ```
+ *
+ * @api
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+#[AsTransformer]
+final readonly class NormalizeKeysToKebabCase implements NormalizerBuilderConfigurator
+{
+    public function configureNormalizerBuilder(NormalizerBuilder $builder): NormalizerBuilder
+    {
+        return $builder->registerTransformer($this->normalize(...));
+    }
+
+    public function normalize(object $object, callable $next): mixed
+    {
+        $result = $next();
+
+        if (! is_array($result)) {
+            return $result;
+        }
+
+        $kebabCased = [];
+
+        foreach ($result as $key => $value) {
+            $lcFirstKey = preg_replace('/[A-Z]/', '-$0', lcfirst($key));
+            $newKey = str_replace('_', '-', strtolower($lcFirstKey ?? $key));
+
+            $kebabCased[$newKey] = $value;
+        }
+
+        return $kebabCased;
+    }
+}

--- a/tests/Integration/Normalizer/Configurator/NormalizeKeysToKebabCaseTest.php
+++ b/tests/Integration/Normalizer/Configurator/NormalizeKeysToKebabCaseTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Normalizer\Configurator;
+
+use CuyZ\Valinor\Normalizer\Configurator\NormalizeKeysToKebabCase;
+use CuyZ\Valinor\Normalizer\Format;
+use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class NormalizeKeysToKebabCaseTest extends IntegrationTestCase
+{
+    /**
+     * @param array<string, non-empty-string> $expectedValue
+     */
+    #[DataProvider('to_kebab_case_data_provider')]
+    public function test_to_kebab_case_converts_keys(array $expectedValue, object $object): void
+    {
+        $result = $this->normalizerBuilder()
+            ->configureWith(new NormalizeKeysToKebabCase())
+            ->normalizer(Format::array())
+            ->normalize($object);
+
+        self::assertSame($expectedValue, $result);
+    }
+
+    public function test_to_kebab_case_attribute_converts_keys_of_annotated_class(): void
+    {
+        $object = new #[NormalizeKeysToKebabCase] class () {
+            public string $someValue = 'foo';
+        };
+
+        $result = $this->normalizerBuilder()
+            ->normalizer(Format::array())
+            ->normalize($object);
+
+        self::assertSame(['some-value' => 'foo'], $result);
+    }
+
+    public function test_to_kebab_case_attribute_targets_only_annotated_class(): void
+    {
+        $annotated = new #[NormalizeKeysToKebabCase] class () {
+            public string $postalCode = 'NW1 6XE';
+        };
+
+        $object = new class ($annotated) {
+            public function __construct(
+                public object $address,
+                public string $userName = 'John Doe',
+            ) {}
+        };
+
+        $result = $this->normalizerBuilder()
+            ->normalizer(Format::array())
+            ->normalize($object);
+
+        // Only the annotated nested class is converted; the enclosing object
+        // keeps its original `camelCase` keys.
+        self::assertSame([
+            'address' => ['postal-code' => 'NW1 6XE'],
+            'userName' => 'John Doe',
+        ], $result);
+    }
+
+    public function test_to_kebab_case_leaves_non_array_normalized_value_untouched(): void
+    {
+        // Some objects (e.g. a `DateTimeInterface`) normalize to a scalar; the
+        // configurator must return that value as-is instead of mangling it.
+        $date = new DateTimeImmutable('2000-01-01T00:00:00+00:00');
+
+        $result = $this->normalizerBuilder()
+            ->configureWith(new NormalizeKeysToKebabCase())
+            ->normalizer(Format::array())
+            ->normalize($date);
+
+        self::assertSame('2000-01-01T00:00:00.000000+00:00', $result);
+    }
+
+    /**
+     * @return iterable<string, array{array, object}>
+     */
+    public static function to_kebab_case_data_provider(): iterable
+    {
+        yield 'from camelCase' => [['some-value' => 'foo'], new class () {
+            public string $someValue = 'foo';
+        }];
+
+        yield 'from PascalCase' => [['some-value' => 'foo'], new class () {
+            public string $SomeValue = 'foo';
+        }];
+
+        yield 'from snake_case' => [['some-value' => 'foo'], new class () {
+            public string $some_value = 'foo';
+        }];
+
+        yield 'from camelCase with multiple words' => [['number-of-items' => 'foo'], new class () {
+            public string $numberOfItems = 'foo';
+        }];
+    }
+}


### PR DESCRIPTION
Normalizes the keys of an object to `kebab-case`.

This class can be used either as a configurator for global usage or as an attribute to target a specific class.

Global usage as a configurator
------------------------------

 ```php
 use CuyZ\Valinor\NormalizerBuilder;
 use CuyZ\Valinor\Normalizer\Configurator\NormalizeKeysToKebabCase;
 use CuyZ\Valinor\Normalizer\Format;

 // The keys of every normalized object will be converted to kebab-case
 $userAsArray = (new NormalizerBuilder())
     ->configureWith(new NormalizeKeysToKebabCase())
     ->normalizer(Format::array())
     ->normalize($user);

 // ['first-name' => 'John']
 ```

Local usage as an attribute
---------------------------

 ```php
 use CuyZ\Valinor\Normalizer\Configurator\NormalizeKeysToKebabCase;
 use CuyZ\Valinor\Normalizer\Format;
 use CuyZ\Valinor\NormalizerBuilder;

 // Only the keys of this class will be converted to `kebab-case`
 #[NormalizeKeysToKebabCase]
 final readonly class User
 {
     public function __construct(
         public string $firstName,
     ) {}
 }

 $userAsArray = (new NormalizerBuilder())
     ->normalizer(Format::array())
     ->normalize(new User('John'));

 // ['first-name' => 'John']
 ```