### PR TITLE
fix: resolve members declared in parent interfaces

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -10,6 +10,14 @@ $finder = PhpCsFixer\Finder::create()->in([
     ->notPath('Fixtures/FunctionWithSeveralImportStatementsInSameUseStatement.php')
     ->notPath('Fixtures/TwoClassesInDifferentNamespaces.php');
 
+if (PHP_VERSION_ID < 8_04_00) {
+    $finder = $finder->notPath('Fixture/Object/InterfaceWithPropertyHooks/BaseInterface.php')
+        ->notPath('Fixture/Object/InterfaceWithPropertyHooks/ChildInterface.php')
+        ->notPath('Fixture/Object/InterfaceWithPropertyHooks/GenericBaseInterface.php')
+        ->notPath('Fixture/Object/InterfaceWithPropertyHooks/GrandChildInterface.php')
+        ->notPath('Fixture/Object/InterfaceWithPropertyHooks/OtherBaseInterface.php');
+}
+
 if (PHP_VERSION_ID < 8_05_00) {
     $finder = $finder->notPath('Integration/Normalizer/TemporaryPHP85/ClassWithPropertyTransformerWithCallable.php');
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,6 +16,12 @@ parameters:
     excludePaths:
         - tests/StaticAnalysis
         - tests/Integration/Normalizer/ExpectedCache/
+        # PHP8.4 remove
+        - tests/Fixture/Object/InterfaceWithPropertyHooks/BaseInterface.php
+        - tests/Fixture/Object/InterfaceWithPropertyHooks/ChildInterface.php
+        - tests/Fixture/Object/InterfaceWithPropertyHooks/GenericBaseInterface.php
+        - tests/Fixture/Object/InterfaceWithPropertyHooks/GrandChildInterface.php
+        - tests/Fixture/Object/InterfaceWithPropertyHooks/OtherBaseInterface.php
     resultCachePath: var/cache/phpstan/phpstan-resultCache.php
     ignoreErrors:
         # \PHPStan\Rules\BooleansInConditions

--- a/src/Definition/Repository/Reflection/ReflectionClassDefinitionRepository.php
+++ b/src/Definition/Repository/Reflection/ReflectionClassDefinitionRepository.php
@@ -34,6 +34,7 @@ use function array_count_values;
 use function array_filter;
 use function array_keys;
 use function array_map;
+use function assert;
 
 /** @internal */
 final class ReflectionClassDefinitionRepository implements ClassDefinitionRepository
@@ -144,7 +145,10 @@ final class ReflectionClassDefinitionRepository implements ClassDefinitionReposi
             if ($declaringClass->name === $type->className()) {
                 $properties[$property->name] = $this->propertyBuilder->for($property, $typeResolver);
             } else {
-                $parentClass = $this->parentTypeResolver->resolveParentTypeFor($type);
+                assert($type instanceof NativeClassType || $type instanceof InterfaceType);
+
+                $parentClass = $this->parentTypeResolver->resolveParentTypeFor($type, $property);
+
                 // @infection-ignore-all Just some memoization
                 $parentClasses[$parentClass->toString()] ??= $this->for($parentClass);
 
@@ -198,7 +202,9 @@ final class ReflectionClassDefinitionRepository implements ClassDefinitionReposi
                 continue;
             }
 
-            $parentClass = $this->parentTypeResolver->resolveParentTypeFor($type);
+            assert($type instanceof NativeClassType || $type instanceof InterfaceType);
+
+            $parentClass = $this->parentTypeResolver->resolveParentTypeFor($type, $method);
 
             // @infection-ignore-all Just some memoization
             $parentClasses[$parentClass->toString()] ??= $this->for($parentClass);

--- a/src/Definition/Repository/Reflection/TypeResolver/ClassParentTypeResolver.php
+++ b/src/Definition/Repository/Reflection/TypeResolver/ClassParentTypeResolver.php
@@ -7,13 +7,17 @@ namespace CuyZ\Valinor\Definition\Repository\Reflection\TypeResolver;
 use CuyZ\Valinor\Type\ObjectType;
 use CuyZ\Valinor\Type\Parser\Factory\TypeParserFactory;
 use CuyZ\Valinor\Type\Parser\Lexer\TokenizedAnnotation;
+use CuyZ\Valinor\Type\Parser\TypeParser;
 use CuyZ\Valinor\Type\Parser\VacantTypeAssignerParser;
 use CuyZ\Valinor\Type\Types\GenericType;
+use CuyZ\Valinor\Type\Types\InterfaceType;
 use CuyZ\Valinor\Type\Types\NativeClassType;
 use CuyZ\Valinor\Type\Types\UnresolvableType;
 use CuyZ\Valinor\Utility\Reflection\Annotations;
 use CuyZ\Valinor\Utility\Reflection\Reflection;
 use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
 
 use function array_map;
 use function array_values;
@@ -33,10 +37,16 @@ final class ClassParentTypeResolver
         $this->templateResolver = new TemplateResolver();
     }
 
-    public function resolveParentTypeFor(ObjectType $child): NativeClassType
+    public function resolveParentTypeFor(NativeClassType|InterfaceType $child, ReflectionProperty|ReflectionMethod $member): ObjectType
     {
-        assert($child instanceof NativeClassType);
+        return match ($child::class) {
+            NativeClassType::class => $this->resolveParentTypeForClass($child),
+            InterfaceType::class => $this->resolveParentTypeForInterface($child, $member),
+        };
+    }
 
+    private function resolveParentTypeForClass(NativeClassType $child): NativeClassType
+    {
         $reflection = Reflection::class($child->className());
 
         /** @var ReflectionClass<covariant object> $parentReflection */
@@ -52,10 +62,7 @@ final class ClassParentTypeResolver
             $extendedClass = $extendedClass[0];
         }
 
-        $generics = $this->genericResolver->resolveGenerics($child);
-
-        $typeParser = $this->typeParserFactory->buildAdvancedTypeParserForClass($child->className());
-        $typeParser = new VacantTypeAssignerParser($typeParser, $generics);
+        $typeParser = $this->buildTypeParserFor($child);
 
         $parentType = $typeParser->parse($extendedClass);
 
@@ -68,6 +75,98 @@ final class ClassParentTypeResolver
         }
 
         return $parentType;
+    }
+
+    /**
+     * The member may be declared in any of the interfaces that the given
+     * reflection extends or implements, possibly deeply nested, so the direct
+     * parent interface that provides it needs to be found first.
+     */
+    private function resolveParentTypeForInterface(InterfaceType $child, ReflectionProperty|ReflectionMethod $member): InterfaceType
+    {
+        $reflection = Reflection::class($child->className());
+        $parent = $this->findDeclaringInterface($reflection, $member);
+
+        $extendedInterfaces = $this->extractParentTypeFromDocBlock($reflection);
+
+        $typeParser = $this->buildTypeParserFor($child);
+
+        $parentType = null;
+        $unresolvableType = null;
+
+        foreach ($extendedInterfaces as $extendedInterface) {
+            $parsed = $typeParser->parse($extendedInterface);
+
+            if ($parsed instanceof UnresolvableType) {
+                $unresolvableType = $parsed;
+            } elseif ($parsed instanceof InterfaceType && $parsed->className() === $parent->name) {
+                if ($parentType !== null) {
+                    return $this->fillParentInterfaceGenericsWithUnresolvableTypes($parent, UnresolvableType::forSeveralExtendTagsFound($reflection->name));
+                }
+
+                $parentType = $parsed;
+            }
+        }
+
+        if ($parentType !== null) {
+            return $parentType;
+        }
+
+        if ($unresolvableType !== null) {
+            return $this->fillParentInterfaceGenericsWithUnresolvableTypes($parent, $unresolvableType->forExtendTagTypeError($reflection->name));
+        }
+
+        $parentType = $typeParser->parse($parent->name);
+
+        if ($parentType instanceof UnresolvableType) {
+            return $this->fillParentInterfaceGenericsWithUnresolvableTypes($parent, $parentType->forExtendTagTypeError($reflection->name));
+        }
+
+        assert($parentType instanceof InterfaceType);
+
+        return $parentType;
+    }
+
+    /**
+     * Among the interfaces directly extended by the given reflection, finds the
+     * most-derived one that declares the member. Interfaces extended by another
+     * interface in the same set are skipped so only the direct parent remains.
+     * Falls back to the member's own declaring class when none matches.
+     *
+     * @param ReflectionClass<covariant object> $reflection
+     * @return ReflectionClass<covariant object>
+     */
+    private function findDeclaringInterface(ReflectionClass $reflection, ReflectionProperty|ReflectionMethod $member): ReflectionClass
+    {
+        $interfaces = $reflection->getInterfaces();
+        $parent = $member->getDeclaringClass();
+
+        foreach ($interfaces as $interface) {
+            foreach ($interfaces as $other) {
+                if ($other->name !== $interface->name && $other->implementsInterface($interface->name)) {
+                    continue 2;
+                }
+            }
+
+            $hasMember = $member instanceof ReflectionProperty
+                ? $interface->hasProperty($member->name)
+                : $interface->hasMethod($member->name);
+
+            if ($hasMember) {
+                $parent = $interface;
+            }
+        }
+
+        return $parent;
+    }
+
+    private function buildTypeParserFor(NativeClassType|InterfaceType $child): TypeParser
+    {
+        $generics = $this->genericResolver->resolveGenerics($child);
+
+        $typeParser = $this->typeParserFactory->buildAdvancedTypeParserForClass($child->className());
+
+        return new VacantTypeAssignerParser($typeParser, $generics);
     }
 
     /**
@@ -89,14 +188,30 @@ final class ClassParentTypeResolver
      */
     private function fillParentGenericsWithUnresolvableTypes(ReflectionClass $class, UnresolvableType $unresolvableType): NativeClassType
     {
+        return new NativeClassType($class->name, $this->unresolvableGenericsFor($class, $unresolvableType));
+    }
+
+    /**
+     * @param ReflectionClass<covariant object> $interface
+     */
+    private function fillParentInterfaceGenericsWithUnresolvableTypes(ReflectionClass $interface, UnresolvableType $unresolvableType): InterfaceType
+    {
+        return new InterfaceType($interface->name, $this->unresolvableGenericsFor($interface, $unresolvableType));
+    }
+
+    /**
+     * @param ReflectionClass<covariant object> $class
+     * @return list<UnresolvableType>
+     */
+    private function unresolvableGenericsFor(ReflectionClass $class, UnresolvableType $unresolvableType): array
+    {
         $typeParser = $this->typeParserFactory->buildAdvancedTypeParserForClass($class->name);
 
         $templates = $this->templateResolver->templatesFromDocBlock($class, $class->name, $typeParser);
-        $generics = array_values(array_map(
+
+        return array_values(array_map(
             static fn (GenericType $type) => new UnresolvableType($type->symbol, $unresolvableType->message()),
             $templates,
         ));
-
-        return new NativeClassType($class->name, $generics);
     }
 }

--- a/tests/Fixture/Object/InterfaceWithPropertyHooks/BaseInterface.php
+++ b/tests/Fixture/Object/InterfaceWithPropertyHooks/BaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks;
+
+interface BaseInterface
+{
+    public string|null $deleted { get; }
+}

--- a/tests/Fixture/Object/InterfaceWithPropertyHooks/ChildInterface.php
+++ b/tests/Fixture/Object/InterfaceWithPropertyHooks/ChildInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks;
+
+interface ChildInterface extends BaseInterface
+{
+    public string $name { get; }
+}

--- a/tests/Fixture/Object/InterfaceWithPropertyHooks/ChildInterfaceImplementation.php
+++ b/tests/Fixture/Object/InterfaceWithPropertyHooks/ChildInterfaceImplementation.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks;
+
+final class ChildInterfaceImplementation implements ChildInterface
+{
+    public string $name;
+
+    public string|null $deleted = null;
+}

--- a/tests/Fixture/Object/InterfaceWithPropertyHooks/ChildInterfaceWithGenericParent.php
+++ b/tests/Fixture/Object/InterfaceWithPropertyHooks/ChildInterfaceWithGenericParent.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks;
+
+/**
+ * @extends GenericBaseInterface<string>
+ */
+interface ChildInterfaceWithGenericParent extends GenericBaseInterface {}

--- a/tests/Fixture/Object/InterfaceWithPropertyHooks/ChildInterfaceWithGenericParentAndNoExtendTag.php
+++ b/tests/Fixture/Object/InterfaceWithPropertyHooks/ChildInterfaceWithGenericParentAndNoExtendTag.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks;
+
+// The missing `@extends` tag on a generic parent is the very case under test.
+// @phpstan-ignore missingType.generics
+interface ChildInterfaceWithGenericParentAndNoExtendTag extends GenericBaseInterface {}

--- a/tests/Fixture/Object/InterfaceWithPropertyHooks/ChildInterfaceWithSeveralParents.php
+++ b/tests/Fixture/Object/InterfaceWithPropertyHooks/ChildInterfaceWithSeveralParents.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks;
+
+interface ChildInterfaceWithSeveralParents extends BaseInterface, OtherBaseInterface {}

--- a/tests/Fixture/Object/InterfaceWithPropertyHooks/ChildInterfaceWithSeveralParentsImplementation.php
+++ b/tests/Fixture/Object/InterfaceWithPropertyHooks/ChildInterfaceWithSeveralParentsImplementation.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks;
+
+final class ChildInterfaceWithSeveralParentsImplementation implements ChildInterfaceWithSeveralParents
+{
+    public string|null $deleted = null;
+
+    public int $count;
+}

--- a/tests/Fixture/Object/InterfaceWithPropertyHooks/GenericBaseInterface.php
+++ b/tests/Fixture/Object/InterfaceWithPropertyHooks/GenericBaseInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks;
+
+/**
+ * @template T
+ */
+interface GenericBaseInterface
+{
+    /** @var T */
+    public mixed $genericValue { get; }
+}

--- a/tests/Fixture/Object/InterfaceWithPropertyHooks/GrandChildInterface.php
+++ b/tests/Fixture/Object/InterfaceWithPropertyHooks/GrandChildInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks;
+
+interface GrandChildInterface extends ChildInterface
+{
+    public bool $active { get; }
+}

--- a/tests/Fixture/Object/InterfaceWithPropertyHooks/GrandChildInterfaceImplementation.php
+++ b/tests/Fixture/Object/InterfaceWithPropertyHooks/GrandChildInterfaceImplementation.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks;
+
+final class GrandChildInterfaceImplementation implements GrandChildInterface
+{
+    public string $name;
+
+    public string|null $deleted = null;
+
+    public bool $active;
+}

--- a/tests/Fixture/Object/InterfaceWithPropertyHooks/OtherBaseInterface.php
+++ b/tests/Fixture/Object/InterfaceWithPropertyHooks/OtherBaseInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks;
+
+interface OtherBaseInterface
+{
+    public int $count { get; }
+}

--- a/tests/Integration/Mapping/InterfaceInferringMappingTest.php
+++ b/tests/Integration/Mapping/InterfaceInferringMappingTest.php
@@ -424,6 +424,21 @@ final class InterfaceInferringMappingTest extends IntegrationTestCase
             ]);
         }
     }
