### PR TITLE
feat: add default value support for `@template` annotations

### DIFF
--- a/docs/pages/usage/type-reference.md
+++ b/docs/pages/usage/type-reference.md
@@ -114,6 +114,64 @@ final readonly class SomeCollection
 }
 ```
 
+## Generics
+
+A class can declare template types with the `@template` annotation; they are
+filled in with concrete types when the class is referenced. A template can be
+bound to a type with `of`, and can declare a default type with `=`.
+
+A template that declares a default type may be omitted when the class is
+referenced, in which case the default type is used. Templates that do not
+declare one must always be filled in.
+
+```php
+final readonly class SomeUser
+{
+    public function __construct(
+        public string $name,
+    ) {}
+}
+
+/**
+ * @template TValue
+ * @template TMeta of array<string, mixed> = array<string, string>
+ */
+final readonly class SomePage
+{
+    public function __construct(
+        /** @var list<TValue> */
+        public array $items,
+
+        /** @var TMeta */
+        public array $meta,
+    ) {}
+}
+
+final readonly class SomeClass
+{
+    public function __construct(
+        // `TMeta` is not filled in, its default type is used
+        /** @var SomePage<SomeUser> */
+        public SomePage $pageWithDefaultMeta,
+
+        // `TMeta` is filled in, overriding its default type
+        /** @var SomePage<SomeUser, array{cursor: int}> */
+        public SomePage $pageWithCursorMeta,
+    ) {}
+}
+```
+
+Templates declaring a default type must come last: a template without a default
+type cannot be declared after one that has a default type. A default type must
+also match the bound declared with `of`, when there is one.
+
+!!! note
+
+    A default type is what makes it possible to add a template to a class that
+    is already referenced elsewhere: the existing references, which do not fill
+    the new template in, keep resolving to its default type and can be made
+    more precise later on.
+
 ## Array & lists
 
 ```php

--- a/src/Definition/Repository/Reflection/ReflectionClassDefinitionRepository.php
+++ b/src/Definition/Repository/Reflection/ReflectionClassDefinitionRepository.php
@@ -19,6 +19,7 @@ use CuyZ\Valinor\Definition\Repository\Reflection\TypeResolver\ClassParentTypeRe
 use CuyZ\Valinor\Definition\Repository\Reflection\TypeResolver\ReflectionTypeResolver;
 use CuyZ\Valinor\Mapper\Object\Constructor;
 use CuyZ\Valinor\Type\ObjectType;
+use CuyZ\Valinor\Type\ObjectWithGenericType;
 use CuyZ\Valinor\Type\Parser\Factory\TypeParserFactory;
 use CuyZ\Valinor\Type\Parser\UnresolvableTypeFinderParser;
 use CuyZ\Valinor\Type\Parser\VacantTypeAssignerParser;
@@ -34,6 +35,7 @@ use function array_count_values;
 use function array_filter;
 use function array_keys;
 use function array_map;
+use function array_values;
 use function assert;
 
 /** @internal */
@@ -76,7 +78,15 @@ final class ReflectionClassDefinitionRepository implements ClassDefinitionReposi
     {
         $reflection = Reflection::class($type->className());
 
-        $vacantTypes = $this->vacantTypes($type);
+        $generics = [];
+
+        if ($type instanceof ObjectWithGenericType) {
+            $generics = $this->genericResolver->resolveGenerics($type);
+
+            $type = new $type($type->className(), array_values($generics));
+        }
+
+        $vacantTypes = $this->vacantTypes($type, $generics);
 
         $nativeTypeParser = $this->typeParserFactory->buildNativeTypeParserForClass($type->className());
 
@@ -98,16 +108,11 @@ final class ReflectionClassDefinitionRepository implements ClassDefinitionReposi
     }
 
     /**
+     * @param array<non-empty-string, Type> $generics
      * @return array<non-empty-string, Type>
      */
