### PR TITLE
fix: resolve docblock types of anonymous classes against their lexical namespace

### DIFF
--- a/src/Type/Parser/Factory/Specifications/AliasSpecification.php
+++ b/src/Type/Parser/Factory/Specifications/AliasSpecification.php
@@ -88,7 +88,12 @@ final class AliasSpecification implements TypeParserSpecification
             }
         }
 
-        if ($reflection->inNamespace()) {
+        if ($reflection->isAnonymous()) {
+            // The name of an anonymous class or closure carries either no
+            // namespace or another type's namespace, not reliably the lexical
+            // one, so the namespace is recovered from the source instead.
+            $namespace = PhpParser::parseNamespace($reflection);
+        } elseif ($reflection->inNamespace()) {
             $namespace = $reflection->getNamespaceName();
         } elseif ($reflection instanceof ReflectionFunction) {
             $namespace = PhpParser::parseNamespace($reflection);

--- a/src/Utility/Reflection/PhpParser.php
+++ b/src/Utility/Reflection/PhpParser.php
@@ -22,19 +22,23 @@ final class PhpParser
     /** @var array<string, array<string, string>> */
     private static array $statements = [];
 
+    /** @var array<string, string|null> */
+    private static array $namespaces = [];
+
     /**
-     * @param ReflectionClass<covariant object>|ReflectionFunction|ReflectionMethod $reflection
-     * @return array<string, string>
+     * @param ReflectionClass<covariant object>|ReflectionFunction $reflection
      */
-    public static function parseUseStatements(ReflectionClass|ReflectionFunction|ReflectionMethod $reflection): array
+    public static function parseNamespace(ReflectionClass|ReflectionFunction $reflection): ?string
     {
         $signature = "{$reflection->getFileName()}:{$reflection->getStartLine()}";
 
-        // @infection-ignore-all
-        return self::$statements[$signature] ??= self::fetchUseStatements($reflection);
+        return self::$namespaces[$signature] ??= self::fetchNamespace($reflection);
     }
 
-    public static function parseNamespace(ReflectionFunction $reflection): ?string
+    /**
+     * @param ReflectionClass<covariant object>|ReflectionFunction $reflection
+     */
+    private static function fetchNamespace(ReflectionClass|ReflectionFunction $reflection): ?string
     {
         $content = self::getFileContent($reflection);
 
@@ -43,6 +47,17 @@ final class PhpParser
         }
 
         return (new NamespaceFinder())->findNamespace($content);
+    }
+
+    /**
+     * @param ReflectionClass<covariant object>|ReflectionFunction|ReflectionMethod $reflection
+     * @return array<string, string>
+     */
+    public static function parseUseStatements(ReflectionClass|ReflectionFunction|ReflectionMethod $reflection): array
+    {
+        $signature = "{$reflection->getFileName()}:{$reflection->getStartLine()}";
+
+        return self::$statements[$signature] ??= self::fetchUseStatements($reflection);
     }
 
     /**
@@ -60,8 +75,12 @@ final class PhpParser
         $tokenParser = new TokenParser($content);
 
         if ($reflection instanceof ReflectionMethod) {
-            $namespaceName = $reflection->getDeclaringClass()->getNamespaceName();
-        } elseif ($reflection instanceof ReflectionFunction) {
+            $reflection = $reflection->getDeclaringClass();
+        }
+
+        if ($reflection instanceof ReflectionFunction || $reflection->isAnonymous()) {
+            // An anonymous class name carries either no namespace or the
+            // extended/implemented type's namespace, not reliably the lexical one.
             $namespaceName = $tokenParser->getNamespace();
         } else {
             $namespaceName = $reflection->getNamespaceName();

--- a/tests/Integration/Mapping/Fixture/AbstractObject.php
+++ b/tests/Integration/Mapping/Fixture/AbstractObject.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Mapping\Fixture;
+
+abstract class AbstractObject {}

--- a/tests/Integration/Mapping/GenericTypesInAnonymousClassConstructorTest.php
+++ b/tests/Integration/Mapping/GenericTypesInAnonymousClassConstructorTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Mapping;
+
+use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
+use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\AbstractObject;
+use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject;
+
+final class GenericTypesInAnonymousClassConstructorTest extends IntegrationTestCase
+{
+    public function test_deserializes_generic_type(): void
+    {
+        $result = $this->mapperBuilder()
+            ->mapper()
+            ->map(
+                (new class (new DummyPaginable(null, [])) {
+                    /** @param DummyPaginable<User> $wrapped */
+                    public function __construct(public DummyPaginable $wrapped) {}
+                })::class,
+                [
+                    'nextPage' => 'abc123',
+                    'items' => [
+                        [
+                            'username' => 'ocramius'
+                        ]
+                    ]
+                ]
+            );
+
+        self::assertEquals(
+            new DummyPaginable('abc123', [new User('ocramius')]),
+            $result->wrapped,
+        );
+    }
+
+    public function test_deserializes_generic_type_with_fqcn_references(): void
+    {
+        $result = $this->mapperBuilder()
+            ->mapper()
+            ->map(
+                (new class (new DummyPaginable(null, [])) {
+                    /** @param \CuyZ\Valinor\Tests\Integration\Mapping\DummyPaginable<\CuyZ\Valinor\Tests\Integration\Mapping\User> $wrapped */
+                    public function __construct(public DummyPaginable $wrapped) {}
+                })::class,
+                [
+                    'nextPage' => 'abc123',
+                    'items' => [
+                        [
+                            'username' => 'ocramius'
+                        ]
+                    ]
+                ]
+            );
+
+        self::assertEquals(
+            new DummyPaginable('abc123', [new User('ocramius')]),
+            $result->wrapped,
+        );
+    }
+
+    public function test_deserializes_generic_type_in_property(): void
+    {
+        $result = $this->mapperBuilder()
+            ->mapper()
+            ->map(
+                (new class () {
+                    /** @var DummyPaginable<User> */
+                    public DummyPaginable $wrapped;
+                })::class,
+                [
+                    'wrapped' => [
+                        'nextPage' => 'abc123',
+                        'items' => [
+                            [
+                                'username' => 'ocramius'
+                            ]
+                        ]
+                    ]
+                ]
+            );
+
+        self::assertEquals(
+            new DummyPaginable('abc123', [new User('ocramius')]),
+            $result->wrapped,
+        );
+    }
+
+    public function test_deserializes_generic_type_when_anonymous_class_extends_class_from_another_namespace(): void
+    {
+        // The name of an anonymous class extending another class is prefixed
+        // with that class' name, so the synthetic name carries the parent's
+        // namespace instead of the lexical one.
+        $result = $this->mapperBuilder()
+            ->mapper()
+            ->map(
+                (new class (new DummyPaginable(null, [])) extends AbstractObject {
+                    /** @param DummyPaginable<User> $wrapped */
+                    public function __construct(public DummyPaginable $wrapped) {}
+                })::class,
+                [
+                    'nextPage' => 'abc123',
+                    'items' => [
+                        [
+                            'username' => 'ocramius'
+                        ]
+                    ]
+                ]
+            );
+
+        self::assertEquals(
+            new DummyPaginable('abc123', [new User('ocramius')]),
+            $result->wrapped,
+        );
+    }
+
+    public function test_deserializes_generic_type_with_imported_type(): void
+    {
+        $result = $this->mapperBuilder()
+            ->mapper()
+            ->map(
+                (new class (new DummyPaginable(null, [])) {
+                    /** @param DummyPaginable<SimpleObject> $wrapped */
+                    public function __construct(public DummyPaginable $wrapped) {}
+                })::class,
+                [
+                    'nextPage' => 'abc123',
+                    'items' => [
+                        [
+                            'value' => 'foo'
+                        ]
+                    ]
+                ]
+            );
+
+        self::assertSame('abc123', $result->wrapped->nextPage);
+        self::assertCount(1, $result->wrapped->items);
+        self::assertSame('foo', $result->wrapped->items[0]->value);
+    }
+}
+
+/** @template Paged of object */
+final readonly class DummyPaginable
+{
+    /** @param list<Paged> $items */
+    public function __construct(
+        public string|null $nextPage,
+        public array $items,
+    ) {}
+}
+
+final readonly class User
+{
+    public function __construct(public string $username) {}
+}