+
+    public function test_infer_interface_with_constructor_declared_in_parent_interface_works_properly(): void
+    {
+        try {
+            $result = $this->mapperBuilder()
+                ->infer(SomeInterfaceWithParentConstructor::class, fn () => SomeClassWithConstructorComingFromParentInterface::class)
+                ->mapper()
+                ->map(SomeInterfaceWithParentConstructor::class, ['valueA' => 'foo']);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertInstanceOf(SomeClassWithConstructorComingFromParentInterface::class, $result);
+        self::assertSame('foo', $result->valueA);
+    }
 }
 
 interface SomeInterface {}
@@ -439,3 +454,15 @@ final class SomeClassThatInheritsInterfaceB implements SomeInterface
 }
 
 final class SomeClassThatInheritsInterfaceC implements SomeInterface {}
+
+interface SomeInterfaceWithConstructor
+{
+    public function __construct(string $valueA);
+}
+
+interface SomeInterfaceWithParentConstructor extends SomeInterfaceWithConstructor {}
+
+final class SomeClassWithConstructorComingFromParentInterface implements SomeInterfaceWithParentConstructor
+{
+    public function __construct(public string $valueA) {}
+}

--- a/tests/Integration/Mapping/InterfaceWithPropertyHooksInferringMappingTest.php
+++ b/tests/Integration/Mapping/InterfaceWithPropertyHooksInferringMappingTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Mapping;
+
+use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\Mapper\Source\Source;
+use CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks\ChildInterface;
+use CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks\ChildInterfaceImplementation;
+use CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks\ChildInterfaceWithSeveralParents;
+use CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks\ChildInterfaceWithSeveralParentsImplementation;
+use CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks\GrandChildInterface;
+use CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks\GrandChildInterfaceImplementation;
+use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+
+// PHP8.4 move to InterfaceInferringMappingTest
+#[RequiresPhp('>=8.4')]
+final class InterfaceWithPropertyHooksInferringMappingTest extends IntegrationTestCase
+{
+    public function test_infer_interface_extending_interface_with_property_hooks_works_properly(): void
+    {
+        try {
+            $result = $this->mapperBuilder()
+                ->infer(ChildInterface::class, fn () => ChildInterfaceImplementation::class)
+                ->mapper()
+                ->map(ChildInterface::class, Source::array([
+                    'name' => 'foo',
+                    'deleted' => null,
+                ]));
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertInstanceOf(ChildInterfaceImplementation::class, $result);
+        self::assertSame('foo', $result->name);
+        self::assertNull($result->deleted);
+    }
+
+    public function test_infer_interface_extending_several_interfaces_with_property_hooks_works_properly(): void
+    {
+        try {
+            $result = $this->mapperBuilder()
+                ->infer(ChildInterfaceWithSeveralParents::class, fn () => ChildInterfaceWithSeveralParentsImplementation::class)
+                ->mapper()
+                ->map(ChildInterfaceWithSeveralParents::class, Source::array([
+                    'deleted' => 'foo',
+                    'count' => 42,
+                ]));
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertInstanceOf(ChildInterfaceWithSeveralParentsImplementation::class, $result);
+        self::assertSame('foo', $result->deleted);
+        self::assertSame(42, $result->count);
+    }
+
+    public function test_infer_interface_extending_chain_of_interfaces_with_property_hooks_works_properly(): void
+    {
+        try {
+            $result = $this->mapperBuilder()
+                ->infer(GrandChildInterface::class, fn () => GrandChildInterfaceImplementation::class)
+                ->mapper()
+                ->map(GrandChildInterface::class, Source::array([
+                    'name' => 'foo',
+                    'deleted' => 'bar',
+                    'active' => true,
+                ]));
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertInstanceOf(GrandChildInterfaceImplementation::class, $result);
+        self::assertSame('foo', $result->name);
+        self::assertSame('bar', $result->deleted);
+        self::assertTrue($result->active);
+    }
+
+    public function test_invalid_value_for_property_declared_in_parent_interface_throws_exception(): void
+    {
+        try {
+            $this->mapperBuilder()
+                ->infer(ChildInterface::class, fn () => ChildInterfaceImplementation::class)
+                ->mapper()
+                ->map(ChildInterface::class, Source::array([
+                    'name' => 'foo',
+                    'deleted' => 1337,
+                ]));
+
+            self::fail('No mapping error when one was expected');
+        } catch (MappingError $exception) {
+            self::assertMappingErrors($exception, [
+                'deleted' => "[cannot_resolve_type_from_union] Value 1337 does not match any of `string`, `null`.",
+            ]);
+        }
+    }
+}

--- a/tests/Unit/Definition/Repository/Reflection/ReflectionClassDefinitionRepositoryTest.php
+++ b/tests/Unit/Definition/Repository/Reflection/ReflectionClassDefinitionRepositoryTest.php
@@ -9,6 +9,8 @@ use CuyZ\Valinor\Definition\Repository\ClassDefinitionRepository;
 use CuyZ\Valinor\Mapper\Object\Constructor;
 use CuyZ\Valinor\Tests\Fake\Type\FakeType;
 use CuyZ\Valinor\Tests\Fixture\Object\AbstractObjectWithInterface;
+use CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks\ChildInterfaceWithGenericParent;
+use CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks\ChildInterfaceWithSeveralParents;
 use CuyZ\Valinor\Tests\Unit\UnitTestCase;
 use CuyZ\Valinor\Type\ObjectType;
 use CuyZ\Valinor\Type\StringType;
@@ -19,9 +21,11 @@ use CuyZ\Valinor\Type\Types\MixedType;
 use CuyZ\Valinor\Type\Types\NativeBooleanType;
 use CuyZ\Valinor\Type\Types\NativeClassType;
 use CuyZ\Valinor\Type\Types\NativeFloatType;
+use CuyZ\Valinor\Type\Types\NativeStringType;
 use CuyZ\Valinor\Type\Types\NonEmptyStringType;
 use CuyZ\Valinor\Type\Types\UnresolvableType;
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use stdClass;
 
 final class ReflectionClassDefinitionRepositoryTest extends UnitTestCase
@@ -445,6 +449,69 @@ final class ReflectionClassDefinitionRepositoryTest extends UnitTestCase
         self::assertMatchesRegularExpression('/The type `class-string<T>` for property `.*` could not be resolved: invalid class string `class-string<float>`, each element must be a class name or an interface name but found `float`./', $type->message());
     }
 
+    public function test_method_declared_in_parent_interface_can_be_retrieved(): void
+    {
+        $type = new InterfaceType(SomeGrandChildInterfaceWithParentMethod::class);
+        $methods = $this->getClass($type)->methods;
+
+        self::assertInstanceOf(StringType::class, $methods->get('map')->returnType);
+    }
+
+    public function test_constructor_declared_in_parent_interface_is_listed_in_methods(): void
+    {
+        $type = new InterfaceType(SomeChildInterfaceWithParentConstructor::class);
+        $methods = $this->getClass($type)->methods;
+
+        self::assertTrue($methods->hasConstructor());
+        self::assertInstanceOf(NativeBooleanType::class, $methods->constructor()->parameters->get('value')->type);
+    }
+
+    public function test_generics_are_assigned_for_parent_interfaces(): void
+    {
+        $type = new InterfaceType(SomeInterfaceWithSeveralGenericParents::class);
+        $methods = $this->getClass($type)->methods;
+
+        self::assertInstanceOf(NonEmptyStringType::class, $methods->get('map')->returnType);
+        self::assertInstanceOf(NativeFloatType::class, $methods->get('normalize')->returnType);
+    }
+
+    public function test_several_extend_tags_for_same_parent_interface_are_marked_as_unresolvable(): void
+    {
+        $type = new InterfaceType(SomeInterfaceWithSeveralExtendTagsForSameParentInterface::class);
+        $returnType = $this->getClass($type)->methods->get('map')->returnType;
+
+        self::assertInstanceOf(UnresolvableType::class, $returnType);
+        self::assertMatchesRegularExpression('/The return type `T` of method `.*` could not be resolved: only one `@extends` tag should be set for the class `.*`./', $returnType->message());
+    }
+
+    public function test_invalid_extend_tag_for_parent_interface_is_marked_as_unresolvable(): void
+    {
+        $type = new InterfaceType(SomeInterfaceWithInvalidExtendTag::class);
+        $returnType = $this->getClass($type)->methods->get('map')->returnType;
+
+        self::assertInstanceOf(UnresolvableType::class, $returnType);
+        self::assertMatchesRegularExpression('/The return type `T` of method `.*` could not be resolved: the `@extends` tag of the class `.*` is not valid: cannot parse unknown symbol `SomeUnknownParentInterface`./', $returnType->message());
+    }
+
+    #[RequiresPhp('>=8.4')]
+    public function test_properties_declared_in_parent_interfaces_can_be_retrieved(): void
+    {
+        $type = new InterfaceType(ChildInterfaceWithSeveralParents::class);
+        $properties = $this->getClass($type)->properties;
+
+        self::assertSame('string|null', $properties->get('deleted')->type->toString());
+        self::assertSame('int', $properties->get('count')->type->toString());
+    }
+
+    #[RequiresPhp('>=8.4')]
+    public function test_generics_are_assigned_for_property_declared_in_parent_interface(): void
+    {
+        $type = new InterfaceType(ChildInterfaceWithGenericParent::class);
+        $properties = $this->getClass($type)->properties;
+
+        self::assertInstanceOf(NativeStringType::class, $properties->get('genericValue')->type);
+    }
+
     private function getClass(ObjectType $type): ClassDefinition
     {
         return $this->getService(ClassDefinitionRepository::class)->for($type);
@@ -487,3 +554,60 @@ final class SomeClassImportingAliasWithGeneric
     /** @var ArrayOfGenericAlias */ // @phpstan-ignore class.notFound
     public $propertyWithGenericAlias;
 }
+
+interface SomeParentInterfaceWithMethod
+{
+    public function map(): string;
+}
+
+interface SomeChildInterfaceWithParentMethod extends SomeParentInterfaceWithMethod {}
+
+interface SomeGrandChildInterfaceWithParentMethod extends SomeChildInterfaceWithParentMethod {}
+
+interface SomeParentInterfaceWithConstructor
+{
+    public function __construct(bool $value);
+}
+
+interface SomeChildInterfaceWithParentConstructor extends SomeParentInterfaceWithConstructor {}
+
+/**
+ * @template T
+ */
+interface SomeGenericParentInterfaceWithMapMethod
+{
+    /**
+     * @return T
+     */
+    public function map();
+}
+
+/**
+ * @template T
+ */
+interface SomeGenericParentInterfaceWithNormalizeMethod
+{
+    /**
+     * @return T
+     */
+    public function normalize();
+}
+
+/**
+ * @extends SomeGenericParentInterfaceWithMapMethod<non-empty-string>
+ * @extends SomeGenericParentInterfaceWithNormalizeMethod<float>
+ */
+interface SomeInterfaceWithSeveralGenericParents extends SomeGenericParentInterfaceWithMapMethod, SomeGenericParentInterfaceWithNormalizeMethod {}
+
+/**
+ * @extends SomeGenericParentInterfaceWithMapMethod<non-empty-string>
+ * @extends SomeGenericParentInterfaceWithMapMethod<float>
+ */
+interface SomeInterfaceWithSeveralExtendTagsForSameParentInterface extends SomeGenericParentInterfaceWithMapMethod {}
+
+/**
+ * @extends SomeUnknownParentInterface<float>
+ *
+ * @phpstan-ignore missingType.generics, generics.wrongParent (This tag is intentionally invalid)
+ */
+interface SomeInterfaceWithInvalidExtendTag extends SomeGenericParentInterfaceWithMapMethod {}

--- a/tests/Unit/Definition/Repository/Reflection/TypeResolver/ClassParentTypeResolverTest.php
+++ b/tests/Unit/Definition/Repository/Reflection/TypeResolver/ClassParentTypeResolverTest.php
@@ -5,11 +5,20 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Unit\Definition\Repository\Reflection\TypeResolver;
 
 use CuyZ\Valinor\Definition\Repository\Reflection\TypeResolver\ClassParentTypeResolver;
+use CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks\ChildInterface;
+use CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks\ChildInterfaceWithGenericParent;
+use CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks\ChildInterfaceWithGenericParentAndNoExtendTag;
+use CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks\ChildInterfaceWithSeveralParents;
+use CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks\GrandChildInterface;
 use CuyZ\Valinor\Tests\Unit\UnitTestCase;
 use CuyZ\Valinor\Type\Parser\Factory\TypeParserFactory;
+use CuyZ\Valinor\Type\Types\InterfaceType;
 use CuyZ\Valinor\Type\Types\NativeClassType;
 use CuyZ\Valinor\Type\Types\UnresolvableType;
+use CuyZ\Valinor\Utility\Reflection\Reflection;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use ReflectionProperty;
 use stdClass;
 
 final class ClassParentTypeResolverTest extends UnitTestCase
@@ -20,7 +29,10 @@ final class ClassParentTypeResolverTest extends UnitTestCase
     #[DataProvider('class_parent_is_resolved_properly_data_provider')]
     public function test_class_parent_is_resolved_properly(string $className, string $expectedParent): void
     {
-        $parent = $this->classParentTypeResolver()->resolveParentTypeFor(new NativeClassType($className));
+        $parent = $this->classParentTypeResolver()->resolveParentTypeFor(
+            new NativeClassType($className),
+            new ReflectionProperty($className, 'inheritedProperty'),
+        );
 
         self::assertSame($expectedParent, $parent->toString());
     }
@@ -33,6 +45,76 @@ final class ClassParentTypeResolverTest extends UnitTestCase
         ];
     }
 