-    private function vacantTypes(ObjectType $type): array
+    private function vacantTypes(ObjectType $type, array $generics): array
     {
-        $generics = [];
-
-        if ($type instanceof NativeClassType || $type instanceof InterfaceType) {
-            $generics = $this->genericResolver->resolveGenerics($type);
-        }
-
         $localTypes = $this->localTypeAliasResolver->resolveLocalTypeAliases($type);
         $importedTypes = $this->importedTypeAliasResolver->resolveImportedTypeAliases($type);
 

--- a/src/Definition/Repository/Reflection/TypeResolver/ClassGenericResolver.php
+++ b/src/Definition/Repository/Reflection/TypeResolver/ClassGenericResolver.php
@@ -36,7 +36,13 @@ final class ClassGenericResolver
         $assignedGenerics = [];
 
         foreach ($templates as $template => $templateType) {
-            $generic = $generics === [] ? $templateType : array_shift($generics);
+            if ($generics !== []) {
+                $generic = array_shift($generics);
+            } elseif ($templateType->default !== null) {
+                $generic = $templateType->default;
+            } else {
+                $generic = $templateType;
+            }
 
             if ($templateType->innerType instanceof UnresolvableType) {
                 $generic = $templateType->innerType;

--- a/src/Definition/Repository/Reflection/TypeResolver/TemplateResolver.php
+++ b/src/Definition/Repository/Reflection/TypeResolver/TemplateResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Definition\Repository\Reflection\TypeResolver;
 
 use CuyZ\Valinor\Type\Parser\TypeParser;
+use CuyZ\Valinor\Type\Type;
 use CuyZ\Valinor\Type\Types\GenericType;
 use CuyZ\Valinor\Type\Types\MixedType;
 use CuyZ\Valinor\Type\Types\UnresolvableType;
@@ -13,9 +14,10 @@ use ReflectionClass;
 use ReflectionFunctionAbstract;
 
 use function array_key_exists;
-use function current;
-use function key;
-use function next;
+use function array_keys;
+use function array_search;
+use function array_values;
+use function count;
 use function str_ends_with;
 
 /** @internal */
@@ -31,43 +33,73 @@ final class TemplateResolver
 
         $templates = [];
 
+        $previousDefaultedTemplate = null;
+
         foreach ($annotations as $annotation) {
             $tokens = $annotation->filtered();
 
-            $name = current($tokens);
+            $keys = array_keys($tokens);
+            $values = array_values($tokens);
+
+            $name = $values[0];
 
             $covariant = str_ends_with($annotation->name(), '-covariant');
 
             if (array_key_exists($name, $templates)) {
-                $templateType = UnresolvableType::forDuplicatedTemplateName($signature, $name);
-            } else {
-                $of = next($tokens);
+                $templates[$name] = new GenericType($name, UnresolvableType::forDuplicatedTemplateName($signature, $name), $covariant);
 
-                if ($of !== 'of') {
-                    // The keyword `of` was not found, the following tokens are
-                    // considered as comments, and we ignore them.
-                    $templateType = MixedType::get();
+                continue;
+            }
+
+            $bound = MixedType::get();
+            $default = null;
+
+            $defaultPosition = array_search('=', $values, true);
+
+            if ($defaultPosition !== false) {
+                if (isset($values[$defaultPosition + 1])) {
+                    $default = $typeParser->parse($annotation->allAfter($keys[$defaultPosition + 1]));
                 } else {
-                    // The keyword `of` was found, the following tokens represent
-                    // the template type.
-                    next($tokens);
+                    // A trailing `=` with no type after it is invalid.
+                    $templates[$name] = new GenericType($name, UnresolvableType::forTemplateWithEmptyDefault($signature, $name), $covariant);
 
-                    /** @var array<int, non-empty-string> $tokens */
-                    $key = key($tokens);
+                    $previousDefaultedTemplate = $name;
 
-                    if ($key === null) {
-                        $templateType = MixedType::get();
-                    } else {
-                        $templateType = $typeParser->parse($annotation->allAfter($key));
-
-                        if ($templateType instanceof UnresolvableType) {
-                            $templateType = $templateType->forInvalidTemplateType($signature, $name);
-                        }
-                    }
+                    continue;
                 }
             }
 
-            $templates[$name] = new GenericType($name, $templateType, $covariant);
+            if (($values[1] ?? null) === 'of') {
+                $boundEnd = $default ? $defaultPosition : count($values);
+
+                if ($boundEnd > 2) {
+                    $bound = $typeParser->parse(
+                        $default
+                            ? $annotation->allBetween($keys[2], $keys[$defaultPosition])
+                            : $annotation->allAfter($keys[2])
+                    );
+                }
+            }
+
+            if ($default === null && $previousDefaultedTemplate !== null) {
+                $templates[$name] = new GenericType($name, UnresolvableType::forTemplateDefaultNotTrailing($signature, $name, $previousDefaultedTemplate), $covariant);
+
+                continue;
+            }
+
+            if ($default !== null) {
+                $previousDefaultedTemplate = $name;
+            }
+
+            if ($bound instanceof UnresolvableType) {
+                $bound = $bound->forInvalidTemplateType($signature, $name);
+            }
+
+            if ($default instanceof UnresolvableType) {
+                $default = $default->forInvalidTemplateType($signature, $name);
+            }
+
+            $templates[$name] = new GenericType($name, $bound, $covariant, $default);
         }
 
         return $templates;

--- a/src/Mapper/Object/Factory/CircularDependencyDetectorObjectBuilderFactory.php
+++ b/src/Mapper/Object/Factory/CircularDependencyDetectorObjectBuilderFactory.php
@@ -6,6 +6,13 @@ namespace CuyZ\Valinor\Mapper\Object\Factory;
 
 use CuyZ\Valinor\Definition\ClassDefinition;
 use CuyZ\Valinor\Mapper\Tree\Exception\CircularDependencyDetected;
+use CuyZ\Valinor\Type\ObjectType;
+use CuyZ\Valinor\Type\ObjectWithGenericType;
+use CuyZ\Valinor\Type\Type;
+
+use function array_map;
+use function array_slice;
+use function count;
 
 /** @internal */
 final class CircularDependencyDetectorObjectBuilderFactory implements ObjectBuilderFactory
@@ -24,7 +31,7 @@ final class CircularDependencyDetectorObjectBuilderFactory implements ObjectBuil
 
             foreach ($builders as $builder) {
                 foreach ($builder->describeArguments() as $argument) {
-                    if ($argument->type()->toString() === $class->type->toString()) {
+                    if ($this->isSameType($argument->type(), $class->type)) {
                         throw new CircularDependencyDetected($argument);
                     }
                 }
@@ -32,5 +39,23 @@ final class CircularDependencyDetectorObjectBuilderFactory implements ObjectBuil
         }
 
         return $builders;
+    }
+
+    private function isSameType(Type $argumentType, ObjectType $classType): bool
+    {
+        if (! $argumentType instanceof ObjectWithGenericType || ! $classType instanceof ObjectWithGenericType) {
+            return $argumentType->toString() === $classType->toString();
+        }
+
+        if ($argumentType->className() !== $classType->className()) {
+            return false;
+        }
+
+        $toString = static fn (Type $type) => $type->toString();
+
+        $argumentGenerics = array_map($toString, $argumentType->generics());
+        $classGenerics = array_map($toString, $classType->generics());
+
+        return $argumentGenerics === array_slice($classGenerics, 0, count($argumentGenerics));
     }
 }

--- a/src/Type/Parser/Lexer/Token/ClassNameToken.php
+++ b/src/Type/Parser/Lexer/Token/ClassNameToken.php
@@ -21,11 +21,14 @@ use CuyZ\Valinor\Utility\Reflection\Reflection;
 use ReflectionClass;
 use ReflectionClassConstant;
 
+use function array_column;
+use function array_filter;
 use function array_map;
 use function array_values;
 use function count;
 use function current;
 use function explode;
+use function in_array;
 use function preg_match;
 use function reset;
 
@@ -67,12 +70,14 @@ final class ClassNameToken implements TraversingToken
             $templates = $this->templates($this->reflection->name);
             $generics = $this->generics($stream, $this->reflection->name);
 
-            if (count($templates) > count($generics)) {
-                throw new MissingGenerics($this->reflection->name, $generics, $templates);
+            $required = array_filter($templates, static fn (array $template) => ! $template['hasDefault']);
+
+            if (count($generics) < count($required)) {
+                throw new MissingGenerics($this->reflection->name, $generics, array_column($required, 'name'));
             }
 
             if (count($generics) > count($templates)) {
-                throw new CannotAssignGeneric($this->reflection->name, $templates, $generics);
+                throw new CannotAssignGeneric($this->reflection->name, array_column($templates, 'name'), $generics);
             }
         }
 
@@ -159,7 +164,7 @@ final class ClassNameToken implements TraversingToken
 
     /**
      * @param class-string $className
-     * @return list<non-empty-string>
+     * @return list<array{name: non-empty-string, hasDefault: bool}>
      */
     private function templates(string $className): array
     {
@@ -170,7 +175,10 @@ final class ClassNameToken implements TraversingToken
         foreach ($annotations as $annotation) {
             $tokens = $annotation->filtered();
 
-            $templates[] = current($tokens);
+            $templates[] = [
+                'name' => current($tokens),
+                'hasDefault' => in_array('=', $tokens, true),
+            ];
         }
 
         return $templates;

--- a/src/Type/Parser/Lexer/TokenizedAnnotation.php
+++ b/src/Type/Parser/Lexer/TokenizedAnnotation.php
@@ -6,6 +6,7 @@ namespace CuyZ\Valinor\Type\Parser\Lexer;
 
 use function array_filter;
 use function array_map;
+use function array_slice;
 use function array_splice;
 use function implode;
 
@@ -36,6 +37,15 @@ final class TokenizedAnnotation
 
         /** @var non-empty-string */
         return implode('', array_splice($tokens, $offset));
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function allBetween(int $start, int $end): string
+    {
+        /** @var non-empty-string */
+        return implode('', array_slice($this->tokens, $start, $end - $start));
     }
 
     /**

--- a/src/Type/Types/GenericType.php
+++ b/src/Type/Types/GenericType.php
@@ -16,6 +16,7 @@ final readonly class GenericType implements VacantType
         public string $symbol,
         public Type $innerType,
         public bool $covariant = false,
+        public ?Type $default = null,
     ) {}
 
     public function accepts(mixed $value): bool

--- a/src/Type/Types/UnresolvableType.php
+++ b/src/Type/Types/UnresolvableType.php
@@ -89,6 +89,22 @@ final class UnresolvableType implements VacantType
         );
     }
 
+    public static function forTemplateWithEmptyDefault(string $signature, string $template): self
+    {
+        return new self(
+            $template,
+            "The template `$template` in `$signature` has no default type declared after `=`."
+        );
+    }
+
+    public static function forTemplateDefaultNotTrailing(string $signature, string $template, string $previousTemplate): self
+    {
+        return new self(
+            $template,
+            "The template `$template` in `$signature` has no default type but is defined after the template `$previousTemplate` which declares one; templates with a default type must be defined last."
+        );
+    }
+
     public static function forClassTypeAliasesCollision(string $alias, int $numberOfCollisions): self
     {
         return new self(

--- a/tests/Integration/Mapping/Object/GenericValuesMappingTest.php
+++ b/tests/Integration/Mapping/Object/GenericValuesMappingTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CuyZ\Valinor\Tests\Integration\Mapping\Object;
 
 use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\Mapper\Tree\Exception\CircularDependencyDetected;
 use CuyZ\Valinor\Tests\Integration\IntegrationTestCase;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject;
 use CuyZ\Valinor\Tests\Integration\Mapping\Fixture\SimpleObject as SimpleObjectAlias;
@@ -39,6 +40,69 @@ final class GenericValuesMappingTest extends IntegrationTestCase
         }
 
         self::assertSame('foo', $result->value);
+    }
+
+    public function test_template_default_is_used_when_generic_is_omitted(): void
+    {
+        try {
+            $result = $this->mapperBuilder()->mapper()->map(ObjectWithDefaultTemplate::class, ['value' => 'foo']);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame('foo', $result->value);
+    }
+
+    public function test_template_default_with_bound_is_used_when_generic_is_omitted(): void
+    {
+        try {
+            $result = $this->mapperBuilder()->mapper()->map(ObjectWithBoundDefaultTemplate::class, ['value' => 42]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame(42, $result->value);
+    }
+
+    public function test_assigned_generic_takes_precedence_over_template_default(): void
+    {
+        try {
+            $result = $this->mapperBuilder()->mapper()->map(ObjectWithDefaultTemplate::class . '<int>', ['value' => 42]);
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame(42, $result->value);
+    }
+
+    public function test_self_referencing_object_with_template_default_is_detected_as_circular(): void
+    {
+        $this->expectException(CircularDependencyDetected::class);
+        $this->expectExceptionMessage('Circular dependency detected for `' . ObjectWithDefaultTemplateAndSelfReference::class . '::$value`.');
+
+        $this->mapperBuilder()->mapper()->map(ObjectWithDefaultTemplateAndSelfReference::class, []);
+    }
+
+    public function test_self_reference_omitting_only_the_defaulted_generic_is_detected_as_circular(): void
+    {
+        $this->expectException(CircularDependencyDetected::class);
+        $this->expectExceptionMessage('Circular dependency detected for `' . ObjectWithTrailingDefaultAndSelfReference::class . '::$value`.');
+
+        $this->mapperBuilder()->mapper()->map(ObjectWithTrailingDefaultAndSelfReference::class . '<int>', []);
+    }
+
+    public function test_object_nested_in_its_own_generic_is_not_detected_as_circular(): void
+    {
+        try {
+            $result = $this->mapperBuilder()->mapper()->map(
+                ObjectWithSingleGeneric::class . '<' . ObjectWithSingleGeneric::class . '<string>>',
+                ['value' => ['value' => 'foo']],
+            );
+        } catch (MappingError $error) {
+            $this->mappingFail($error);
+        }
+
+        self::assertSame('foo', $result->value->value);
     }
 
     public function test_values_are_mapped_properly(): void
@@ -302,4 +366,49 @@ final readonly class CovariantGenericObjectWithConstraint
     public function __construct(
         public mixed $value,
     ) {}
+}
+
+/**
+ * @template T = string
+ */
+final class ObjectWithDefaultTemplate
+{
+    /** @var T */
+    public mixed $value;
+}
+
+/**
+ * @template T of int|string = int
+ */
+final class ObjectWithBoundDefaultTemplate
+{
+    /** @var T */
+    public mixed $value;
+}
+
+/**
+ * @template T = string
+ */
+final class ObjectWithDefaultTemplateAndSelfReference
+{
+    public self $value;
+}
+
+/**
+ * @template T
+ */
+final class ObjectWithSingleGeneric
+{
+    /** @var T */
+    public mixed $value;
+}
+
+/**
+ * @template TemplateA
+ * @template TemplateB = string
+ */
+final class ObjectWithTrailingDefaultAndSelfReference
+{
+    /** @var self<TemplateA> */
+    public self $value;
 }

--- a/tests/Integration/Mapping/TypeErrorDuringMappingTest.php
+++ b/tests/Integration/Mapping/TypeErrorDuringMappingTest.php
@@ -70,6 +70,41 @@ final class TypeErrorDuringMappingTest extends IntegrationTestCase
         $this->mapperBuilder()->mapper()->map($class, 'foo');
     }
 
+    public function test_template_with_empty_default_throws_exception(): void
+    {
+        $class =
+            /**
+             * @template T =
+             */
+            (new class () {
+                /** @var T */
+                public mixed $value; // @phpstan-ignore-line
+            })::class;
+
+        $this->expectException(TypeErrorDuringMapping::class);
+        $this->expectExceptionMessage("Error while trying to map to `$class`: the type `T` for property `$class::\$value` could not be resolved: the template `T` in `$class` has no default type declared after `=`.");
+
+        $this->mapperBuilder()->mapper()->map($class, ['value' => 'foo']);
+    }
+
+    public function test_required_template_after_defaulted_template_throws_exception(): void
+    {
+        $class =
+            /**
+             * @template A = string
+             * @template B
+             */
+            (new class () {
+                /** @var B */
+                public mixed $b; // @phpstan-ignore-line
+            })::class;
+
+        $this->expectException(TypeErrorDuringMapping::class);
+        $this->expectExceptionMessage("Error while trying to map to `$class<int>`: the type `B` for property `$class::\$b` could not be resolved: the template `B` in `$class` has no default type but is defined after the template `A` which declares one; templates with a default type must be defined last.");
+
+        $this->mapperBuilder()->mapper()->map("$class<int>", ['b' => 'foo']);
+    }
+
     public function test_function_parameter_with_non_matching_types_throws_exception(): void
     {
         $function =

--- a/tests/Integration/Normalizer/ExpectedCache/class-with-generic.php
+++ b/tests/Integration/Normalizer/ExpectedCache/class-with-generic.php
@@ -13,10 +13,10 @@ return fn (array $transformers, CuyZ\Valinor\Normalizer\Transformer\Transformer 
     public function transform(mixed $value): mixed
     {
         $references = new WeakMap();
-        return $this->transform_object_cuyz_valinor_tests_integration_normalizer_classwithgeneric_1292a3d8($value, $references);
+        return $this->transform_object_cuyz_valinor_tests_integration_normalizer_classwithgeneric_t_of_string__40f4d4fa($value, $references);
     }
 
-    private function transform_object_cuyz_valinor_tests_integration_normalizer_classwithgeneric_1292a3d8(CuyZ\Valinor\Tests\Integration\Normalizer\ClassWithGeneric $value, WeakMap $references): array
+    private function transform_object_cuyz_valinor_tests_integration_normalizer_classwithgeneric_t_of_string__40f4d4fa(CuyZ\Valinor\Tests\Integration\Normalizer\ClassWithGeneric $value, WeakMap $references): array
     {
         if (isset($references[$value])) {
             throw new CuyZ\Valinor\Normalizer\Exception\CircularReferenceFoundDuringNormalization($value);

--- a/tests/Unit/Definition/Repository/Reflection/ReflectionClassDefinitionRepositoryTest.php
+++ b/tests/Unit/Definition/Repository/Reflection/ReflectionClassDefinitionRepositoryTest.php
@@ -21,10 +21,12 @@ use CuyZ\Valinor\Type\Types\MixedType;
 use CuyZ\Valinor\Type\Types\NativeBooleanType;
 use CuyZ\Valinor\Type\Types\NativeClassType;
 use CuyZ\Valinor\Type\Types\NativeFloatType;
+use CuyZ\Valinor\Type\Types\NativeIntegerType;
 use CuyZ\Valinor\Type\Types\NativeStringType;
 use CuyZ\Valinor\Type\Types\NonEmptyStringType;
 use CuyZ\Valinor\Type\Types\UnresolvableType;
 use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhp;
 use stdClass;
 
@@ -526,11 +528,53 @@ final class ReflectionClassDefinitionRepositoryTest extends UnitTestCase
         self::assertInstanceOf(NativeStringType::class, $properties->get('genericValue')->type);
     }
 
+    #[DataProvider('type_of_definition_data_provider')]
+    public function test_type_of_definition_is_the_type_that_was_asked_for(ObjectType $type, string $expected): void
+    {
+        self::assertSame($expected, $this->getClass($type)->type->toString());
+    }
+
+    public static function type_of_definition_data_provider(): iterable
+    {
+        $classWithDefaultedTemplate =
+            /**
+             * @template TemplateA = string
+             */
+            (new class () {})::class;
+
+        yield 'template with a default, no generic assigned' => [
+            new NativeClassType($classWithDefaultedTemplate),
+            "$classWithDefaultedTemplate<string>",
+        ];
+
+        $classWithPartiallyDefaultedTemplates =
+            /**
+             * @template TemplateA
+             * @template TemplateB = string
+             */
+            (new class () {})::class;
+
+        yield 'only the generic of the non-defaulted template assigned' => [
+            new NativeClassType($classWithPartiallyDefaultedTemplates, [NativeIntegerType::get()]),
+            "$classWithPartiallyDefaultedTemplates<int, string>",
+        ];
+
+        yield 'interface with a defaulted template' => [
+            new InterfaceType(SomeInterfaceWithDefaultedGeneric::class),
+            SomeInterfaceWithDefaultedGeneric::class . '<string>',
+        ];
+    }
+
     private function getClass(ObjectType $type): ClassDefinition
     {
         return $this->getService(ClassDefinitionRepository::class)->for($type);
     }
 }
+
+/**
+ * @template T = string
+ */
+interface SomeInterfaceWithDefaultedGeneric {}
 
 /**
  * @template T

--- a/tests/Unit/Definition/Repository/Reflection/TypeResolver/ClassGenericResolverTest.php
+++ b/tests/Unit/Definition/Repository/Reflection/TypeResolver/ClassGenericResolverTest.php
@@ -32,6 +32,24 @@ final class ClassGenericResolverTest extends UnitTestCase
         self::assertSame("The template `TemplateA` in `$className` was defined at least twice.", $generics['TemplateA']->message());
     }
 
+    public function test_template_after_duplicated_template_name_is_still_resolved(): void
+    {
+        $className =
+            /**
+             * @template TemplateA
+             * @template TemplateA
+             * @template TemplateB
+             */
+            (new class () {})::class;
+
+        $type = new NativeClassType($className, [NativeIntegerType::get(), NativeStringType::get()]);
+
+        $generics = $this->classGenericResolver()->resolveGenerics($type);
+
+        self::assertInstanceOf(UnresolvableType::class, $generics['TemplateA']);
+        self::assertSame('string', $generics['TemplateB']->toString());
+    }
+
     public function test_invalid_template_type_sets_unresolvable_type_for_generic(): void
     {
         $className =
@@ -174,6 +192,205 @@ final class ClassGenericResolverTest extends UnitTestCase
 
         self::assertInstanceOf(UnresolvableType::class, $generics['T']);
         self::assertSame("The generic `bool` is not a subtype of `string` for the template `T` of the class `$className`.", $generics['T']->message());
+    }
+
+    public function test_template_default_is_used_when_generic_is_omitted(): void
+    {
+        $className =
+            /**
+             * @template T = string
+             */
+            (new class () {})::class;
+
+        $type = new NativeClassType($className, []);
+
+        $generics = $this->classGenericResolver()->resolveGenerics($type);
+
+        self::assertArrayHasKey('T', $generics);
+        self::assertSame('string', $generics['T']->toString());
+    }
+
+    public function test_template_default_with_bound_is_used_when_generic_is_omitted(): void
+    {
+        $className =
+            /**
+             * @template T of string|int = int
+             */
+            (new class () {})::class;
+
+        $type = new NativeClassType($className, []);
+
+        $generics = $this->classGenericResolver()->resolveGenerics($type);
+
+        self::assertArrayHasKey('T', $generics);
+        self::assertSame('int', $generics['T']->toString());
+    }
+
+    public function test_assigned_generic_for_required_template_is_combined_with_default_of_trailing_template(): void
+    {
+        $className =
+            /**
+             * @template TemplateA
+             * @template TemplateB = string
+             */
+            (new class () {})::class;
+
+        $type = new NativeClassType($className, [NativeIntegerType::get()]);
+
+        $generics = $this->classGenericResolver()->resolveGenerics($type);
+
+        self::assertSame('int', $generics['TemplateA']->toString());
+        self::assertSame('string', $generics['TemplateB']->toString());
+    }
+
+    public function test_template_without_default_and_no_assigned_generic_falls_back_to_template_type(): void
+    {
+        $className =
+            /**
+             * @template Template of string
+             */
+            (new class () {})::class;
+
+        $type = new NativeClassType($className, []);
+
+        $generics = $this->classGenericResolver()->resolveGenerics($type);
+
+        self::assertSame('Template of string', $generics['Template']->toString());
+    }
+
+    public function test_template_with_of_keyword_but_no_bound_resolves_to_mixed_bound(): void
+    {
+        $className =
+            /**
+             * @template Template of
+             */
+            (new class () {})::class;
+
+        $type = new NativeClassType($className, [NativeStringType::get()]);
+
+        $generics = $this->classGenericResolver()->resolveGenerics($type);
+
+        self::assertSame('string', $generics['Template']->toString());
+    }
+
+    public function test_assigned_generic_takes_precedence_over_template_default(): void
+    {
+        $className =
+            /**
+             * @template T = string
+             */
+            (new class () {})::class;
+
+        $type = new NativeClassType($className, [NativeIntegerType::get()]);
+
+        $generics = $this->classGenericResolver()->resolveGenerics($type);
+
+        self::assertArrayHasKey('T', $generics);
+        self::assertSame('int', $generics['T']->toString());
+    }
+
+    public function test_template_default_not_matching_bound_sets_unresolvable_type_for_generic(): void
+    {
+        $className =
+            /**
+             * @template T of string = int
+             */
+            (new class () {})::class;
+
+        $type = new NativeClassType($className, []);
+
+        $generics = $this->classGenericResolver()->resolveGenerics($type);
+
+        self::assertInstanceOf(UnresolvableType::class, $generics['T']);
+        self::assertSame("The generic `int` is not a subtype of `string` for the template `T` of the class `$className`.", $generics['T']->message());
+    }
+
+    public function test_invalid_template_default_type_sets_unresolvable_type_for_generic(): void
+    {
+        $className =
+            /**
+             * @template T = InvalidType
+             */
+            (new class () {})::class;
+
+        $type = new NativeClassType($className, []);
+
+        $generics = $this->classGenericResolver()->resolveGenerics($type);
+
+        self::assertInstanceOf(UnresolvableType::class, $generics['T']);
+        self::assertSame("Invalid template `T` for `$className`: cannot parse unknown symbol `InvalidType`.", $generics['T']->message());
+    }
+
+    public function test_template_with_empty_default_sets_unresolvable_type_for_generic(): void
+    {
+        $className =
+            /**
+             * @template T =
+             */
+            (new class () {})::class;
+
+        $type = new NativeClassType($className, []);
+
+        $generics = $this->classGenericResolver()->resolveGenerics($type);
+
+        self::assertInstanceOf(UnresolvableType::class, $generics['T']);
+        self::assertSame("The template `T` in `$className` has no default type declared after `=`.", $generics['T']->message());
+    }
+
+    public function test_required_template_after_defaulted_template_sets_unresolvable_type_for_generic(): void
+    {
+        $className =
+            /**
+             * @template A = string
+             * @template B
+             */
+            (new class () {})::class;
+
+        $type = new NativeClassType($className, [NativeIntegerType::get()]);
+
+        $generics = $this->classGenericResolver()->resolveGenerics($type);
+
+        self::assertInstanceOf(UnresolvableType::class, $generics['B']);
+        self::assertSame("The template `B` in `$className` has no default type but is defined after the template `A` which declares one; templates with a default type must be defined last.", $generics['B']->message());
+    }
+
+    public function test_template_after_required_template_following_defaulted_template_is_still_resolved(): void
+    {
+        $className =
+            /**
+             * @template TemplateA = string
+             * @template TemplateB
+             * @template TemplateC = int
+             */
+            (new class () {})::class;
+
+        $type = new NativeClassType($className, []);
+
+        $generics = $this->classGenericResolver()->resolveGenerics($type);
+
+        self::assertSame('string', $generics['TemplateA']->toString());
+        self::assertInstanceOf(UnresolvableType::class, $generics['TemplateB']);
+        self::assertSame('int', $generics['TemplateC']->toString());
+    }
+
+    public function test_required_template_after_empty_default_template_does_not_leak_generic(): void
+    {
+        $className =
+            /**
+             * @template A =
+             * @template B
+             */
+            (new class () {})::class;
+
+        $type = new NativeClassType($className, [NativeIntegerType::get()]);
+
+        $generics = $this->classGenericResolver()->resolveGenerics($type);
+
+        self::assertInstanceOf(UnresolvableType::class, $generics['A']);
+        self::assertSame("The template `A` in `$className` has no default type declared after `=`.", $generics['A']->message());
+
+        self::assertInstanceOf(UnresolvableType::class, $generics['B']);
+        self::assertSame("The template `B` in `$className` has no default type but is defined after the template `A` which declares one; templates with a default type must be defined last.", $generics['B']->message());
     }
 
     private function classGenericResolver(): ClassGenericResolver

--- a/tests/Unit/Type/Parser/Lexer/TokenizedAnnotationTest.php
+++ b/tests/Unit/Type/Parser/Lexer/TokenizedAnnotationTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CuyZ\Valinor\Tests\Unit\Type\Parser\Lexer;
+
+use CuyZ\Valinor\Tests\Unit\UnitTestCase;
+use CuyZ\Valinor\Type\Parser\Lexer\TokenizedAnnotation;
+
+final class TokenizedAnnotationTest extends UnitTestCase
+{
+    public function test_all_between_returns_tokens_within_given_offsets(): void
+    {
+        // Tokens of an annotation like `@template T of Foo = Bar`.
+        $annotation = new TokenizedAnnotation('@template', ['T', ' ', 'of', ' ', 'Foo', ' ', '=', ' ', 'Bar']);
+
+        self::assertSame('Foo ', $annotation->allBetween(4, 6));
+    }
+}

--- a/tests/Unit/Type/Parser/LexingParserTest.php
+++ b/tests/Unit/Type/Parser/LexingParserTest.php
@@ -2213,6 +2213,36 @@ final class LexingParserTest extends UnitTestCase
         self::assertSame("Could not find a template to assign the generic(s) `string` for the class `$className`.", $type->message());
     }
 
+    public function test_omitted_generic_with_default_template_does_not_throw_exception(): void
+    {
+        $className = SomeClassWithDefaultTemplate::class;
+
+        $type = $this->parse($className);
+
+        self::assertNotInstanceOf(UnresolvableType::class, $type);
+        self::assertSame($className, $type->toString());
+    }
+
+    public function test_omitted_trailing_default_generic_does_not_throw_exception(): void
+    {
+        $className = SomeClassWithRequiredAndDefaultTemplate::class;
+
+        $type = $this->parse("$className<int>");
+
+        self::assertNotInstanceOf(UnresolvableType::class, $type);
+        self::assertSame("$className<int>", $type->toString());
+    }
+
+    public function test_missing_required_generic_with_trailing_default_throws_exception(): void
+    {
+        $className = SomeClassWithRequiredAndDefaultTemplate::class;
+
+        $type = $this->parse($className);
+
+        self::assertInstanceOf(UnresolvableType::class, $type);
+        self::assertSame("There are 1 missing generics for `$className<?>`.", $type->message());
+    }
+
     public function test_value_of_enum_missing_opening_bracket_throws_exception(): void
     {
         $type = $this->parse('value-of');
@@ -2356,6 +2386,17 @@ final class SomeClassWithOneTemplate {}
  * @template TemplateC
  */
 final class SomeClassWithThreeTemplates {}
+
+/**
+ * @template TemplateA = string
+ */
+final class SomeClassWithDefaultTemplate {}
+
+/**
+ * @template TemplateA
+ * @template TemplateB = string
+ */
+final class SomeClassWithRequiredAndDefaultTemplate {}
 
 /**
  * @template TemplateA of array-key

--- a/tests/Unit/Type/Types/GenericTypeTest.php
+++ b/tests/Unit/Type/Types/GenericTypeTest.php
@@ -97,6 +97,29 @@ final class GenericTypeTest extends UnitTestCase
         self::assertSame('T of string', $genericTypeOfString->toString());
     }
 
+    public function test_default_is_null_by_default(): void
+    {
+        $genericType = new GenericType('T', new NativeStringType());
+
+        self::assertNull($genericType->default);
+    }
+
+    public function test_default_can_be_set(): void
+    {
+        $genericType = new GenericType('T', new MixedType(), default: new NativeStringType());
+
+        self::assertSame('string', $genericType->default?->toString());
+    }
+
+    public function test_string_value_does_not_contain_default(): void
+    {
+        $genericTypeWithDefault = new GenericType('T', new MixedType(), default: new NativeStringType());
+        $genericTypeWithBoundAndDefault = new GenericType('T', new NativeStringType(), default: new NativeStringType());
+
+        self::assertSame('T', $genericTypeWithDefault->toString());
+        self::assertSame('T of string', $genericTypeWithBoundAndDefault->toString());
+    }
+
     private function compiledAccept(Type $type, mixed $value): bool
     {
         /** @var bool */


### PR DESCRIPTION
Every generic of a class had to be given during mapping, even when a sensible fallback existed for some of them. Following PHPStan and Psalm, a template can now declare a default type, making the matching generic optional:

```php
/**
 * @template TValue
 * @template TMeta of array<string, mixed> = array<string, string>
 */
final readonly class SomePage
{
    public function __construct(
        /** @var list<TValue> */
        public array $items,

        /** @var TMeta */
        public array $meta,
    ) {}
}

final readonly class SomeClass
{
    public function __construct(
        // `TMeta` is not filled in, its default type is used
        /** @var SomePage<SomeUser> */
        public SomePage $pageWithDefaultMeta,

        // `TMeta` is filled in, overriding its default type
        /** @var SomePage<SomeUser, array{cursor: int}> */
        public SomePage $pageWithCursorMeta,
    ) {}
}
```

Templates declaring a default are not counted as required anymore, and the default is used as the fallback for an omitted generic, instead of the template itself.

Fixes #600