--- a/tests/Integration/Mapping/GenericTypesInAnonymousClassConstructorTest.php
+++ b/tests/Integration/Mapping/GenericTypesInAnonymousClassConstructorTest.php
@@ -8,6 +8,21 @@ use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\AbstractObject;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject;
 
+/** @template Paged of object */
+final readonly class DummyPaginable
+{
+    /** @param list<Paged> $items */
+    public function __construct(
+        public string|null $nextPage,
+        public array $items,
+    ) {}
+}
+
+final readonly class User
+{
+    public function __construct(public string $username) {}
+}
+
 final class GenericTypesInAnonymousClassConstructorTest extends IntegrationTestCase
 {
     public function test_deserializes_generic_type(): void
@@ -138,19 +153,4 @@ final class GenericTypesInAnonymousClassConstructorTest extends IntegrationTestC
         self::assertCount(1, $result->wrapped->items);
         self::assertSame('foo', $result->wrapped->items[0]->value);
     }
-}
-
-/** @template Paged of object */
-final readonly class DummyPaginable
-{
-    /** @param list<Paged> $items */
-    public function __construct(
-        public string|null $nextPage,
-        public array $items,
-    ) {}
-}
-
-final readonly class User
-{
-    public function __construct(public string $username) {}
 }

--- a/tests/Unit/Definition/Repository/Reflection/ReflectionClassDefinitionRepositoryTest.php
+++ b/tests/Unit/Definition/Repository/Reflection/ReflectionClassDefinitionRepositoryTest.php
@@ -209,6 +209,20 @@ final class ReflectionClassDefinitionRepositoryTest extends UnitTestCase
         self::assertSame('non-empty-array<string>', $propertyType->toString());
     }
 