+    /**
+     * @param class-string $className
+     */
+    #[RequiresPhp('>=8.4')]
+    #[DataProvider('interface_parent_is_resolved_properly_data_provider')]
+    public function test_interface_parent_is_resolved_properly(string $className, string $memberName, string $expectedParent): void
+    {
+        $member = Reflection::class($className)->getProperty($memberName);
+
+        $parent = $this->classParentTypeResolver()->resolveParentTypeFor(new InterfaceType($className), $member);
+
+        self::assertSame($expectedParent, $parent->toString());
+    }
+
+    public static function interface_parent_is_resolved_properly_data_provider(): iterable
+    {
+        yield 'member from grandparent is resolved to the direct parent interface' => [
+            'className' => GrandChildInterface::class,
+            'memberName' => 'deleted',
+            'expectedParent' => ChildInterface::class,
+        ];
+
+        yield 'member declared in the direct parent interface' => [
+            'className' => GrandChildInterface::class,
+            'memberName' => 'name',
+            'expectedParent' => ChildInterface::class,
+        ];
+
+        yield 'member declared in the interface itself falls back to that interface' => [
+            'className' => GrandChildInterface::class,
+            'memberName' => 'active',
+            'expectedParent' => GrandChildInterface::class,
+        ];
+
+        yield 'member from the first of several parent interfaces' => [
+            'className' => ChildInterfaceWithSeveralParents::class,
+            'memberName' => 'deleted',
+            'expectedParent' => \CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks\BaseInterface::class,
+        ];
+
+        yield 'member from the second of several parent interfaces' => [
+            'className' => ChildInterfaceWithSeveralParents::class,
+            'memberName' => 'count',
+            'expectedParent' => \CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks\OtherBaseInterface::class,
+        ];
+
+        yield 'generic parent interface is resolved with its generics from the extends tag' => [
+            'className' => ChildInterfaceWithGenericParent::class,
+            'memberName' => 'genericValue',
+            'expectedParent' => 'CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks\GenericBaseInterface<string>',
+        ];
+    }
+
+    #[RequiresPhp('>=8.4')]
+    public function test_generic_parent_interface_without_extends_tag_sets_unresolvable_type_in_generic(): void
+    {
+        $className = ChildInterfaceWithGenericParentAndNoExtendTag::class;
+
+        $member = Reflection::class($className)->getProperty('genericValue');
+
+        $parent = $this->classParentTypeResolver()->resolveParentTypeFor(new InterfaceType($className), $member);
+
+        self::assertInstanceOf(InterfaceType::class, $parent);
+        self::assertInstanceOf(UnresolvableType::class, $parent->generics()[0]);
+        self::assertSame(
+            "The `@extends` tag of the class `$className` is not valid: there are 1 missing generics for `" . 'CuyZ\Valinor\Tests\Fixture\Object\InterfaceWithPropertyHooks\GenericBaseInterface<?>`.',
+            $parent->generics()[0]->message(),
+        );
+    }
+
     public function test_several_extends_tags_sets_unresolvable_type_in_generic(): void
     {
         $class =
@@ -42,8 +124,12 @@ final class ClassParentTypeResolverTest extends UnitTestCase
              */
             (new class () extends SomeAbstractClassDefiningTwoTemplates {})::class;
 
-        $parent = $this->classParentTypeResolver()->resolveParentTypeFor(new NativeClassType($class));
+        $parent = $this->classParentTypeResolver()->resolveParentTypeFor(
+            new NativeClassType($class),
+            new ReflectionProperty($class, 'inheritedProperty'),
+        );
 
+        self::assertInstanceOf(NativeClassType::class, $parent);
         self::assertInstanceOf(UnresolvableType::class, $parent->generics()[0]);
         self::assertSame("Only one `@extends` tag should be set for the class `$class`.", $parent->generics()[0]->message());
     }
