### PR TITLE
docs: fix two typos in documentation

### DIFF
--- a/docs/pages/project/upgrading.md
+++ b/docs/pages/project/upgrading.md
@@ -164,7 +164,7 @@ reasons:
 > and user experience.
 
 After a discussion with `@pure` aficionados, the decision has been made to
-re-introduce them. This time, is is possible to easily suppress the errors
+re-introduce them. This time, it is possible to easily suppress the errors
 reported by PHPStan and Psalm by using plugins provided out of the box by this
 library.
 

--- a/docs/pages/serialization/normalizing-json.md
+++ b/docs/pages/serialization/normalizing-json.md
@@ -76,7 +76,7 @@ $normalizer->normalize($users);
 
 By default, the JSON normalizer will only use `JSON_THROW_ON_ERROR` to encode
 non-boolean scalar values. There might be use-cases where projects will need
-flags like `JSON_JSON_PRESERVE_ZERO_FRACTION`.
+flags like `JSON_PRESERVE_ZERO_FRACTION`.
 
 This can be achieved by passing these flags to the
 `JsonNormalizer::withOptions()` method:


### PR DESCRIPTION
Fix two typos found in the documentation:

- `docs/pages/project/upgrading.md`: "is is possible" → "it is possible"
  - https://valinor-php.dev/latest/project/upgrading/#add-pure-markers-to-mapperbuilder-and-normalizerbuilder-methods
- `docs/pages/serialization/normalizing-json.md`: `JSON_JSON_PRESERVE_ZERO_FRACTION` → `JSON_PRESERVE_ZERO_FRACTION`
  - https://valinor-php.dev/latest/serialization/normalizing-json/#passing-json_encode-flags