+    public function test_named_class_declared_without_source_file_can_use_type_from_its_own_namespace(): void
+    {
+        // `eval()` of a static literal is used here as the only way to declare
+        // a named class without a source file: no source can be parsed, so the
+        // class name is the only remaining namespace-resolution context.
+        eval('namespace CuyZ\Valinor\Tests\Unit\Definition\Repository\Reflection; final class NamedClassDeclaredWithoutSourceFile { /** @var ClassWithInheritedPrivateConstructor */ public object $value; }');
+
+        $type = new NativeClassType(NamedClassDeclaredWithoutSourceFile::class); // @phpstan-ignore class.notFound
+        $properties = $this->getClass($type)->properties;
+        $propertyType = $properties->get('value')->type;
+
+        self::assertSame(ClassWithInheritedPrivateConstructor::class, $propertyType->toString());
+    }
+
     public function test_can_use_nested_local_types(): void
     {
         $class =

--- a/tests/Unit/Utility/Reflection/Fixtures/anonymous-class-with-imports.php
+++ b/tests/Unit/Utility/Reflection/Fixtures/anonymous-class-with-imports.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Unit\Utility\Reflection\Fixtures\AnonymousClassNamespace;
+
+use CuyZ\Valinor\Tests\Unit\Utility\Reflection\Fixtures\SubDir\Bar as BarAlias;
+use CuyZ\Valinor\Tests\Unit\Utility\Reflection\Fixtures\SubDir\Foo;
+
+return new class (null, null) {
+    public function __construct(
+        public BarAlias|null $bar,
+        public Foo|null $foo,
+    ) {}
+};

--- a/tests/Unit/Utility/Reflection/PhpParserTest.php
+++ b/tests/Unit/Utility/Reflection/PhpParserTest.php
@@ -21,6 +21,9 @@ use ReflectionFunction;
 use ReflectionMethod;
 use stdClass;
 
+use function assert;
+use function is_object;
+
 require_once __DIR__ . '/Fixtures/TwoClassesInDifferentNamespaces.php';
 require_once __DIR__ . '/Fixtures/FunctionInRootNamespace.php';
 require_once __DIR__ . '/Fixtures/FunctionWithSeveralImportStatementsInSameUseStatement.php';
@@ -174,6 +177,14 @@ final class PhpParserTest extends UnitTestCase
                 'foo' => Foo::class,
             ]
         ];