@@ -56,8 +142,12 @@ final class ClassParentTypeResolverTest extends UnitTestCase
              */
             (new class () extends SomeAbstractClassDefiningTwoTemplates {})::class;
 
-        $parent = $this->classParentTypeResolver()->resolveParentTypeFor(new NativeClassType($class));
+        $parent = $this->classParentTypeResolver()->resolveParentTypeFor(
+            new NativeClassType($class),
+            new ReflectionProperty($class, 'inheritedProperty'),
+        );
 
+        self::assertInstanceOf(NativeClassType::class, $parent);
         self::assertInstanceOf(UnresolvableType::class, $parent->generics()[0]);
         self::assertSame("The `@extends` tag of the class `$class` is not valid: the closing bracket is missing for the generic `" . SomeAbstractClassDefiningTwoTemplates::class . "<array<string>>`.", $parent->generics()[0]->message());
     }
@@ -70,8 +160,12 @@ final class ClassParentTypeResolverTest extends UnitTestCase
              */
             (new class () extends SomeAbstractClassDefiningTwoTemplates {})::class;
 
-        $parent = $this->classParentTypeResolver()->resolveParentTypeFor(new NativeClassType($class));
+        $parent = $this->classParentTypeResolver()->resolveParentTypeFor(
+            new NativeClassType($class),
+            new ReflectionProperty($class, 'inheritedProperty'),
+        );
 
