### PR TITLE
feat: add `@valinor-*` annotations to override an unparseable type

### DIFF
--- a/docs/pages/usage/type-reference.md
+++ b/docs/pages/usage/type-reference.md
@@ -4,6 +4,30 @@ To prevent conflicts or duplication of the type annotations, this library tries
 to handle most of the type annotations that are accepted by [PHPStan] and
 [Psalm].
 
+!!! tip
+
+    When a property, parameter or return type uses a PHPStan or Psalm syntax
+    that the library cannot parse yet, for instance a conditional type like
+    `($a is 1 ? int : null)`, the dedicated `@valinor-var`, `@valinor-param` and
+    `@valinor-return` annotations can be used to give the library a type it
+    understands. They take precedence over every other annotation, so the static
+    analysis tools keep using their own type while the library uses the
+    override:
+    
+    ```php
+    final class SomeClass
+    {
+        /**
+         * @phpstan-param ($a is 1 ? int : null) $b
+         * @valinor-param int|null $b
+         */
+        public function __construct(
+            public readonly int $a,
+            public readonly ?int $b,
+        ) {}
+    }
+    ```
+
 ## Scalar
 
 ```php

--- a/src/Definition/Repository/Reflection/TypeResolver/ParameterTypeResolver.php
+++ b/src/Definition/Repository/Reflection/TypeResolver/ParameterTypeResolver.php
@@ -11,7 +11,7 @@ use CuyZ\Valinor\Type\Types\UnresolvableType;
 use CuyZ\Valinor\Utility\Reflection\Annotations;
 use ReflectionParameter;
 
-use function array_search;
+use function in_array;
 
 /** @internal */
 final class ParameterTypeResolver
@@ -58,18 +58,36 @@ final class ParameterTypeResolver
         $annotations = Annotations::forParameters($reflection->getDeclaringFunction());
 
         foreach ($annotations as $annotation) {
-            $tokens = $annotation->filtered();
-
-            $dollarSignKey = array_search('$', $tokens, true);
-
-            if ($dollarSignKey === false) {
-                continue;
-            }
-
-            $parameterName = $tokens[$dollarSignKey + 1] ?? null;
+            $parameterName = $this->parameterNameOf($annotation->filtered());
 
             if ($parameterName === $reflection->name) {
                 return $annotation->raw();
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Finds the parameter name declared by a `@param`-like annotation. The
+     * name is the first `$variable` token located outside of any bracket, so
+     * that variable references nested inside the type (for instance the `$a`
+     * in a conditional type `($a is 1 ? int : string) $b`) are not mistaken
+     * for the parameter name.
+     *
+     * @param array<int, non-empty-string> $tokens
+     */
+    private function parameterNameOf(array $tokens): ?string
+    {
+        $depth = 0;
+
+        foreach ($tokens as $key => $token) {
+            if (in_array($token, ['(', '<', '[', '{'], true)) {
+                $depth++;
+            } elseif (in_array($token, [')', '>', ']', '}'], true)) {
+                $depth--;
+            } elseif ($token === '$' && $depth === 0) {
+                return $tokens[$key + 1] ?? null;
             }
         }
 

--- a/src/Utility/Reflection/Annotations.php
+++ b/src/Utility/Reflection/Annotations.php
@@ -115,6 +115,7 @@ final class Annotations
     public static function forParameters(ReflectionFunctionAbstract $function): array
     {
         return (new self($function->getDocComment()))->filteredByPriority(
+            '@valinor-param',
             '@phpstan-param',
             '@psalm-param',
             '@param',
@@ -124,6 +125,7 @@ final class Annotations
     public static function forProperty(ReflectionProperty $function): ?string
     {
         return (new self($function->getDocComment()))->firstOf(
+            '@valinor-var',
             '@phpstan-var',
             '@psalm-var',
             '@var',
@@ -133,6 +135,7 @@ final class Annotations
     public static function forFunctionReturnType(ReflectionFunctionAbstract $function): ?string
     {
         return (new self($function->getDocComment()))->firstOf(
+            '@valinor-return',
             '@phpstan-return',
             '@psalm-return',
             '@return',

--- a/tests/Integration/Mapping/DocBlockTypeOverrideMappingTest.php
+++ b/tests/Integration/Mapping/DocBlockTypeOverrideMappingTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Integration\Mapping;
+
+use CuyZ\Valinor\Mapper\Exception\TypeErrorDuringMapping;
+use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
+
+final class DocBlockTypeOverrideMappingTest extends IntegrationTestCase
+{
+    public function test_valinor_param_overrides_unparseable_conditional_type(): void
+    {
+        $class = new class (0, null) {
+            /**
+             * @phpstan-param ($a is 1 ? int : null) $b
+             * @valinor-param int|null $b
+             */
+            public function __construct(
+                public readonly int $a,
+                public readonly ?int $b,
+            ) {}
+        };
+
+        try {
+            $result = $this->mapperBuilder()
+                ->mapper()
+                ->map($class::class, ['a' => 0, 'b' => null]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame(0, $result->a);
+        self::assertNull($result->b);
+    }
+
+    public function test_unparseable_conditional_type_without_override_throws_exception(): void
+    {
+        $class = (new class (0, null) {
+            /**
+             * @phpstan-param ($a is 1 ? int : null) $b
+             */
+            public function __construct(
+                public readonly int $a,
+                public readonly ?int $b,
+            ) {}
+        })::class;
+
+        $this->expectException(TypeErrorDuringMapping::class);
+        $this->expectExceptionMessage("Error while trying to map to `$class`: the type `(\$a is 1 ? int : null) \$b` for parameter `$class::__construct(\$b)` could not be resolved: unexpected token `a`, expected a valid type.");
+
+        $this->mapperBuilder()->mapper()->map($class, ['a' => 0, 'b' => null]);
+    }
+
+    public function test_valinor_var_overrides_unparseable_property_type(): void
+    {
+        $class = new class () {
+            /**
+             * @var ($foo is 1 ? int : string)
+             * @valinor-var non-empty-string
+             * @phpstan-ignore property.phpDocType
+             */
+            public string $value;
+        };
+
+        try {
+            $result = $this->mapperBuilder()
+                ->mapper()
+                ->map($class::class, ['value' => 'foo']);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame('foo', $result->value);
+    }
+}

--- a/tests/Unit/Definition/Repository/Reflection/TypeResolver/FunctionReturnTypeResolverTest.php
+++ b/tests/Unit/Definition/Repository/Reflection/TypeResolver/FunctionReturnTypeResolverTest.php
@@ -135,6 +135,26 @@ final class FunctionReturnTypeResolverTest extends UnitTestCase
             fn () => 42,
             'positive-int',
         ];
+
+        yield 'valinor has precedence over other tags' => [
+            /**
+             * @return int
+             * @psalm-return int
+             * @phpstan-return int
+             * @valinor-return positive-int
+             */
+            fn () => 42,
+            'positive-int',
+        ];
+
+        yield 'valinor overrides an unparseable return tag' => [
+            /**
+             * @phpstan-return ($foo is 1 ? int : string)
+             * @valinor-return positive-int
+             */
+            fn () => 42,
+            'positive-int',
+        ];
     }
 
     private function functionReturnTypeResolver(): FunctionReturnTypeResolver

--- a/tests/Unit/Definition/Repository/Reflection/TypeResolver/ParameterTypeResolverTest.php
+++ b/tests/Unit/Definition/Repository/Reflection/TypeResolver/ParameterTypeResolverTest.php
@@ -34,6 +34,15 @@ final class ParameterTypeResolverTest extends UnitTestCase
             'string',
         ];
 
+        yield 'phpdoc @param with generic type' => [
+            new ReflectionParameter(
+                /** @param array<positive-int> $list */
+                static function ($list): void {},
+                'list',
+            ),
+            'array<positive-int>',
+        ];
+
         yield 'phpdoc @param with comment' => [
             new ReflectionParameter(
                 /**
@@ -121,6 +130,56 @@ final class ParameterTypeResolverTest extends UnitTestCase
                 'value',
             ),
             'non-empty-string',
+        ];
+
+        yield 'valinor @param has precedence over other tags' => [
+            new ReflectionParameter(
+                /**
+                 * @param string $value
+                 * @psalm-param string $value
+                 * @phpstan-param string $value
+                 * @valinor-param non-empty-string $value
+                 */
+                static function ($value): void {},
+                'value',
+            ),
+            'non-empty-string',
+        ];
+
+        yield 'valinor @param overrides an unparseable @param' => [
+            new ReflectionParameter(
+                /**
+                 * @phpstan-param ($value is 1 ? int : string) $value
+                 * @valinor-param non-empty-string $value
+                 */
+                static function ($value): void {},
+                'value',
+            ),
+            'non-empty-string',
+        ];
+
+        yield 'valinor @param overrides an unparseable @param targeting another parameter' => [
+            new ReflectionParameter(
+                /**
+                 * @phpstan-param ($a is 1 ? int : string) $b
+                 * @valinor-param int|null $b
+                 */
+                static function ($a, $b): void {},
+                'b',
+            ),
+            'int|null',
+        ];
+
+        yield 'conditional type referencing another parameter is not mis-attributed' => [
+            new ReflectionParameter(
+                /**
+                 * @param int $a
+                 * @phpstan-param ($a is 1 ? int : string) $b
+                 */
+                static function ($a, $b): void {},
+                'a',
+            ),
+            'int',
         ];
 
         yield 'phpdoc several incomplete @param' => [

--- a/tests/Unit/Definition/Repository/Reflection/TypeResolver/PropertyTypeResolverTest.php
+++ b/tests/Unit/Definition/Repository/Reflection/TypeResolver/PropertyTypeResolverTest.php
@@ -125,6 +125,30 @@ final class PropertyTypeResolverTest extends UnitTestCase
             'non-empty-string',
         ];
 
+        yield 'valinor @var has precedence over other tags' => [
+            new ReflectionProperty(new class () {
+                /**
+                 * @var string
+                 * @psalm-var string
+                 * @phpstan-var string
+                 * @valinor-var non-empty-string
+                 */
+                public $foo;
+            }, 'foo'),
+            'non-empty-string',
+        ];
+
+        yield 'valinor @var overrides an unparseable @var' => [
+            new ReflectionProperty(new class () {
+                /**
+                 * @var ($foo is 1 ? int : string)
+                 * @valinor-var non-empty-string
+                 */
+                public $foo;
+            }, 'foo'),
+            'non-empty-string',
+        ];
+
         yield 'docBlock present but no @var annotation' => [
             new ReflectionProperty(new class () {
                 /**


### PR DESCRIPTION
PHPStan and Psalm accept type syntaxes that this library cannot parse, for instance a conditional type like `($a is 1 ? int : null)`. Such a type ends up unresolvable, and the only way out was to remove or weaken the annotation, making the static analysis tools lose information the library was not able to use anyway.

The annotations `@valinor-var`, `@valinor-param` and `@valinor-return` can now declare a type that only this library reads. They take precedence over their `@phpstan-*`, `@psalm-*` and native counterparts, so both worlds can be served by the same docblock:

```php
final class SomeClass
{
    /**
     * @phpstan-param ($a is 1 ? int : null) $b
     * @valinor-param int|null $b
     */
    public function __construct(
        public readonly int $a,
        public readonly ?int $b,
    ) {}
}
```

Finding the parameter name declared by a `@param`-like annotation now ignores the `$variable` tokens nested inside brackets, so a conditional type such as `($a is 1 ? int : string) $b` is bound to `$b` and not to the `$a` appearing inside the type.

Fixes #448