+
+        yield 'anonymous class' => [
+            new ReflectionClass(require __DIR__ . '/Fixtures/anonymous-class-with-imports.php'), // @phpstan-ignore argument.type
+            [
+                'baralias' => Bar::class,
+                'foo' => Foo::class,
+            ]
+        ];
     }
 
     public function test_can_parse_namespace_for_closure_with_one_level_namespace(): void
@@ -198,5 +209,28 @@ final class PhpParserTest extends UnitTestCase
         $namespace = PhpParser::parseNamespace($reflection);
 
         self::assertSame('Root\QualifiedNamespace', $namespace);
+    }
+
+    public function test_can_parse_namespace_for_anonymous_class(): void
+    {
+        $object = require __DIR__ . '/Fixtures/anonymous-class-with-imports.php';
+        assert(is_object($object));
+
+        $namespace = PhpParser::parseNamespace(new ReflectionClass($object));
+
+        self::assertSame('CuyZ\Valinor\Tests\Unit\Utility\Reflection\Fixtures\AnonymousClassNamespace', $namespace);
+    }
+
+    public function test_parse_namespace_for_function_without_source_file_returns_null(): void
+    {
+        // `eval()` of a static literal is used here as the only way to
+        // declare a function without a source file.
+        $function = eval('return static fn () => null;');
+
+        assert($function instanceof Closure);
+
+        $namespace = PhpParser::parseNamespace(new ReflectionFunction($function));
+
+        self::assertNull($namespace);
     }
 }


### PR DESCRIPTION
Builds on #824. Its reproduction test is the first commit here, authorship preserved.

### Root cause

The namespace used to resolve short docblock type names comes from the class name (`ReflectionClass::getNamespaceName()` / `inNamespace()`). For an anonymous class that name is synthetic. It carries no namespace at all, or the namespace of the extended/implemented type. It does not reliably carry the lexical namespace of the file the class was written in.

This breaks both resolution layers. The `use` statements table comes back empty, because `TokenParser::parseUseStatements()` never matches the file's namespace block, so imported symbols fail. And the same-namespace fallback is never entered; for parent-prefixed synthetic names, resolution is attempted against the parent type's namespace instead.

A partial-fix experiment separates the two: with only the second layer fixed, the original tests of this PR turn green while a test using an imported symbol stays red. Each layer therefore has its own regression test in this PR.

### The fix

For anonymous classes, the lexical namespace is recovered from the tokenized source, behind an `isAnonymous()` check. Closures already worked this way, and they are anonymous in the same sense, so both now share one code path. Named classes and named functions keep byte-identical behaviour. That includes named `eval()`'d classes: no source is available for them, but their name still carries the namespace, and a dedicated test pins that. `PhpParser::parseNamespace()` now accepts classes and memoizes per file/line, mirroring `parseUseStatements()`.

### BC note

For anonymous classes extending or implementing a namespaced type, short-name resolution was previously attempted against the parent type's namespace, and could only succeed where a class of the same name exists there. It now resolves against the declaring file's namespace, which is how PHP itself resolves type hints at the declaration site.

### Pre-existing issues noticed while testing (out of scope)

- An `eval()`'d anonymous class cannot be mapped by its class name at all; its synthetic name does not survive the type-signature parser (`InvalidMappingTypeSignature`).
- Compiling the definition of an `eval()`'d closure with an unresolvable docblock type does not round-trip through the filesystem cache (`CorruptedCompiledPhpCacheFile`). Whether the trigger is the missing source or the unresolvable type was not isolated.

### Validation

- Full suite green on PHP 8.2, 8.3, 8.4 and 8.5 (2708 tests); mutation tests at 100% MSI on the changed lines.
- The new regression tests fail on `master` without the `src/` changes; the FQCN control passes.
- An escaped mutant in the first CI round exposed a missing guard: nothing pinned that named `eval()`'d classes must keep resolving through their name. `test_named_class_declared_without_source_file_can_use_type_from_its_own_namespace` covers that now.
- PHPStan, Psalm and PHP-CS-Fixer are clean.