+        self::assertInstanceOf(NativeClassType::class, $parent);
         self::assertInstanceOf(UnresolvableType::class, $parent->generics()[0]);
         self::assertSame("The `@extends` tag of the class `$class` has invalid type `string`, it should be `" . SomeAbstractClassDefiningTwoTemplates::class . '`.', $parent->generics()[0]->message());
     }
@@ -84,8 +178,12 @@ final class ClassParentTypeResolverTest extends UnitTestCase
              */
             (new class () extends SomeAbstractClassDefiningTwoTemplates {})::class;
 
-        $parent = $this->classParentTypeResolver()->resolveParentTypeFor(new NativeClassType($class));
+        $parent = $this->classParentTypeResolver()->resolveParentTypeFor(
+            new NativeClassType($class),
+            new ReflectionProperty($class, 'inheritedProperty'),
+        );
 
+        self::assertInstanceOf(NativeClassType::class, $parent);
         self::assertInstanceOf(UnresolvableType::class, $parent->generics()[0]);
         self::assertSame("The `@extends` tag of the class `$class` has invalid type `stdClass`, it should be `" . SomeAbstractClassDefiningTwoTemplates::class . "`.", $parent->generics()[0]->message());
     }
@@ -102,7 +200,10 @@ final class ClassParentTypeResolverTest extends UnitTestCase
  * @template TemplateA
  * @template TemplateB
  */
-abstract class SomeAbstractClassDefiningTwoTemplates {}
+abstract class SomeAbstractClassDefiningTwoTemplates
+{
+    public mixed $inheritedProperty = null;
+}
 
 /**
  * @extends SomeAbstractClassDefiningTwoTemplates<non-empty-string, int<42, 1337>>


### PR DESCRIPTION
Mapping to an interface crashed as soon as one of its members was declared in a parent interface, because the parent type resolver assumed single class inheritance: `ReflectionClass::getParentClass()` returns `false` for an interface, leading to an assertion error or a `TypeError` further down.

The resolver now handles interfaces separately, finding the direct parent interface that declares the member before resolving its type, including its generics when an `@extends` tag is present.

Fixes #822